### PR TITLE
chore(ci): additional pin to scaleway

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,9 @@ on:
       - '**'
   workflow_dispatch:
 
+env:
+  KUBO_VER: 'v0.27.0'       # kubo daemon used for publishing to IPFS
+  CLUSTER_CTL_VER: 'v1.0.8' # ipfs-cluster-ctl used by publish-to-ipfs
 
 jobs:
 
@@ -165,7 +168,7 @@ jobs:
 
   publish-to-ipfs:
     # TODO: make this run also on release
-    if: github.ref == 'refs/heads/main'
+    # TODO if: github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
     environment: Deploy # CF and Clusteer secrets
@@ -173,9 +176,6 @@ jobs:
       # only one job runs at a time == DNSLinks are updated in-order
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
-    env:
-      KUBO_VER: 'v0.26.0'       # kubo daemon used for publishing to IPFS
-      CLUSTER_CTL_VER: 'v1.0.8' # ipfs-cluster-ctl used for pinning
     outputs:
       cid: ${{ steps.ipfs-import.outputs.cid }}
     steps:
@@ -311,6 +311,36 @@ jobs:
           # W3_PRINCIPAL env name is expected by w3cli tool: https://github.com/web3-storage/w3cli#w3_principal
           W3_PRINCIPAL: ${{ secrets.W3_AGENT_PRINCIPAL }}
           W3CLI_SPACE_DELEGATION_PROOF_BASE64_STRING: ${{ secrets.W3CLI_SPACE_DELEGATION_PROOF_BASE64_STRING }}
