### PR TITLE
chore: update verified-fetch & react types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@helia/verified-fetch": "^1.3.3",
+        "@helia/verified-fetch": "^1.3.4",
         "@libp2p/logger": "^4.0.8",
         "@multiformats/dns": "^1.0.5",
         "@sgtpooki/file-type": "^1.0.1",
@@ -25,7 +25,7 @@
         "@babel/preset-react": "^7.24.1",
         "@babel/preset-typescript": "^7.24.1",
         "@playwright/test": "^1.42.1",
-        "@types/react": "^18.2.68",
+        "@types/react": "^18.2.74",
         "aegir": "^42.2.5",
         "babel-loader": "^9.1.3",
         "copy-webpack-plugin": "^12.0.2",
@@ -3306,9 +3306,9 @@
       }
     },
     "node_modules/@helia/verified-fetch": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@helia/verified-fetch/-/verified-fetch-1.3.3.tgz",
-      "integrity": "sha512-OtKHl9u2+qRvWkDZdZTlR1pfIVTajnrzCv5Xmt0zpy41uKZFUdZplOD6AGWbDup3fnwktdB8sBF0TJ+YGTfRtg==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@helia/verified-fetch/-/verified-fetch-1.3.4.tgz",
+      "integrity": "sha512-wMOLG6fuQjoLx3p3chSwb776GC0SEE5gN/cgU20B7Q+NZgaHEVoQ9r7IOao425Vnv9UU3ftloUE2wcRiZmpCLQ==",
       "dependencies": {
         "@helia/block-brokers": "^2.0.2",
         "@helia/car": "^3.1.0",
@@ -5256,9 +5256,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "18.2.72",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.72.tgz",
-      "integrity": "sha512-/e7GWxGzXQF7OJAua7UAYqYi/4VpXEfbGtmYQcAQwP3SjjjAXfybTf/JK5S+SaetB/ChXl8Y2g1hCsj7jDXxcg==",
+      "version": "18.2.74",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.74.tgz",
+      "integrity": "sha512-9AEqNZZyBx8OdZpxzQlaFEVCSFUM2YXJH46yPOiOpm078k6ZLOCcuAzGum/zK8YBwY+dbahVNbHrbgrAwIRlqw==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     }
   },
   "dependencies": {
-    "@helia/verified-fetch": "^1.3.3",
+    "@helia/verified-fetch": "^1.3.4",
     "@libp2p/logger": "^4.0.8",
     "@multiformats/dns": "^1.0.5",
     "@sgtpooki/file-type": "^1.0.1",
@@ -57,7 +57,7 @@
     "@babel/preset-react": "^7.24.1",
     "@babel/preset-typescript": "^7.24.1",
     "@playwright/test": "^1.42.1",
-    "@types/react": "^18.2.68",
+    "@types/react": "^18.2.74",
     "aegir": "^42.2.5",
     "babel-loader": "^9.1.3",
     "copy-webpack-plugin": "^12.0.2",


### PR DESCRIPTION
- chore: update deps

```bash
╰─ ✔ ❯ ncu
Checking /Users/sgtpooki/code/work/protocol.ai/ipfs-shipyard/helia-service-worker-gateway/package.json
[====================] 38/38 100%

 @helia/verified-fetch    ^1.3.3  →    ^1.3.4
 @types/react           ^18.2.68  →  ^18.2.74

Run ncu -u to upgrade package.json

╰─ ✔ ❯ ncu -u
Upgrading /Users/sgtpooki/code/work/protocol.ai/ipfs-shipyard/helia-service-worker-gateway/package.json
[====================] 38/38 100%

 @helia/verified-fetch    ^1.3.3  →    ^1.3.4
 @types/react           ^18.2.68  →  ^18.2.74

Run npm install to install new versions.
```

fixes #83
