### PR TITLE
fix: handle helia-sw query from _redirects

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,6 +1,7 @@
-import React, { useContext, useEffect } from 'react'
+import React, { useContext, useEffect, useState } from 'react'
 import Config from './components/config.tsx'
 import { ConfigContext } from './context/config-context.tsx'
+import { ServiceWorkerContext } from './context/service-worker-context.tsx'
 import HelperUi from './helper-ui.tsx'
 import { getActualUrl } from './lib/ipfs-hosted-redirect-utils.ts'
 import { isConfigPage } from './lib/is-config-page.ts'
@@ -9,17 +10,32 @@ import RedirectPage from './redirectPage.tsx'
 
 function App (): JSX.Element {
   const { isConfigExpanded, setConfigExpanded } = useContext(ConfigContext)
+  const [originRedirect, setOriginRedirect] = useState<string | null>(null)
+  const { isServiceWorkerRegistered } = useContext(ServiceWorkerContext)
 
   useEffect(() => {
     async function originEnforcement (): Promise<void> {
       // enforce  early when loaded before SW was registered
-      const originRedirect = await findOriginIsolationRedirect(getActualUrl(window.location.href))
-      if (originRedirect !== null) {
-        window.location.replace(originRedirect)
-      }
+      const originRedirect = await findOriginIsolationRedirect(window.location)
+      setOriginRedirect(originRedirect)
     }
     void originEnforcement()
   }, [])
+
+  useEffect(() => {
+    if (originRedirect !== null) {
+      window.location.replace(originRedirect)
+      return
+    }
+    const actualUrl = getActualUrl(window.location.href)
+    if (isServiceWorkerRegistered && window.location.href !== actualUrl.href) {
+      /**
+       * If hosted on ipfs site and we were redirected to a ?helia-sw=/ip[fn]s/<path> url,
+       * this will reload with a request to /ip[fn]s/<path>, because the SW can capture it now.
+       */
+      window.location.replace(actualUrl)
+    }
+  }, [isServiceWorkerRegistered, originRedirect])
 
   if (isConfigPage()) {
     setConfigExpanded(true)

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,41 +1,13 @@
-import React, { useContext, useEffect, useState } from 'react'
+import React, { useContext } from 'react'
 import Config from './components/config.tsx'
 import { ConfigContext } from './context/config-context.tsx'
-import { ServiceWorkerContext } from './context/service-worker-context.tsx'
 import HelperUi from './helper-ui.tsx'
-import { getActualUrl } from './lib/ipfs-hosted-redirect-utils.ts'
 import { isConfigPage } from './lib/is-config-page.ts'
-import { isPathOrSubdomainRequest, findOriginIsolationRedirect } from './lib/path-or-subdomain.ts'
+import { isPathOrSubdomainRequest } from './lib/path-or-subdomain.ts'
 import RedirectPage from './redirectPage.tsx'
 
 function App (): JSX.Element {
   const { isConfigExpanded, setConfigExpanded } = useContext(ConfigContext)
-  const [originRedirect, setOriginRedirect] = useState<string | null>(null)
-  const { isServiceWorkerRegistered } = useContext(ServiceWorkerContext)
-
-  useEffect(() => {
-    async function originEnforcement (): Promise<void> {
-      // enforce  early when loaded before SW was registered
-      const originRedirect = await findOriginIsolationRedirect(window.location)
-      setOriginRedirect(originRedirect)
-    }
-    void originEnforcement()
-  }, [])
-
-  useEffect(() => {
-    if (originRedirect !== null) {
-      window.location.replace(originRedirect)
-      return
-    }
-    const actualUrl = getActualUrl(window.location.href)
-    if (isServiceWorkerRegistered && window.location.href !== actualUrl.href) {
-      /**
-       * If hosted on ipfs site and we were redirected to a ?helia-sw=/ip[fn]s/<path> url,
-       * this will reload with a request to /ip[fn]s/<path>, because the SW can capture it now.
-       */
-      window.location.replace(actualUrl)
-    }
-  }, [isServiceWorkerRegistered, originRedirect])
 
   if (isConfigPage()) {
     setConfigExpanded(true)

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -2,6 +2,7 @@ import React, { useContext, useEffect } from 'react'
 import Config from './components/config.tsx'
 import { ConfigContext } from './context/config-context.tsx'
 import HelperUi from './helper-ui.tsx'
+import { getActualUrl } from './lib/ipfs-hosted-redirect-utils.ts'
 import { isConfigPage } from './lib/is-config-page.ts'
 import { isPathOrSubdomainRequest, findOriginIsolationRedirect } from './lib/path-or-subdomain.ts'
 import RedirectPage from './redirectPage.tsx'
@@ -12,7 +13,7 @@ function App (): JSX.Element {
   useEffect(() => {
     async function originEnforcement (): Promise<void> {
       // enforce  early when loaded before SW was registered
-      const originRedirect = await findOriginIsolationRedirect(window.location)
+      const originRedirect = await findOriginIsolationRedirect(getActualUrl(window.location.href))
       if (originRedirect !== null) {
         window.location.replace(originRedirect)
       }

--- a/src/context/service-worker-context.tsx
+++ b/src/context/service-worker-context.tsx
@@ -1,5 +1,21 @@
+/**
+ * @file This file contains the ServiceWorkerProvider component which is used to register the service worker,
+ * and provide the isServiceWorkerRegistered state to the rest of the app.
+ *
+ * URL / location logic dependent upon the service worker being registered should be handled here. Some examples of this are:
+ *
+ * Before the Service Worker is registered (e.g. first requests to root hosted domain or subdomains):
+ *
+ * 1. Being redirected from _redirects file to a ?helia-sw= url
+ * 2. The app is loaded because service worker is not yet registered, we need to reload the page so the service worker intercepts the request
+ *
+ * After the service worker is loaded. Usually any react code isn't loaded, but some edge cases are:
+ * 1. The page being loaded using some /ip[fn]s/<path> url, but subdomain isolation is supported, so we need to redirect to the isolated origin
+ */
 import React, { createContext, useEffect, useState } from 'react'
+import { translateIpfsRedirectUrl } from '../lib/ipfs-hosted-redirect-utils.ts'
 import { error } from '../lib/logger.ts'
+import { findOriginIsolationRedirect } from '../lib/path-or-subdomain.ts'
 import { registerServiceWorker } from '../service-worker-utils.ts'
 
 export const ServiceWorkerContext = createContext({
@@ -9,8 +25,32 @@ export const ServiceWorkerContext = createContext({
 export const ServiceWorkerProvider = ({ children }): JSX.Element => {
   const [isServiceWorkerRegistered, setIsServiceWorkerRegistered] = useState(false)
 
+  const windowLocation = translateIpfsRedirectUrl(window.location.href)
+
   useEffect(() => {
     if (isServiceWorkerRegistered) {
+      /**
+       * The service worker is registered, now we need to check for "helia-sw" and origin isolation support
+       */
+      if (windowLocation.href !== window.location.href) {
+      /**
+       * We're at a domain with ?helia-sw=, we can reload the page so the service worker will
+       * capture the request
+       */
+        window.location.replace(windowLocation.href)
+      } else {
+        /**
+         * ?helia-sw= url handling is done, now we can check for origin isolation redirects
+         */
+        void findOriginIsolationRedirect(windowLocation).then((originRedirect) => {
+          if (originRedirect !== null) {
+            window.location.replace(originRedirect)
+          }
+        })
+      }
+      /**
+       * The service worker is registered, we don't need to do any more work
+       */
       return
     }
     async function doWork (): Promise<void> {
@@ -32,7 +72,7 @@ export const ServiceWorkerProvider = ({ children }): JSX.Element => {
       }
     }
     void doWork()
-  }, [])
+  }, [isServiceWorkerRegistered])
 
   return (
     <ServiceWorkerContext.Provider value={{ isServiceWorkerRegistered }}>

--- a/src/lib/ipfs-hosted-redirect-utils.ts
+++ b/src/lib/ipfs-hosted-redirect-utils.ts
@@ -4,7 +4,7 @@
  *
  * This function will check for "?helia-sw=" in the URL and modify the URL so that it works with the rest of our logic
  */
-export function getActualUrl (urlString: string): URL {
+export function translateIpfsRedirectUrl (urlString: string): URL {
   const url = new URL(urlString)
   const heliaSw = url.searchParams.get('helia-sw')
   if (heliaSw != null) {

--- a/src/lib/ipfs-hosted-redirect-utils.ts
+++ b/src/lib/ipfs-hosted-redirect-utils.ts
@@ -1,0 +1,15 @@
+/**
+ * If you host helia-service-worker-gateway on an IPFS domain, the redirects file will route some requests from
+ * `<domain>/<wildcard-splat>` to `https://<domain>/?helia-sw=<wildcard-splat>`.
+ *
+ * This function will check for "?helia-sw=" in the URL and modify the URL so that it works with the rest of our logic
+ */
+export function getActualUrl (urlString: string): string {
+  const url = new URL(urlString)
+  const heliaSw = url.searchParams.get('helia-sw')
+  if (heliaSw != null) {
+    url.searchParams.delete('helia-sw')
+    url.pathname = heliaSw
+  }
+  return url.toString()
+}

--- a/src/lib/ipfs-hosted-redirect-utils.ts
+++ b/src/lib/ipfs-hosted-redirect-utils.ts
@@ -4,12 +4,12 @@
  *
  * This function will check for "?helia-sw=" in the URL and modify the URL so that it works with the rest of our logic
  */
-export function getActualUrl (urlString: string): string {
+export function getActualUrl (urlString: string): URL {
   const url = new URL(urlString)
   const heliaSw = url.searchParams.get('helia-sw')
   if (heliaSw != null) {
     url.searchParams.delete('helia-sw')
     url.pathname = heliaSw
   }
-  return url.toString()
+  return url
 }

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -3,7 +3,6 @@ import { getHelia } from './get-helia.ts'
 import { HeliaServiceWorkerCommsChannel, type ChannelMessage } from './lib/channel.ts'
 import { getSubdomainParts } from './lib/get-subdomain-parts.ts'
 import { heliaFetch } from './lib/heliaFetch.ts'
-import { getActualUrl } from './lib/ipfs-hosted-redirect-utils.ts'
 import { error, log, trace } from './lib/logger.ts'
 import { findOriginIsolationRedirect } from './lib/path-or-subdomain.ts'
 import type { Helia } from '@helia/interface'
@@ -52,7 +51,7 @@ interface FetchHandlerArg {
 
 const fetchHandler = async ({ path, request }: FetchHandlerArg): Promise<Response> => {
   // test and enforce origin isolation before anything else is executed
-  const originLocation = await findOriginIsolationRedirect(getActualUrl(request.url))
+  const originLocation = await findOriginIsolationRedirect(new URL(request.url))
   if (originLocation !== null) {
     const body = 'Gateway supports subdomain mode, redirecting to ensure Origin isolation..'
     return new Response(body, {

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -52,7 +52,7 @@ interface FetchHandlerArg {
 
 const fetchHandler = async ({ path, request }: FetchHandlerArg): Promise<Response> => {
   // test and enforce origin isolation before anything else is executed
-  const originLocation = await findOriginIsolationRedirect(new URL(getActualUrl(request.url)))
+  const originLocation = await findOriginIsolationRedirect(getActualUrl(request.url))
   if (originLocation !== null) {
     const body = 'Gateway supports subdomain mode, redirecting to ensure Origin isolation..'
     return new Response(body, {

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -3,6 +3,7 @@ import { getHelia } from './get-helia.ts'
 import { HeliaServiceWorkerCommsChannel, type ChannelMessage } from './lib/channel.ts'
 import { getSubdomainParts } from './lib/get-subdomain-parts.ts'
 import { heliaFetch } from './lib/heliaFetch.ts'
+import { getActualUrl } from './lib/ipfs-hosted-redirect-utils.ts'
 import { error, log, trace } from './lib/logger.ts'
 import { findOriginIsolationRedirect } from './lib/path-or-subdomain.ts'
 import type { Helia } from '@helia/interface'
@@ -51,7 +52,7 @@ interface FetchHandlerArg {
 
 const fetchHandler = async ({ path, request }: FetchHandlerArg): Promise<Response> => {
   // test and enforce origin isolation before anything else is executed
-  const originLocation = await findOriginIsolationRedirect(new URL(request.url))
+  const originLocation = await findOriginIsolationRedirect(new URL(getActualUrl(request.url)))
   if (originLocation !== null) {
     const body = 'Gateway supports subdomain mode, redirecting to ensure Origin isolation..'
     return new Response(body, {


### PR DESCRIPTION
## Title

<!---
The title of the PR will be the commit message of the merge commit, so please make sure it is descriptive enough.
We utilize the Conventional Commits specification for our commit messages. See <https://www.conventionalcommits.org/en/v1.0.0/#specification> for more information.
The commit tag types can be of one of the following: feat, fix, deps, refactor, chore, docs. See <https://github.com/ipfs/helia/blob/main/.github/workflows/main.yml#L184-L192>
The title must also be fewer than 72 characters long or it will fail the Semantic PR check. See <https://github.com/ipfs/helia/blob/main/.github/workflows/semantic-pull-request.yml>
--->

## Description

Fixes an issue where helia-service-worker-gateway will redirect `<domain>/<requestedPath>` to `<domain>/?helia-sw=/<requestedPath>` and then not be handled by the service-worker appropriately.

## Notes & open questions

still debugging this. WIP

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