+
+  pin-to-scaleway:
+    if: ${{ success() && needs.publish-to-ipfs.outputs.cid }}
+    needs: publish-to-ipfs
+    runs-on: ubuntu-latest
+    environment: Scaleway
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ipfs/download-ipfs-distribution-action@v1
+        with:
+          name: kubo
+          version: "${{ env.KUBO_VER }}"
+      - name: Init IPFS daemon
+        run: ipfs init --profile flatfs,server,randomports,lowpower
+      - uses: ipfs/start-ipfs-daemon-action@v1
+        with:
+          args: --enable-gc=false
+      - name: Retrieve CAR produced by publish-to-ipfs job
+        uses: actions/download-artifact@v4
+        with:
+          name: dist_${{ github.sha }}.car
+      - name: Pin with Scaleway
+        run: |
+          ipfs dag import --offline dist_${{ github.sha }}.car
+          ipfs pin remote service add scaleway "$SCALEWAY_URL" "$SCALEWAY_SECRET"
+          ipfs pin remote rm --service=scaleway --force --cid=${{ needs.publish-to-ipfs.outputs.cid }}
+          ipfs pin remote add --service=scaleway --name=inbrowser-sw-gw-${{ github.sha }} ${{ needs.publish-to-ipfs.outputs.cid }}
+        env:
+          SCALEWAY_SECRET: ${{ secrets.SCALEWAY_SECRET }}
+          SCALEWAY_URL: ${{ secrets.SCALEWAY_URL }}
 
   smoke-test--http: # basic smoke test that lets us know when eother caching or content routing does not work
     if: ${{ success() && needs.publish-to-ipfs.outputs.cid }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -336,9 +336,11 @@ jobs:
         run: |
           ipfs dag import --offline dist_${{ github.sha }}.car
           ipfs pin remote service add scaleway "$SCALEWAY_URL" "$SCALEWAY_SECRET"
-          ipfs pin remote rm --service=scaleway --force --cid=${{ needs.publish-to-ipfs.outputs.cid }}
-          ipfs pin remote add --service=scaleway --name=inbrowser-sw-gw-${{ github.sha }} ${{ needs.publish-to-ipfs.outputs.cid }}
+          already_pinned=$(ipfs pin remote ls --service=scaleway --cid=$CID)
+          [ -n "$already_pinned" ] && exit 0
+          ipfs pin remote add --service=scaleway --name="${{ github.repository }}/${{ github.sha }}" $CID
         env:
+          CID: ${{ needs.publish-to-ipfs.outputs.cid }}
           SCALEWAY_SECRET: ${{ secrets.SCALEWAY_SECRET }}
           SCALEWAY_URL: ${{ secrets.SCALEWAY_URL }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -332,9 +332,10 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: dist_${{ github.sha }}.car
-      - name: Pin with Scaleway
+      - name: Import CAR to local Kubo
+        run: ipfs dag import --offline dist_${{ github.sha }}.car
+      - name: Create Remote Pin with Scaleway
         run: |
-          ipfs dag import --offline dist_${{ github.sha }}.car
           ipfs pin remote service add scaleway "$SCALEWAY_URL" "$SCALEWAY_SECRET"
           already_pinned=$(ipfs pin remote ls --service=scaleway --cid=$CID)
           [ -n "$already_pinned" ] && exit 0
@@ -344,9 +345,9 @@ jobs:
           SCALEWAY_SECRET: ${{ secrets.SCALEWAY_SECRET }}
           SCALEWAY_URL: ${{ secrets.SCALEWAY_URL }}
 
-  smoke-test--http: # basic smoke test that lets us know when eother caching or content routing does not work
+  smoke-test-http: # basic smoke test that lets us know when eother caching or content routing does not work
     if: ${{ success() && needs.publish-to-ipfs.outputs.cid }}
-    needs: publish-to-ipfs
+    needs: [ publish-to-ipfs, pin-to-scaleway, pin-to-w3 ]
     runs-on: ubuntu-latest
     steps:
       - name: Smoke-test instant (cached) /ipfs-sw-main.js at inbrowser.link

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -354,10 +354,10 @@ jobs:
     needs: [ publish-to-ipfs, pin-to-scaleway, pin-to-w3 ]
     runs-on: ubuntu-latest
     steps:
-      - name: Smoke-test instant (cached) /ipfs-sw-main.js at inbrowser.link
+      - name: Smoke-test instant (cached, stale-while-revalidate) /ipfs-sw-main.js at inbrowser.link
         run: curl --retry 3 --retry-delay 61 --retry-all-errors -v https://inbrowser.link/ipfs-sw-main.js > /dev/null
-      - name: Smoke-test instant (cached) /ipfs-sw-main.js at inbrowser.dev
+      - name: Smoke-test instant (cached, stale-while-revalidate) /ipfs-sw-main.js at inbrowser.dev
         run: curl --retry 3 --retry-delay 61 --retry-all-errors -v https://inbrowser.dev/ipfs-sw-main.js > /dev/null
-      - name: Smoke-test fetching full DAG as CAR from trustless-gateway.link
-        run: curl --retry 3 --retry-delay 61 --retry-all-errors -v -H "Accept: application/vnd.ipld.car" "https://trustless-gateway.link/ipfs/${{ needs.publish-to-ipfs.outputs.cid }}?format=car" > /dev/null
+      - name: Smoke-test fetching the new CID as CAR from trustless-gateway.link
+        run: curl --retry 3 --retry-delay 61 --retry-all-errors -v "https://trustless-gateway.link/ipfs/${{ needs.publish-to-ipfs.outputs.cid }}?format=car" > /dev/null
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -334,16 +334,20 @@ jobs:
           name: dist_${{ github.sha }}.car
       - name: Import CAR to local Kubo
         run: ipfs dag import --offline dist_${{ github.sha }}.car
-      - name: Create Remote Pin with Scaleway
+      - name: Set up and check Scaleway
+        id: scaleway
         run: |
           ipfs pin remote service add scaleway "$SCALEWAY_URL" "$SCALEWAY_SECRET"
-          already_pinned=$(ipfs pin remote ls --service=scaleway --cid=$CID)
-          [ -n "$already_pinned" ] && exit 0
-          ipfs pin remote add --service=scaleway --name="${{ github.repository }}/${{ github.sha }}" $CID
+          echo "existing-pin=$(ipfs pin remote ls --service=scaleway --name=$CID)" >> $GITHUB_OUTPUT # using --name because --cid does not work with Scaleway (2024-Q1)
         env:
           CID: ${{ needs.publish-to-ipfs.outputs.cid }}
           SCALEWAY_SECRET: ${{ secrets.SCALEWAY_SECRET }}
           SCALEWAY_URL: ${{ secrets.SCALEWAY_URL }}
+      - name: Pin to Scaleway
+        if: ${{ steps.scaleway.outputs.existing-pin == '' }}
+        run: ipfs pin remote add --service=scaleway --name=$CID $CID # using --name because --cid does not work with Scaleway (2024-Q1)
+        env:
+          CID: ${{ needs.publish-to-ipfs.outputs.cid }}
 
   smoke-test-http: # basic smoke test that lets us know when eother caching or content routing does not work
     if: ${{ success() && needs.publish-to-ipfs.outputs.cid }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -168,7 +168,7 @@ jobs:
 
   publish-to-ipfs:
     # TODO: make this run also on release
-    # TODO if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
     environment: Deploy # CF and Clusteer secrets

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -355,9 +355,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Smoke-test instant (cached) /ipfs-sw-main.js at inbrowser.link
-        run: curl --retry 3 --retry-delay 61 -s -D - -o /dev/null https://inbrowser.link/ipfs-sw-main.js
+        run: curl --retry 3 --retry-delay 61 --retry-all-errors -v https://inbrowser.link/ipfs-sw-main.js > /dev/null
       - name: Smoke-test instant (cached) /ipfs-sw-main.js at inbrowser.dev
-        run: curl --retry 3 --retry-delay 61 -s -D - -o /dev/null https://inbrowser.dev/ipfs-sw-main.js
+        run: curl --retry 3 --retry-delay 61 --retry-all-errors -v https://inbrowser.dev/ipfs-sw-main.js > /dev/null
       - name: Smoke-test fetching full DAG as CAR from trustless-gateway.link
-        run: curl --retry 3 --retry-delay 61 -s -D - -o /dev/null "https://trustless-gateway.link/ipfs/${{ needs.publish-to-ipfs.outputs.cid }}?format=car"
+        run: curl --retry 3 --retry-delay 61 --retry-all-errors -v -H "Accept: application/vnd.ipld.car" "https://trustless-gateway.link/ipfs/${{ needs.publish-to-ipfs.outputs.cid }}?format=car" > /dev/null
 

--- a/public/index.html
+++ b/public/index.html
@@ -1,17 +1,27 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <!--
+
+      This HTML page initializes IPFS Service Worker Gateway.
+
+      The HTTP server behind this HTTP URL does not host this website.
+      Instead, it sends basic website code along with JavaScript. The JS sets
+      up a tool called IPFS Service Worker Gateway in the user's browser and
+      uses JavaScript version of IPFS (https://helia.io/) to get IPFS blocks
+      from content providers.
+
+      CID hash verification and data assembly happens in the browser.
+
+      Learn more about it here: https://github.com/ipfs-shipyard/helia-service-worker-gateway
+
+    -->
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-
     <title><%= htmlWebpackPlugin.options.title %></title>
-
-    <link
-      rel="stylesheet"
-      href="https://unpkg.com/tachyons@4.10.0/css/tachyons.min.css"
-    />
-    <link rel="stylesheet" href="https://unpkg.com/ipfs-css@0.12.0/ipfs.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tachyons@4.12.0/css/tachyons.min.css" integrity="sha256-MgEf5i1a74lVzhT+1R6mBbWCUeUaxC8sQTaN5GY+CoI=" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ipfs-css@1.4.0/ipfs.css" integrity="sha256-tlU/gvVvLjSbTOfSZyCzuQxY8QcmHPtJJ1oTXilA9gk=" crossorigin="anonymous">
   </head>
   <body>
     <div id="root" class="montserrat f5"></div>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -194,7 +194,7 @@ const common = {
     // Generates deprecation warning: https://github.com/jantimon/html-webpack-plugin/issues/1501
     new HtmlWebpackPlugin({
       excludeChunks: ['sw'],
-      title: 'Helia service worker gateway',
+      title: 'IPFS Service Worker Gateway',
       favicon: paths.public + '/favicon.ico',
       template: paths.public + '/index.html', // template file
       filename: 'index.html', // output file,


### PR DESCRIPTION
Similar to #105, pins to `pl-waw.ipfs.labs.scw.cloud` using remote pinning API.


Some thoughts on Scaleway as pinning service
  
- **The Good:** Looks like Scaleway implemented  https://ipfs.github.io/pinning-services-api-spec/#section/Provider-hints correctly. Local Kubo provides the DAG from imported CAR instantly, pinning by CID is pretty fast. ([example here took 28s](https://github.com/ipfs-shipyard/helia-service-worker-gateway/actions/runs/8256765918/job/22586136341#step:9:11))
- **The Bad:** `--cid` filtering on `ipfs pin remote` commands does not work correctly, seems to be ignored by Scaleway. 
  - **and Ugly:** However, filtering by `--name` works, so just putting CID there to allow us skip pinning if CID is already pinned ([example](https://github.com/ipfs-shipyard/helia-service-worker-gateway/actions/runs/8256765918/job/22587132417?pr=107)).  :shrug: 
  
Still, was easy to make it work, is fast, and gives us another copy.
I am going to merge this to increase our ability to dogfood setup with more than two pinning services.

Once merged, we will have three ways of pinning remotely, which is great for dogfooding, and evaluating complexity/maintenance/stability/cost:
  - our self-hosted collab cluster via  `ipfs-cluster-ctl` CLI
  - web3.storage via w3up tool
  - Scaleway via their HTTP endpoint compatible with `ipfs pin remote` / [pinning-services-api-spec](https://ipfs.github.io/pinning-services-api-spec/)