### PR TITLE
fix: load the iframe in the same port as the parent domain

### DIFF
--- a/src/redirectPage.tsx
+++ b/src/redirectPage.tsx
@@ -9,7 +9,7 @@ import { error } from './lib/logger.ts'
 const ConfigIframe = (): JSX.Element => {
   const { parentDomain } = getSubdomainParts(window.location.href)
 
-  const iframeSrc = `${window.location.protocol}//${parentDomain}/config?origin=${encodeURIComponent(window.location.origin)}`
+  const iframeSrc = `${window.location.protocol}//${parentDomain}:${window.location.port}/config?origin=${encodeURIComponent(window.location.origin)}`
 
   return (
     <iframe id="redirect-config-iframe" src={iframeSrc} style={{ width: '100vw', height: '100vh', border: 'none' }} />

--- a/src/redirectPage.tsx
+++ b/src/redirectPage.tsx
@@ -9,7 +9,8 @@ import { error } from './lib/logger.ts'
 const ConfigIframe = (): JSX.Element => {
   const { parentDomain } = getSubdomainParts(window.location.href)
 
-  const iframeSrc = `${window.location.protocol}//${parentDomain}:${window.location.port}/config?origin=${encodeURIComponent(window.location.origin)}`
+  const portString = window.location.port === '' ? '' : `:${window.location.port}`
+  const iframeSrc = `${window.location.protocol}//${parentDomain}${portString}/config?origin=${encodeURIComponent(window.location.origin)}`
 
   return (
     <iframe id="redirect-config-iframe" src={iframeSrc} style={{ width: '100vw', height: '100vh', border: 'none' }} />


### PR DESCRIPTION
## Background

This makes sure that the config iframe is loaded from the same port. Otherwise this fails when not on port 80, e.g. using the local development server. 


This also makes it possible to use subdomain resolution locally with the Webpack dev server.


## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
