### PR TITLE
test: enable testing of inbrowser.dev and inbrowser.link

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "test:browsers": "playwright test -c playwright.config.js",
     "test:chrome": "playwright test -c playwright.config.js --project chromium",
     "test:firefox": "playwright test -c playwright.config.js --project firefox",
+    "test:inbrowser-dev": "playwright test -c playwright.config.js --project continuous-delivery-dev",
+    "test:inbrowser-prod": "playwright test -c playwright.config.js --project continuous-delivery-prod",
     "test:node": "aegir test -t node -f dist-tsc/test/node.js --cov",
     "postinstall": "patch-package"
   },

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -36,8 +36,25 @@ export default defineConfig({
     {
       name: 'firefox',
       use: { ...devices['Desktop Firefox'] }
+    },
+    {
+      name: 'continuous-delivery-dev',
+      use: {
+        ...devices['Desktop Chrome'],
+        ...devices['Desktop Firefox'],
+        baseURL: 'https://inbrowser.dev'
+      }
+    },
+    {
+      name: 'continuous-delivery-prod',
+      use: {
+        ...devices['Desktop Chrome'],
+        ...devices['Desktop Firefox'],
+        baseURL: 'https://inbrowser.link'
+      }
     }
   ],
+  // TODO: disable webservers when testing `continuous-delivery-dev` and `continuous-delivery-prod`
   webServer: [
     {
       command: 'node test-e2e/reverse-proxy.js',

--- a/test-e2e/fixtures/config-test-fixtures.ts
+++ b/test-e2e/fixtures/config-test-fixtures.ts
@@ -6,9 +6,14 @@ const rootDomain = async ({ baseURL }, use): Promise<void> => {
   const url = new URL(baseURL)
   await use(url.host)
 }
+const baseURLProtocol = async ({ baseURL }, use): Promise<void> => {
+  const url = new URL(baseURL)
+  await use(url.protocol)
+}
 
-export const test = base.extend<{ rootDomain: string, baseURL: string }>({
+export const test = base.extend<{ rootDomain: string, baseURL: string, protocol: string }>({
   rootDomain: [rootDomain, { scope: 'test' }],
+  protocol: [baseURLProtocol, { scope: 'test' }],
   page: async ({ page, baseURL }, use) => {
     await page.goto(baseURL, { waitUntil: 'networkidle' })
     await waitForServiceWorker(page)
@@ -27,8 +32,9 @@ export const test = base.extend<{ rootDomain: string, baseURL: string }>({
 /**
  * You should use this fixture instead of the `test` fixture from `@playwright/test` when testing path routing via the service worker.
  */
-export const testPathRouting = base.extend<{ rootDomain: string, baseURL: string }>({
+export const testPathRouting = base.extend<{ rootDomain: string, baseURL: string, protocol: string }>({
   rootDomain: [rootDomain, { scope: 'test' }],
+  protocol: [baseURLProtocol, { scope: 'test' }],
   page: async ({ page, rootDomain }, use) => {
     if (!rootDomain.includes('localhost')) {
       // for non localhost tests, we skip path routing tests
@@ -59,16 +65,17 @@ export const testPathRouting = base.extend<{ rootDomain: string, baseURL: string
  * import { testSubdomainRouting as test, expect } from './fixtures/config-test-fixtures.js'
  *
  * test.describe('subdomain-detection', () => {
- *   test('path requests are redirected to subdomains', async ({ page }) => {
- *     await page.goto('http://bafkqablimvwgy3y.ipfs.localhost:3333/', { waitUntil: 'networkidle' })
+ *   test('path requests are redirected to subdomains', async ({ page, rootDomain, protocol }) => {
+ *     await page.goto(`${protocol}//bafkqablimvwgy3y.ipfs.${rootDomain}/`, { waitUntil: 'networkidle' })
  *     const bodyTextLocator = page.locator('body')
  *     await expect(bodyTextLocator).toContainText('hello')
  *   })
  * })
  * ```
  */
-export const testSubdomainRouting = base.extend<{ rootDomain: string, baseURL: string }>({
+export const testSubdomainRouting = base.extend<{ rootDomain: string, baseURL: string, protocol: string }>({
   rootDomain: [rootDomain, { scope: 'test' }],
+  protocol: [baseURLProtocol, { scope: 'test' }],
   page: async ({ page, baseURL }, use) => {
     await page.goto(baseURL, { waitUntil: 'networkidle' })
     await waitForServiceWorker(page)

--- a/test-e2e/subdomain-detection.test.ts
+++ b/test-e2e/subdomain-detection.test.ts
@@ -3,16 +3,16 @@ import { setConfig, setSubdomainConfig } from './fixtures/set-sw-config.js'
 import { waitForServiceWorker } from './fixtures/wait-for-service-worker.js'
 
 test.describe('subdomain-detection', () => {
-  test('path requests are redirected to subdomains', async ({ page, baseURL, rootDomain }) => {
+  test('path requests are redirected to subdomains', async ({ page, baseURL, rootDomain, protocol }) => {
     await page.goto(baseURL, { waitUntil: 'networkidle' })
     await waitForServiceWorker(page)
     await setConfig({ page, config: { autoReload: false, gateways: [process.env.KUBO_GATEWAY as string], routers: [process.env.KUBO_GATEWAY as string] } })
     const initialResponse = await page.goto('/ipfs/bafkqablimvwgy3y', { waitUntil: 'commit' })
 
-    expect(initialResponse?.url()).toBe(`http://bafkqablimvwgy3y.ipfs.${rootDomain}/`)
-    expect(initialResponse?.request()?.redirectedFrom()?.url()).toBe(`http://${rootDomain}/ipfs/bafkqablimvwgy3y`)
+    expect(initialResponse?.url()).toBe(`${protocol}//bafkqablimvwgy3y.ipfs.${rootDomain}/`)
+    expect(initialResponse?.request()?.redirectedFrom()?.url()).toBe(`${protocol}//${rootDomain}/ipfs/bafkqablimvwgy3y`)
 
-    await page.waitForURL(`http://bafkqablimvwgy3y.ipfs.${rootDomain}`)
+    await page.waitForURL(`${protocol}//bafkqablimvwgy3y.ipfs.${rootDomain}`)
     const bodyTextLocator = page.locator('body')
     await expect(bodyTextLocator).toContainText('Registering Helia service worker')
 
@@ -24,8 +24,8 @@ test.describe('subdomain-detection', () => {
     await expect(bodyTextLocator).toContainText('hello')
   })
 
-  test('enabling autoreload automatically loads the subdomain', async ({ page, rootDomain }) => {
-    await page.goto(`http://bafkqablimvwgy3y.ipfs.${rootDomain}/`, { waitUntil: 'networkidle' })
+  test('enabling autoreload automatically loads the subdomain', async ({ page, rootDomain, protocol }) => {
+    await page.goto(`${protocol}//bafkqablimvwgy3y.ipfs.${rootDomain}/`, { waitUntil: 'networkidle' })
     await setSubdomainConfig({ page, config: { autoReload: true, gateways: [process.env.KUBO_GATEWAY as string], routers: [process.env.KUBO_GATEWAY as string] } })
 
     const bodyTextLocator = page.locator('body')
@@ -35,8 +35,8 @@ test.describe('subdomain-detection', () => {
 })
 
 testSubdomainRouting.describe('subdomain-detection auto fixture', () => {
-  testSubdomainRouting('loads subdomains easily', async ({ page, rootDomain }) => {
-    await page.goto(`http://bafkqablimvwgy3y.ipfs.${rootDomain}/`, { waitUntil: 'networkidle' })
+  testSubdomainRouting('loads subdomains easily', async ({ page, rootDomain, protocol }) => {
+    await page.goto(`${protocol}//bafkqablimvwgy3y.ipfs.${rootDomain}/`, { waitUntil: 'networkidle' })
 
     const bodyTextLocator = page.locator('body')
 

--- a/test-e2e/subdomain-detection.test.ts
+++ b/test-e2e/subdomain-detection.test.ts
@@ -1,4 +1,3 @@
-// import { test } from '@playwright/test'
 import { test, testSubdomainRouting, expect } from './fixtures/config-test-fixtures.js'
 import { setConfig, setSubdomainConfig } from './fixtures/set-sw-config.js'
 import { waitForServiceWorker } from './fixtures/wait-for-service-worker.js'

--- a/test-e2e/subdomain-detection.test.ts
+++ b/test-e2e/subdomain-detection.test.ts
@@ -1,19 +1,19 @@
-import { test } from '@playwright/test'
-import { testSubdomainRouting, expect } from './fixtures/config-test-fixtures.js'
+// import { test } from '@playwright/test'
+import { test, testSubdomainRouting, expect } from './fixtures/config-test-fixtures.js'
 import { setConfig, setSubdomainConfig } from './fixtures/set-sw-config.js'
 import { waitForServiceWorker } from './fixtures/wait-for-service-worker.js'
 
 test.describe('subdomain-detection', () => {
-  test('path requests are redirected to subdomains', async ({ page }) => {
-    await page.goto('http://localhost:3333', { waitUntil: 'networkidle' })
+  test('path requests are redirected to subdomains', async ({ page, baseURL, rootDomain }) => {
+    await page.goto(baseURL, { waitUntil: 'networkidle' })
     await waitForServiceWorker(page)
     await setConfig({ page, config: { autoReload: false, gateways: [process.env.KUBO_GATEWAY as string], routers: [process.env.KUBO_GATEWAY as string] } })
     const initialResponse = await page.goto('/ipfs/bafkqablimvwgy3y', { waitUntil: 'commit' })
 
-    expect(initialResponse?.url()).toBe('http://bafkqablimvwgy3y.ipfs.localhost:3333/')
-    expect(initialResponse?.request()?.redirectedFrom()?.url()).toBe('http://localhost:3333/ipfs/bafkqablimvwgy3y')
+    expect(initialResponse?.url()).toBe(`http://bafkqablimvwgy3y.ipfs.${rootDomain}/`)
+    expect(initialResponse?.request()?.redirectedFrom()?.url()).toBe(`http://${rootDomain}/ipfs/bafkqablimvwgy3y`)
 
-    await page.waitForURL('http://bafkqablimvwgy3y.ipfs.localhost:3333')
+    await page.waitForURL(`http://bafkqablimvwgy3y.ipfs.${rootDomain}`)
     const bodyTextLocator = page.locator('body')
     await expect(bodyTextLocator).toContainText('Registering Helia service worker')
 
@@ -25,8 +25,8 @@ test.describe('subdomain-detection', () => {
     await expect(bodyTextLocator).toContainText('hello')
   })
 
-  test('enabling autoreload automatically loads the subdomain', async ({ page }) => {
-    await page.goto('http://bafkqablimvwgy3y.ipfs.localhost:3333/', { waitUntil: 'networkidle' })
+  test('enabling autoreload automatically loads the subdomain', async ({ page, rootDomain }) => {
+    await page.goto(`http://bafkqablimvwgy3y.ipfs.${rootDomain}/`, { waitUntil: 'networkidle' })
     await setSubdomainConfig({ page, config: { autoReload: true, gateways: [process.env.KUBO_GATEWAY as string], routers: [process.env.KUBO_GATEWAY as string] } })
 
     const bodyTextLocator = page.locator('body')
@@ -36,8 +36,8 @@ test.describe('subdomain-detection', () => {
 })
 
 testSubdomainRouting.describe('subdomain-detection auto fixture', () => {
-  testSubdomainRouting('loads subdomains easily', async ({ page }) => {
-    await page.goto('http://bafkqablimvwgy3y.ipfs.localhost:3333/', { waitUntil: 'networkidle' })
+  testSubdomainRouting('loads subdomains easily', async ({ page, rootDomain }) => {
+    await page.goto(`http://bafkqablimvwgy3y.ipfs.${rootDomain}/`, { waitUntil: 'networkidle' })
 
     const bodyTextLocator = page.locator('body')
 


### PR DESCRIPTION
## Title

<!---
The title of the PR will be the commit message of the merge commit, so please make sure it is descriptive enough.
We utilize the Conventional Commits specification for our commit messages. See <https://www.conventionalcommits.org/en/v1.0.0/#specification> for more information.
The commit tag types can be of one of the following: feat, fix, deps, refactor, chore, docs. See <https://github.com/ipfs/helia/blob/main/.github/workflows/main.yml#L184-L192>
The title must also be fewer than 72 characters long or it will fail the Semantic PR check. See <https://github.com/ipfs/helia/blob/main/.github/workflows/semantic-pull-request.yml>
--->
test: enable testing of inbrowser.dev and inbrowser.link

## Description

<!--
Please write a summary of your changes and why you made them.
Please include any relevant issues in here, for example:
Related https://github.com/ipfs/helia/issues/ABCD.
Fixes https://github.com/ipfs/helia/issues/XYZ.
-->

This PR enables testing of inbrowser.dev and inbrowser.link.

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

Had to add a new `rootDomain` fixture to `config-test-fixtures.ts` to enable picking and expecting the correct urls.

This PR also ensures that path-routing tests are skipped for inbrowser.dev and inbrowser.link.

inbrowser.dev and inbrowser.link are currently failing when running `npm run test:inbrowser-dev` and `npm run test:inbrowser-prod`, even though they're passing for local tests. We should be able to add these into our release process as well as test inbrowser's functionality locally via these e2e tests.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
