### PR TITLE
feat: some updates to #92

### DIFF
--- a/src/sw.ts
+++ b/src/sw.ts
@@ -243,7 +243,7 @@ async function getResponseFromCacheOrFetch (event: FetchEvent): Promise<Response
   // 👇 fetch always
   const response = fetchHandler({ path: url.pathname, request: event.request })
 
-  void response
+  await response
     .then(async response => storeReponseInCache({ response, isMutable, cacheKey }))
     .catch(err => {
       error('helia-ws: failed updating response in cache for %s in the background', cacheKey, err)

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -236,11 +236,9 @@ async function getResponseFromCacheOrFetch (event: FetchEvent): Promise<Response
   if (isValidCacheResponse(cachedResponse)) {
     log('helia-ws: cached response HIT for %s (expires: %s) %o', cacheKey, cachedResponse.headers.get('sw-cache-expires'), cachedResponse)
     return cachedResponse
-  } else {
-    log('helia-ws: cached response MISS for %s', cacheKey)
   }
+  log('helia-ws: cached response MISS for %s', cacheKey)
 
-  // 👇 fetch always
   const response = fetchHandler({ path: url.pathname, request: event.request })
 
   await response

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -191,7 +191,7 @@ function isSwAssetRequest (event: FetchEvent): boolean {
 function setExpiresHeader (response: Response, ttlSeconds: number = 3600): void {
   const expirationTime = new Date(Date.now() + ttlSeconds * 1000)
 
-  response.headers.set('Expires', expirationTime.toUTCString())
+  response.headers.set('sw-cache-expires', expirationTime.toUTCString())
 }
 
 function isValidCacheResponse (cachedResponse?: Response): cachedResponse is Response {
@@ -203,7 +203,7 @@ function isValidCacheResponse (cachedResponse?: Response): cachedResponse is Res
  * Note that this ignores the Cache-Control header since the expires header is set by us
  */
 function hasExpired (response: Response): boolean {
-  const expiresHeader = response.headers.get('Expires')
+  const expiresHeader = response.headers.get('sw-cache-expires')
 
   if (expiresHeader == null) {
     return false
@@ -238,7 +238,7 @@ async function getResponseFromCacheOrFetch (event: FetchEvent): Promise<Response
    * update the cache entry in the background.
    */
   if (isValidCacheResponse(cachedResponse)) {
-    log('helia-ws: cached response HIT for %s (expires: %s) %o', cacheKey, cachedResponse.headers.get('Expires'), cachedResponse)
+    log('helia-ws: cached response HIT for %s (expires: %s) %o', cacheKey, cachedResponse.headers.get('sw-cache-expires'), cachedResponse)
     return cachedResponse
   }
 

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -236,6 +236,8 @@ async function getResponseFromCacheOrFetch (event: FetchEvent): Promise<Response
   if (isValidCacheResponse(cachedResponse)) {
     log('helia-ws: cached response HIT for %s (expires: %s) %o', cacheKey, cachedResponse.headers.get('sw-cache-expires'), cachedResponse)
     return cachedResponse
+  } else {
+    log('helia-ws: cached response MISS for %s', cacheKey)
   }
 
   // 👇 fetch always

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -212,11 +212,7 @@ function hasExpired (response: Response): boolean {
   const expires = new Date(expiresHeader)
   const now = new Date()
 
-  if (expires < now) {
-    return true
-  }
-
-  return false
+  return expires < now
 }
 
 function getCacheKey (event: FetchEvent): string {


### PR DESCRIPTION
minor code cleanup and improvements for #92

- chore: PR comments and minor improvements
- fix: use sw-cache-expires
- chore: cleanup hasExpired return
- chore: log on cache miss
- chore: wait for response so we can cache it
- chore: minor cleanup
- chore: minor cleanup
- fix: stale-while-revalidate for ipns


notable changes:

1. stale-while-revalidate only for IPNS content (if people want no network requests, query ipfs resource)
2. sw-cache-expires as called out by @2color 
3. consolidation of fetch + update cache in `fetchAndUpdateCache` function