### PR TITLE
feat(ci): build car, pin to cluster, update dnslink

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,7 @@ on:
       - '**'
   workflow_dispatch:
 
+
 jobs:
 
   build:
@@ -23,7 +24,6 @@ jobs:
       with:
         name: dist_${{ github.sha }}
         path: dist
-        retention-days: 3
 
   check:
     needs: build
@@ -166,8 +166,11 @@ jobs:
   publish-to-ipfs:
     needs: build
     runs-on: ubuntu-latest
-    environment: Deploy
-    # TODO only if: release or main branch
+    environment: Deploy # dependency on 'Deploy' env means 'publish-to-ipfs' only runs when it is present
+    concurrency:
+      # only one job runs at a time == DNSLinks are updated in-order
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     env:
       KUBO_VER: 'v0.26.0'       # kubo daemon used for publishing to IPFS
       CLUSTER_CTL_VER: 'v1.0.8' # ipfs-cluster-ctl used for pinning
@@ -240,18 +243,28 @@ jobs:
           CLUSTER_USER: ${{ secrets.CLUSTER_USER }}
           CLUSTER_PASSWORD: ${{ secrets.CLUSTER_PASSWORD }}
         timeout-minutes: 60
-      - name: Update DNSLink at inbrowser.dev
-        # TODO .dev only if: github.ref == 'refs/heads/main'
+      - name: Update DNSLink at inbrowser.dev (Dev Testing)
+        if: github.ref == 'refs/heads/main'
         run: |
-          curl --request PUT --header "Authorization: Bearer ${AUTH_TOKEN}" \
+          curl --request PUT --header "Authorization: Bearer ${AUTH_TOKEN}" --header 'Content-Type: application/json' \
             --url "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records/${RECORD_ID}" \
-            --header 'Content-Type: application/json' \
-            --data "{\"type\":\"TXT\",\"name\":\"${DNSLINK_NAME}\",\"content\":\"dnslink=/ipfs/${DNSLINK_CID}\",\"comment\":\"${{ github.repository }}/${{ github.sha }}\"}"
+            --data "{\"type\":\"TXT\",\"name\":\"_dnslink.${DNSLINK_NAME}\",\"content\":\"dnslink=/ipfs/${DNSLINK_CID}\",\"comment\":\"${{ github.repository }}/${{ github.sha }}\"}"
         env:
-          # TODO switch to real name, and update record_id
-          DNSLINK_NAME: test.inbrowser.dev
+          DNSLINK_NAME: inbrowser.dev
           DNSLINK_CID: ${{ steps.ipfs-import.outputs.cid }}
           ZONE_ID: ${{ secrets.CF_INBROWSERDEV_ZONE_ID }}
           RECORD_ID:  ${{ secrets.CF_INBROWSERDEV_RECORD_ID }}
           AUTH_TOKEN: ${{ secrets.CF_INBROWSERDEV_AUTH_TOKEN }}
