### PR TITLE
chore(ci): switch to cluster defaults

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -172,7 +172,7 @@ jobs:
 
   publish-to-ipfs:
     # NOTE: workflow_dispatch here allows maintainer to manually run against any branch, and it will produce a CAR with CID that is pinned to our cluster
-    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'release' && github.event.action == 'published')
+    # TODO: if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'release' && github.event.action == 'published')
     needs: build
     runs-on: ubuntu-latest
     environment: Deploy # Clusteer secrets

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -215,7 +215,7 @@ jobs:
       - name: IPFS import of ./dist
         id: ipfs-import
         run: |
-          root_cid=$(ipfs add --cid-version 1 --inline --chunker size-1048576 -Q -r --offline ./dist)
+          root_cid=$(ipfs add --cid-version 1 --inline --chunker size-262144 -Q -r --offline ./dist)
           echo "cid=$root_cid" >> $GITHUB_OUTPUT
       - name: ℹ️  Generated DAG and CID
         run: ipfs dag stat --progress=false ${{ steps.ipfs-import.outputs.cid }}
@@ -234,8 +234,6 @@ jobs:
               --basic-auth "${CLUSTER_USER}:${CLUSTER_PASSWORD}" \
               pin add \
               --name "${{ github.repository }}/${{ github.sha }}" \
-              --replication-min 2 \
-              --replication-max 6 \
               --wait \
               "$PIN_CID"
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -172,7 +172,7 @@ jobs:
 
   publish-to-ipfs:
     # NOTE: workflow_dispatch here allows maintainer to manually run against any branch, and it will produce a CAR with CID that is pinned to our cluster
-    # TODO: if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'release' && github.event.action == 'published')
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'release' && github.event.action == 'published')
     needs: build
     runs-on: ubuntu-latest
     environment: Deploy # Clusteer secrets


### PR DESCRIPTION
This PR aims to align the way we do cluster pinning to be closer to what seems to work (better?) for dist.ipfs.tech.

- `--wait` will wait until there is one copy in cluster, no need to over-specify the replication factor (we don't do that on dist.ipfs.tech)
  - it _should_ be equivalent to legacy wait we have implemented in [distributions/scripts/ci/pin-to-cluster.sh#L14-L2](https://github.com/ipfs/distributions/blob/80b389e6046f039243772082905a9562c6741b6d/scripts/ci/pin-to-cluster.sh#L14-L26) but perhaps `--wait` with works differently without `--replication-min` than we expect (need to see in practice)
- while at it, switching block size to default in kubo just to reduce number of differences with dist.ipfs.tech
