### PR TITLE
feat: use separate logger for service worker

### DIFF
--- a/src/lib/sw-logger.ts
+++ b/src/lib/sw-logger.ts
@@ -1,6 +1,6 @@
 import { logger } from '@libp2p/logger'
 
-const logObj = logger('service-worker-gateway:ui')
+const logObj = logger('service-worker-gateway:sw')
 
 export const log = logObj
 export const error = logObj.error

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -1,7 +1,7 @@
 import { getVerifiedFetch } from './get-helia.ts'
 import { HeliaServiceWorkerCommsChannel, type ChannelMessage } from './lib/channel.ts'
 import { getSubdomainParts } from './lib/get-subdomain-parts.ts'
-import { error, log, trace } from './lib/logger.ts'
+import { error, log, trace } from './lib/sw-logger.ts'
 import { findOriginIsolationRedirect } from './lib/path-or-subdomain.ts'
 import type { VerifiedFetch } from '@helia/verified-fetch'
 
@@ -84,10 +84,10 @@ self.addEventListener('fetch', (event) => {
   const url = new URL(urlString)
 
   if (!isValidRequestForSW(event)) {
-    trace('helia-sw: not a valid request for helia-sw, ignoring ', urlString)
+    trace('not a valid request for helia-sw, ignoring ', urlString)
     return
   } else {
-    log('helia-sw: valid request for helia-sw: ', urlString)
+    log('valid request for helia-sw: ', urlString)
   }
 
   if (isRootRequestForContent(event)) {

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -1,8 +1,8 @@
 import { getVerifiedFetch } from './get-helia.ts'
 import { HeliaServiceWorkerCommsChannel, type ChannelMessage } from './lib/channel.ts'
 import { getSubdomainParts } from './lib/get-subdomain-parts.ts'
-import { error, log, trace } from './lib/sw-logger.ts'
 import { findOriginIsolationRedirect } from './lib/path-or-subdomain.ts'
+import { error, log, trace } from './lib/sw-logger.ts'
 import type { VerifiedFetch } from '@helia/verified-fetch'
 
 /**


### PR DESCRIPTION
## Description

This PR creates a separate logger instance for the service worker to make it a bit easier for debugging and avoid needing to prefix the log messages in the service worker. 


## Notes & open questions

-

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