-        # TODO same for .link but only if release
+      - name: Update DNSLink at inbrowser.link (Stable Production)
+        # TODO: make this run only on release
+        if: github.ref == 'refs/heads/main'
+        run: |
+          curl --request PUT --header "Authorization: Bearer ${AUTH_TOKEN}" --header 'Content-Type: application/json'  \
+            --url "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records/${RECORD_ID}" \
+            --data "{\"type\":\"TXT\",\"name\":\"_dnslink.${DNSLINK_NAME}\",\"content\":\"dnslink=/ipfs/${DNSLINK_CID}\",\"comment\":\"${{ github.repository }}/${{ github.sha }}\"}"
+        env:
+          DNSLINK_NAME: inbrowser.link
+          DNSLINK_CID: ${{ steps.ipfs-import.outputs.cid }}
+          ZONE_ID: ${{ secrets.CF_INBROWSERLINK_ZONE_ID }}
+          RECORD_ID:  ${{ secrets.CF_INBROWSERLINK_RECORD_ID }}
+          AUTH_TOKEN: ${{ secrets.CF_INBROWSERLINK_AUTH_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -214,11 +214,13 @@ jobs:
         env:
           CLUSTER_USER: ${{ secrets.CLUSTER_USER }}
           CLUSTER_PASSWORD: ${{ secrets.CLUSTER_PASSWORD }}
-      - name: IPFS import of ./dist and generating CID
+      - name: IPFS import of ./dist
         id: ipfs-import
         run: |
-          root_cid=$(ipfs add --cid-version 1 -Q -r --offline ./dist)
+          root_cid=$(ipfs add --cid-version 1 --inline --chunker size-1048576 -Q -r --offline ./dist)
           echo "cid=$root_cid" >> $GITHUB_OUTPUT
+      - name: ℹ️  Generated DAG and CID
+        run: ipfs dag stat --progress=false ${{ steps.ipfs-import.outputs.cid }}
       - name: Create CAR file
         run: ipfs dag export ${{ steps.ipfs-import.outputs.cid }} > dist_${{ github.sha }}.car
       - name: Attach CAR to Github Action

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches:
       - '**'
+  workflow_dispatch:
 
 jobs:
 
@@ -17,6 +18,12 @@ jobs:
       with:
         node-version: lts/*
     - uses: ipfs/aegir/actions/cache-node-modules@master
+    - name: Save ./dist output for later
+      uses: actions/upload-artifact@v4
+      with:
+        name: dist_${{ github.sha }}
+        path: dist
+        retention-days: 3
 
   check:
     needs: build
@@ -155,3 +162,96 @@ jobs:
         with:
           flags: electron-renderer
           files: .coverage/*,packages/*/.coverage/*
+
+  publish-to-ipfs:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: Deploy
+    # TODO only if: release or main branch
+    env:
+      KUBO_VER: 'v0.26.0'       # kubo daemon used for publishing to IPFS
+      CLUSTER_CTL_VER: 'v1.0.8' # ipfs-cluster-ctl used for pinning
+    steps:
+      - uses: actions/checkout@v4
+      - name: Retrieve ./dist produced by build job
+        uses: actions/download-artifact@v4
+        with:
+          name: dist_${{ github.sha }}
+          path: dist
+      - uses: ipfs/download-ipfs-distribution-action@v1
+        with:
+          name: kubo
+          version: "${{ env.KUBO_VER }}"
+      - uses: ipfs/download-ipfs-distribution-action@v1
+        with:
+          name: ipfs-cluster-ctl
+          version: "${{ env.CLUSTER_CTL_VER }}"
+      - name: Init IPFS daemon
+        run: |
+          # fix resolv - DNS provided by Github is unreliable for DNSLik/dnsaddr
+          sudo sed -i -e 's/nameserver 127.0.0.*/nameserver 1.1.1.1/g' /etc/resolv.conf
+          ipfs init --profile flatfs,server,randomports,lowpower
+          # make flatfs async for faster ci
+          ipfs config --json 'Datastore.Spec.mounts' "$(ipfs config 'Datastore.Spec.mounts' | jq -c '.[0].child.sync=false')"
+        shell: bash
+      - uses: ipfs/start-ipfs-daemon-action@v1
+        with:
+          args: --enable-gc=false
+      - name: Preconnect to cluster peers
+        run: |
+          ipfs-cluster-ctl --enc=json \
+            --host "/dnsaddr/ipfs-websites.collab.ipfscluster.io" \
+            --basic-auth "$CLUSTER_USER:$CLUSTER_PASSWORD" \
+            peers ls | tee cluster-peers-ls
+          for maddr in $(jq -r '.ipfs.addresses[]?' cluster-peers-ls); do
+            ipfs swarm peering add $maddr
+            ipfs swarm connect $maddr || true &
+          done
+        shell: bash
+        env:
+          CLUSTER_USER: ${{ secrets.CLUSTER_USER }}
+          CLUSTER_PASSWORD: ${{ secrets.CLUSTER_PASSWORD }}
+      - name: IPFS import of ./dist and generating CID
+        id: ipfs-import
+        run: |
+          root_cid=$(ipfs add --cid-version 1 -Q -r --offline ./dist)
+          echo "cid=$root_cid" >> $GITHUB_OUTPUT
+      - name: Create CAR file
+        run: ipfs dag export ${{ steps.ipfs-import.outputs.cid }} > dist_${{ github.sha }}.car
+      - name: Attach CAR to Github Action
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist_${{ github.sha }}.car
+          path: dist_${{ github.sha }}.car
+          if-no-files-found: error
+      - name: Pin to ipfs-websites.collab.ipfscluster.io
+        run: |
+          ipfs-cluster-ctl --enc=json \
+              --host "/dnsaddr/ipfs-websites.collab.ipfscluster.io" \
+              --basic-auth "${CLUSTER_USER}:${CLUSTER_PASSWORD}" \
+              pin add \
+              --name "${{ github.repository }}/${{ github.sha }}" \
+              --replication-min 2 \
+              --replication-max 6 \
+              --wait \
+              "$PIN_CID"
+        env:
+          PIN_CID: ${{ steps.ipfs-import.outputs.cid }}
+          CLUSTER_USER: ${{ secrets.CLUSTER_USER }}
+          CLUSTER_PASSWORD: ${{ secrets.CLUSTER_PASSWORD }}
+        timeout-minutes: 60
+      - name: Update DNSLink at inbrowser.dev
+        # TODO .dev only if: github.ref == 'refs/heads/main'
+        run: |
+          curl --request PUT --header "Authorization: Bearer ${AUTH_TOKEN}" \
+            --url "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records/${RECORD_ID}" \
+            --header 'Content-Type: application/json' \
+            --data "{\"type\":\"TXT\",\"name\":\"${DNSLINK_NAME}\",\"content\":\"dnslink=/ipfs/${DNSLINK_CID}\",\"comment\":\"${{ github.repository }}/${{ github.sha }}\"}"
+        env:
+          # TODO switch to real name, and update record_id
+          DNSLINK_NAME: test.inbrowser.dev
+          DNSLINK_CID: ${{ steps.ipfs-import.outputs.cid }}
+          ZONE_ID: ${{ secrets.CF_INBROWSERDEV_ZONE_ID }}
+          RECORD_ID:  ${{ secrets.CF_INBROWSERDEV_RECORD_ID }}
+          AUTH_TOKEN: ${{ secrets.CF_INBROWSERDEV_AUTH_TOKEN }}
+        # TODO same for .link but only if release


### PR DESCRIPTION
## Description

This PR is wip, part of #20.

The goal is to:
- remove dependency on Fleek for `inbrowser.link` and `.dev` 
- build CAR in CI and attach it to build so it can be downloaded and imported manually
- pin the CID to cluster to ensure multiple providers
- update DNSLinkat `inbrowser.link` and `.dev` ourselves

## Notes & open questions

- [x] Initial design confirmed to work as expected in [job/22106307031](https://github.com/ipfs-shipyard/helia-service-worker-gateway/actions/runs/8089796647/job/22106307031?pr=69#step:13:21): pinned, dnslink updated on test domain.
  - took < 30s
  - note: ttl "1" in Cloudflare DNS API output means "Auto", which is ~300 
- [x] Secrets are added to "Deploy" environment, which will be locked down after we are happy with the setup. Right now limited to `main` and `ci-publish-to-ipfs` branches.
- [x] Detach `.dev` from `.link` and add separate secrets for both to "Deploy" env
- [x] Make both update to the same CID for now (deploy `main` HEAD)
- [x] Limit `publish-to-ipfs` stage and "Deploy" env to be run and exposed only on `main` and release builds

In the future we can change the behavior and:
  - `.link` for stable production (updated only by release event) 
  - `.dev` with latest changes from main branch

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
