### PR TITLE
feat: quick TTFB & TTI for large content

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@helia/verified-fetch": "^1.2.1",
+        "@helia/verified-fetch": "^1.3.0",
         "@libp2p/logger": "^4.0.6",
         "@multiformats/dns": "^1.0.5",
         "@sgtpooki/file-type": "^1.0.1",
@@ -3016,9 +3016,9 @@
       "integrity": "sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ=="
     },
     "node_modules/@helia/verified-fetch": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@helia/verified-fetch/-/verified-fetch-1.2.1.tgz",
-      "integrity": "sha512-l1DJT0qkbLrGv80OgwfEwg4J0H2xpROyNMBkCEyYl1z557zRLsgMsSIuoL4dXhryYlNWZuPIAstHCvxN8YdLjw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@helia/verified-fetch/-/verified-fetch-1.3.0.tgz",
+      "integrity": "sha512-8mEmh+A6PMnEVOwY1QT+mBMpABfhBE8qd8MbwO6zC/qrsDop9UrU1D/4Lcm9G1cjqGItPxB8u4Y1d2sUoXeHPg==",
       "dependencies": {
         "@helia/block-brokers": "^2.0.2",
         "@helia/car": "^3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "helia-service-worker-gateway",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@helia/verified-fetch": "^1.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "helia-service-worker-gateway",
       "version": "1.0.0",
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@helia/verified-fetch": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     }
   },
   "dependencies": {
-    "@helia/verified-fetch": "^1.2.1",
+    "@helia/verified-fetch": "^1.3.0",
     "@libp2p/logger": "^4.0.6",
     "@multiformats/dns": "^1.0.5",
     "@sgtpooki/file-type": "^1.0.1",

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -362,11 +362,11 @@ function shouldCacheResponse ({ event, response }: { event: FetchEvent, response
   }
   const invalidOkResponseCodesForCache = [206]
   if (invalidOkResponseCodesForCache.some(code => code === response.status)) {
-    log('helia-sw-cache-debug: not caching response with status %s', response.status)
+    log('helia-sw: not caching response with status %s', response.status)
     return false
   }
   if (event.request.headers.get('pragma') === 'no-cache' || event.request.headers.get('cache-control') === 'no-cache') {
-    log('helia-sw-cache-debug: request indicated no-cache, not caching')
+    log('helia-sw: request indicated no-cache, not caching')
     return false
   }
 

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -82,6 +82,7 @@ const CURRENT_CACHES = Object.freeze({
 })
 let verifiedFetch: VerifiedFetch
 const channel = new HeliaServiceWorkerCommsChannel('SW')
+const timeoutAbortEventType = 'verified-fetch-timeout'
 const ONE_HOUR_IN_SECONDS = 3600
 const urlInterceptRegex = [new RegExp(`${self.location.origin}/ip(n|f)s/`)]
 const updateVerifiedFetch = async (): Promise<void> => {
@@ -427,7 +428,7 @@ async function fetchHandler ({ path, request, event }: FetchHandlerArg): Promise
   const signal = abortController.signal
   const abortFn = (event: Pick<AbortSignalEventMap['abort'], 'type'>): void => {
     clearTimeout(signalAbortTimeout)
-    if (event?.type !== 'verified-fetch-timeout') {
+    if (event?.type !== timeoutAbortEventType) {
       log.trace('helia-sw: request signal aborted')
       abortController.abort('request signal aborted')
     } else {
@@ -441,7 +442,7 @@ async function fetchHandler ({ path, request, event }: FetchHandlerArg): Promise
    * @todo reduce to 2 minutes?
    */
   const signalAbortTimeout = setTimeout(() => {
-    abortFn({ type: 'verified-fetch-timeout' })
+    abortFn({ type: timeoutAbortEventType })
   }, 5 * 60 * 1000)
   // if the fetch event is aborted, we need to abort the signal we give to @helia/verified-fetch
   event.request.signal.addEventListener('abort', abortFn)

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -428,12 +428,12 @@ async function fetchHandler ({ path, request, event }: FetchHandlerArg): Promise
   const signal = abortController.signal
   const abortFn = (event: Pick<AbortSignalEventMap['abort'], 'type'>): void => {
     clearTimeout(signalAbortTimeout)
-    if (event?.type !== timeoutAbortEventType) {
-      log.trace('helia-sw: request signal aborted')
-      abortController.abort('request signal aborted')
-    } else {
+    if (event?.type === timeoutAbortEventType) {
       log.trace('helia-sw: timeout waiting for response from @helia/verified-fetch')
       abortController.abort('timeout')
+    } else {
+      log.trace('helia-sw: request signal aborted')
+      abortController.abort('request signal aborted')
     }
   }
   /**

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -441,7 +441,7 @@ async function fetchHandler ({ path, request, event }: FetchHandlerArg): Promise
       log.trace('fetchHandler: request headers: %s: %s', key, value)
     })
 
-    const response = await verifiedFetch(verifiedFetchUrl, {
+    const response = verifiedFetch(verifiedFetchUrl, {
       signal,
       headers,
       // TODO redirect: 'manual', // enable when http urls are supported by verified-fetch: https://github.com/ipfs-shipyard/helia-service-worker-gateway/issues/62#issuecomment-1977661456
@@ -459,7 +459,7 @@ async function fetchHandler ({ path, request, event }: FetchHandlerArg): Promise
      * the response object, regardless of it's inner content
      */
     clearTimeout(signalAbortTimeout)
-    return response
+    return await response
   } catch (err: unknown) {
     const errorMessages: string[] = []
     if (isAggregateError(err)) {

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -361,7 +361,7 @@ function shouldCacheResponse ({ event, response }: { event: FetchEvent, response
     return false
   }
   const statusCodesToNotCache = [206]
-  if (invalidOkResponseCodesForCache.some(code => code === response.status)) {
+  if (statusCodesToNotCache.some(code => code === response.status)) {
     log('helia-sw: not caching response with status %s', response.status)
     return false
   }

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -456,7 +456,7 @@ async function fetchHandler ({ path, request, event }: FetchHandlerArg): Promise
       log.trace('fetchHandler: request headers: %s: %s', key, value)
     })
 
-    const response = verifiedFetch(verifiedFetchUrl, {
+    const response = await verifiedFetch(verifiedFetchUrl, {
       signal,
       headers,
       // TODO redirect: 'manual', // enable when http urls are supported by verified-fetch: https://github.com/ipfs-shipyard/helia-service-worker-gateway/issues/62#issuecomment-1977661456
@@ -474,7 +474,7 @@ async function fetchHandler ({ path, request, event }: FetchHandlerArg): Promise
      * the response object, regardless of it's inner content
      */
     clearTimeout(signalAbortTimeout)
-    return await response
+    return response
   } catch (err: unknown) {
     const errorMessages: string[] = []
     if (isAggregateError(err)) {

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -360,7 +360,7 @@ function shouldCacheResponse ({ event, response }: { event: FetchEvent, response
   if (!response.ok) {
     return false
   }
-  const invalidOkResponseCodesForCache = [206]
+  const statusCodesToNotCache = [206]
   if (invalidOkResponseCodesForCache.some(code => code === response.status)) {
     log('helia-sw: not caching response with status %s', response.status)
     return false


### PR DESCRIPTION
## Title

<!---
The title of the PR will be the commit message of the merge commit, so please make sure it is descriptive enough.
We utilize the Conventional Commits specification for our commit messages. See <https://www.conventionalcommits.org/en/v1.0.0/#specification> for more information.
The commit tag types can be of one of the following: feat, fix, deps, refactor, chore, docs. See <https://github.com/ipfs/helia/blob/main/.github/workflows/main.yml#L184-L192>
The title must also be fewer than 72 characters long or it will fail the Semantic PR check. See <https://github.com/ipfs/helia/blob/main/.github/workflows/semantic-pull-request.yml>
--->

feat: quick TTFB & TTI for large content

## Description

<!--
Please write a summary of your changes and why you made them.
Please include any relevant issues in here, for example:
Related https://github.com/ipfs/helia/issues/ABCD.
Fixes https://github.com/ipfs/helia/issues/XYZ.
-->

This updates helia-service-worker-gateway to @helia/verified-fetch@1.3.0 and ensures we're respecting the request event's AbortSignal.

Summary of changes (thanks @2color):

1. Handle aborts from original fetch event
1. Don't await Cache API puts
1. Respect cache-control: no-cache & pragma: no-cache

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->
after getting https://github.com/ipfs-shipyard/helia-service-worker-gateway/pull/122 and https://github.com/ipfs/helia-verified-fetch/pull/26 merged.. then updating @helia/verified-fetch in service-worker-gateway locally…. large video loading feels much more responsive

For the below, I hardcoded my local kubo node to ensure trustless-gateway.link was not being used.


### big-buck-bunny TTFB/TTI for the code in this PR from kubo node with content:

Brave: consistently < 800ms 
FireFox: 159ms

1. A local kubo gateway configured (that has the content) `npx kubo daemon`
2. cache disabled in the browser.

You can use the below process and code snippet to get TTFB:

1. clear out service worker
3. reload the page (you will see redirect page, make sure config is set up properly)
4. click "load content" or reload.
5. When the video renders, pause it.
6. Run the below snippet in the dev console

```
new PerformanceObserver((entryList) => {
  const videoLoadEntries = performance.getEntriesByType('navigation')
    .filter((entry) => entry.name.includes('bafybeidsp6fva53dexzjycntiucts57ftecajcn5omzfgjx57pqfy3kwbq.ipfs.helia-sw-gateway.localhost'))

  for (const videoLoadEntry of videoLoadEntries) {
    console.log(`TTFB: ${videoLoadEntry.duration}ms for ${videoLoadEntry.name}`)
  }
}).observe({
  type: 'navigation',
  buffered: true
});
```


### big-buck-bunny TTFB/TTI for code in this PR pulling from *fresh* kubo node:

Brave: 4-12s.

see https://github.com/ipfs-shipyard/helia-service-worker-gateway/issues/131#issuecomment-2014184623


### big-buck-bunny TTFB/TTI for `main` branch code on kubo node with content


In Brave: Consistently over 1000ms.. with a fresh service worker

In Firefox: idk why but it was returning within a few ms.. old cache/sw that wouldn't go away? https://support.mozilla.org/en-US/kb/clear-cookies-and-site-data-firefox didn't always take


### big-buck-bunny TTFB/TTI for code in `main` from *fresh* kubo node:

Brave: averaging ~70-90 seconds


## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
