### PR TITLE
fix: ipfs-hosted redirects are not infinite

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -70,6 +70,16 @@ export default defineConfig({
       stderr: process.env.CI ? undefined : 'pipe'
     },
     {
+      command: 'node test-e2e/ipfs-gateway.js',
+      timeout: 5 * 1000,
+      env: {
+        PROXY_PORT: '3334',
+        GATEWAY_PORT: '8088'
+      },
+      stdout: process.env.CI ? undefined : 'pipe',
+      stderr: process.env.CI ? undefined : 'pipe'
+    },
+    {
       // need to use built assets due to service worker loading issue.
       // TODO: figure out how to get things working with npm run start
       command: 'npm run build && npx http-server --silent -p 3000 dist',

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,9 +1,7 @@
 import 'preact/debug'
 import React, { render } from 'preact/compat'
 import App from './app.jsx'
-import { ConfigProvider } from './context/config-context.jsx'
 import { RouterProvider, type Route } from './context/router-context.jsx'
-import { ServiceWorkerProvider } from './context/service-worker-context.jsx'
 
 // SW did not trigger for this request
 const container = document.getElementById('root')
@@ -23,18 +21,20 @@ const routes: Route[] = [
   { default: true, component: LazyHelperUi },
   { shouldRender: async () => (await import('./lib/routing-render-checks.js')).shouldRenderRedirectsInterstitial(), component: LazyInterstitial },
   { path: '#/ipfs-sw-config', shouldRender: async () => (await import('./lib/routing-render-checks.js')).shouldRenderConfigPage(), component: LazyConfig },
-  { shouldRender: async () => (await import('./lib/routing-render-checks.js')).shouldRenderRedirectPage(), component: LazyRedirectPage }
+  {
+    shouldRender: async () => {
+      const renderChecks = await import('./lib/routing-render-checks.js')
+      return renderChecks.shouldRenderRedirectPage()
+    },
+    component: LazyRedirectPage
+  }
 ]
 
 render(
   <React.StrictMode>
-    <ServiceWorkerProvider>
-      <ConfigProvider>
-        <RouterProvider routes={routes}>
-          <App />
-        </RouterProvider>
-      </ConfigProvider>
-    </ServiceWorkerProvider>
+    <RouterProvider routes={routes}>
+      <App />
+    </RouterProvider>
   </React.StrictMode>,
   container
 )

--- a/src/lib/routing-render-checks.ts
+++ b/src/lib/routing-render-checks.ts
@@ -1,3 +1,12 @@
+/**
+ * We should load the redirect page if:
+ *
+ * 1. The request is the first hit on the subdomain
+ * - but NOT if subdomains are supported and we're not currently on the subdomain.
+ * i.e. example.com?helia-sw=/ipfs/blah will hit shouldRenderRedirectsInterstitial, which will redirect to blah.ipfs.example.com, which will THEN return true from shouldRenderRedirectPage
+ * 2. The request is not an explicit request to view the config page
+ * 3. The request would otherwise be handled by the service worker but it's not yet registered.
+ */
 export async function shouldRenderRedirectPage (): Promise<boolean> {
   const { isConfigPage } = await import('../lib/is-config-page.js')
   const { isPathOrSubdomainRequest } = await import('./path-or-subdomain.js')
@@ -6,6 +15,7 @@ export async function shouldRenderRedirectPage (): Promise<boolean> {
   const isTopLevelWindow = window.self === window.top
   const isRequestToViewConfigPageAndTopLevelWindow = isRequestToViewConfigPage && isTopLevelWindow
   const result = shouldRequestBeHandledByServiceWorker && !isRequestToViewConfigPageAndTopLevelWindow
+
   return result
 }
 
@@ -16,7 +26,7 @@ export async function shouldRenderConfigPage (): Promise<boolean> {
   return isRequestToViewConfigPage
 }
 
-export async function shouldRenderRedirectsInterstitial (): Promise<boolean> {
+export function shouldRenderRedirectsInterstitial (): boolean {
   const url = new URL(window.location.href)
   const heliaSw = url.searchParams.get('helia-sw')
   return heliaSw != null

--- a/src/lib/translate-ipfs-redirect-url.ts
+++ b/src/lib/translate-ipfs-redirect-url.ts
@@ -1,6 +1,7 @@
 /**
- * If you host helia-service-worker-gateway on an IPFS domain, the redirects file will route some requests from
- * `<domain>/<wildcard-splat>` to `https://<domain>/?helia-sw=<wildcard-splat>`.
+ * If you host helia-service-worker-gateway with an IPFS gateway, the _redirects file will route some requests from
+ * `<domain>/<wildcard-splat>` to `https://<domain>/?helia-sw=<wildcard-splat>` when they hit the server instead of
+ * the service worker. This only occurs when the service worker is not yet registered.
  *
  * This function will check for "?helia-sw=" in the URL and modify the URL so that it works with the rest of our logic
  */

--- a/src/lib/translate-ipfs-redirect-url.ts
+++ b/src/lib/translate-ipfs-redirect-url.ts
@@ -1,0 +1,15 @@
+/**
+ * If you host helia-service-worker-gateway on an IPFS domain, the redirects file will route some requests from
+ * `<domain>/<wildcard-splat>` to `https://<domain>/?helia-sw=<wildcard-splat>`.
+ *
+ * This function will check for "?helia-sw=" in the URL and modify the URL so that it works with the rest of our logic
+ */
+export function translateIpfsRedirectUrl (urlString: string): URL {
+  const url = new URL(urlString)
+  const heliaSw = url.searchParams.get('helia-sw')
+  if (heliaSw != null) {
+    url.searchParams.delete('helia-sw')
+    url.pathname = heliaSw
+  }
+  return url
+}

--- a/src/pages/config.tsx
+++ b/src/pages/config.tsx
@@ -3,7 +3,9 @@ import { Collapsible } from '../components/collapsible.jsx'
 import LocalStorageInput from '../components/local-storage-input.jsx'
 import { LocalStorageToggle } from '../components/local-storage-toggle.jsx'
 import { ServiceWorkerReadyButton } from '../components/sw-ready-button.jsx'
+import { ConfigProvider } from '../context/config-context.jsx'
 import { RouteContext } from '../context/router-context.jsx'
+import { ServiceWorkerProvider } from '../context/service-worker-context.jsx'
 import { HeliaServiceWorkerCommsChannel } from '../lib/channel.js'
 import { getConfig, loadConfigFromLocalStorage } from '../lib/config-db.js'
 import { LOCAL_STORAGE_KEYS } from '../lib/local-storage.js'
@@ -34,7 +36,7 @@ const stringValidationFn = (value: string): Error | null => {
   return null
 }
 
-export default (): React.JSX.Element | null => {
+function ConfigPage (): React.JSX.Element | null {
   const { gotoPage } = React.useContext(RouteContext)
   const [error, setError] = useState<Error | null>(null)
 
@@ -94,5 +96,15 @@ export default (): React.JSX.Element | null => {
         {error != null && <span style={{ color: 'red' }}>{error.message}</span>}
       </Collapsible>
     </main>
+  )
+}
+
+export default (): React.JSX.Element => {
+  return (
+    <ServiceWorkerProvider>
+      <ConfigProvider>
+        <ConfigPage />
+      </ConfigProvider>
+    </ServiceWorkerProvider>
   )
 }

--- a/src/pages/helper-ui.tsx
+++ b/src/pages/helper-ui.tsx
@@ -2,9 +2,11 @@ import React, { useState, useEffect } from 'preact/compat'
 import Form from '../components/Form.jsx'
 import Header from '../components/Header.jsx'
 import CidRenderer from '../components/input-validator.jsx'
+import { ConfigProvider } from '../context/config-context.jsx'
+import { ServiceWorkerProvider } from '../context/service-worker-context.jsx'
 import { LOCAL_STORAGE_KEYS } from '../lib/local-storage.js'
 
-export default function (): React.JSX.Element {
+function HelperUi (): React.JSX.Element {
   const [requestPath, setRequestPath] = useState(localStorage.getItem(LOCAL_STORAGE_KEYS.forms.requestPath) ?? '')
 
   useEffect(() => {
@@ -32,5 +34,15 @@ export default function (): React.JSX.Element {
 
       </main>
     </>
+  )
+}
+
+export default (): React.JSX.Element => {
+  return (
+    <ServiceWorkerProvider>
+      <ConfigProvider>
+        <HelperUi />
+      </ConfigProvider>
+    </ServiceWorkerProvider>
   )
 }

--- a/src/pages/redirects-interstitial.tsx
+++ b/src/pages/redirects-interstitial.tsx
@@ -1,34 +1,41 @@
-import React from 'preact/compat'
+import React, { useEffect } from 'preact/compat'
+import { findOriginIsolationRedirect } from '../lib/path-or-subdomain.js'
+import { translateIpfsRedirectUrl } from '../lib/translate-ipfs-redirect-url.js'
+import RedirectPage from './redirect-page'
 
 /**
  * This page is only used to capture the ?helia-sw=/ip[fn]s/blah query parameter that
  * is used by IPFS hosted versions of the service-worker-gateway when non-existent paths are requested.
+ * This will only redirect if the URL is for a subdomain
  */
 export default function RedirectsInterstitial (): React.JSX.Element {
-  const windowLocation = translateIpfsRedirectUrl(window.location.href)
-  if (windowLocation.href !== window.location.href) {
-  /**
-   * We're at a domain with ?helia-sw=, we can reload the page so the service worker will
-   * capture the request
-   */
-    window.location.replace(windowLocation.href)
+  const [subdomainRedirectUrl, setSubdomainRedirectUrl] = React.useState<string | null>(null)
+  const [isSubdomainCheckDone, setIsSubdomainCheckDone] = React.useState<boolean>(false)
+  useEffect(() => {
+    async function doWork (): Promise<void> {
+      setSubdomainRedirectUrl(await findOriginIsolationRedirect(translateIpfsRedirectUrl(window.location.href)))
+      setIsSubdomainCheckDone(true)
+    }
+    void doWork()
+  })
+
+  useEffect(() => {
+    if (subdomainRedirectUrl != null && window.location.href !== subdomainRedirectUrl) {
+      /**
+       * We're at a domain with ?helia-sw=, we can reload the page so the service worker will
+       * capture the request
+       */
+      window.location.replace(subdomainRedirectUrl)
+    }
+  }, [subdomainRedirectUrl])
+
+  if (!isSubdomainCheckDone) {
+    return (<>First-hit on IPFS hosted service-worker-gateway. Determining state...</>)
   }
 
-  return (<>First-hit on IPFS hosted service-worker-gateway. Reloading</>)
-}
-
-/**
- * If you host helia-service-worker-gateway on an IPFS domain, the redirects file will route some requests from
- * `<domain>/<wildcard-splat>` to `https://<domain>/?helia-sw=<wildcard-splat>`.
- *
- * This function will check for "?helia-sw=" in the URL and modify the URL so that it works with the rest of our logic
- */
-function translateIpfsRedirectUrl (urlString: string): URL {
-  const url = new URL(urlString)
-  const heliaSw = url.searchParams.get('helia-sw')
-  if (heliaSw != null) {
-    url.searchParams.delete('helia-sw')
-    url.pathname = heliaSw
+  if (subdomainRedirectUrl == null) {
+    return <RedirectPage />
   }
-  return url
+
+  return <>Waiting for redirect to subdomain...</>
 }

--- a/src/pages/redirects-interstitial.tsx
+++ b/src/pages/redirects-interstitial.tsx
@@ -30,12 +30,34 @@ export default function RedirectsInterstitial (): React.JSX.Element {
   }, [subdomainRedirectUrl])
 
   if (!isSubdomainCheckDone) {
+    /**
+     * We're waiting for the subdomain check to complete.. this will look like a FOUC (Flash Of Unstyled Content) when
+     * the assets are quickly loaded, but are informative to users when loading of assets is slow.
+     *
+     * TODO: Better styling.
+     */
     return (<>First-hit on IPFS hosted service-worker-gateway. Determining state...</>)
   }
 
   if (subdomainRedirectUrl == null) {
+    /**
+     * We now render the redirect page if ?helia-sw is observed and subdomain redirect is not required., but not by
+     * conflating logic into the actual RedirectPage component.
+     *
+     * However, the url in the browser for this scenario will be "<domain>/?helia-sw=/ipfs/blah", and the RedirectPage
+     * will update that URL when the user clicks "load Content" to "<domain>/ipfs/blah".
+     */
     return <RedirectPage />
   }
 
+  /**
+   * If we redirect to a subdomain, this page will not be rendered again for the requested URL. The `RedirectPage`
+   * component will render directly.
+   *
+   * This page should also not render again for any subsequent unique urls because the SW is registered and would
+   * trigger the redirect logic, which would then load RedirectPage if a "first-hit" for that subdomain.
+   *
+   * TODO: Better styling.
+   */
   return <>Waiting for redirect to subdomain...</>
 }

--- a/test-e2e/first-hit.test.ts
+++ b/test-e2e/first-hit.test.ts
@@ -12,7 +12,8 @@ test.describe('first-hit ipfs-hosted', () => {
       }
     })
     test('redirects to ?helia-sw=<path> are handled', async ({ page }) => {
-      const response = await page.goto('http://127.0.0.1:3333/?helia-sw=/ipfs/bafkqablimvwgy3y', { waitUntil: 'commit' })
+      // const response = await page.goto('http://127.0.0.1:3333/?helia-sw=/ipfs/bafkqablimvwgy3y', { waitUntil: 'commit' })
+      const response = await page.goto('http://127.0.0.1:3334/ipfs/bafkqablimvwgy3y', { waitUntil: 'commit' })
 
       // first loads the root page
       expect(response?.status()).toBe(200)
@@ -21,7 +22,8 @@ test.describe('first-hit ipfs-hosted', () => {
       expect(headers?.['content-type']).toContain('text/html')
 
       // then we should be redirected to the IPFS path
-      await page.waitForURL('http://127.0.0.1:3333/ipfs/bafkqablimvwgy3y')
+      // await page.waitForURL('http://127.0.0.1:3333/ipfs/bafkqablimvwgy3y')
+      await page.waitForURL('http://127.0.0.1:3334/ipfs/bafkqablimvwgy3y')
 
       // and then the normal redirectPage logic:
       await waitForServiceWorker(page)

--- a/test-e2e/first-hit.test.ts
+++ b/test-e2e/first-hit.test.ts
@@ -12,8 +12,9 @@ test.describe('first-hit ipfs-hosted', () => {
       }
     })
     test('redirects to ?helia-sw=<path> are handled', async ({ page }) => {
-      // const response = await page.goto('http://127.0.0.1:3333/?helia-sw=/ipfs/bafkqablimvwgy3y', { waitUntil: 'commit' })
-      const response = await page.goto('http://127.0.0.1:3334/ipfs/bafkqablimvwgy3y', { waitUntil: 'commit' })
+      const response = await page.goto('http://127.0.0.1:3334/ipfs/bafkqablimvwgy3y')
+
+      expect(response?.url()).toBe('http://127.0.0.1:3334/?helia-sw=/ipfs/bafkqablimvwgy3y')
 
       // first loads the root page
       expect(response?.status()).toBe(200)
@@ -22,13 +23,10 @@ test.describe('first-hit ipfs-hosted', () => {
       expect(headers?.['content-type']).toContain('text/html')
 
       // then we should be redirected to the IPFS path
-      // await page.waitForURL('http://127.0.0.1:3333/ipfs/bafkqablimvwgy3y')
-      await page.waitForURL('http://127.0.0.1:3334/ipfs/bafkqablimvwgy3y')
-
-      // and then the normal redirectPage logic:
-      await waitForServiceWorker(page)
       const bodyTextLocator = page.locator('body')
       await expect(bodyTextLocator).toContainText('Please save your changes to the config to apply them')
+      // and then the normal redirectPage logic:
+      await waitForServiceWorker(page)
 
       // it should render the config iframe
       await expect(page.locator('#redirect-config-iframe')).toBeAttached({ timeout: 1 })
@@ -45,7 +43,9 @@ test.describe('first-hit ipfs-hosted', () => {
 
   test.describe('subdomain-routing', () => {
     test('redirects to ?helia-sw=<path> are handled', async ({ page, rootDomain, protocol }) => {
-      const response = await page.goto(`${protocol}//${rootDomain}/?helia-sw=/ipfs/bafkqablimvwgy3y`, { waitUntil: 'commit' })
+      const response = await page.goto('http://localhost:3334/ipfs/bafkqablimvwgy3y')
+
+      expect(response?.url()).toBe('http://localhost:3334/?helia-sw=/ipfs/bafkqablimvwgy3y')
 
       // first loads the root page
       expect(response?.status()).toBe(200)
@@ -55,7 +55,7 @@ test.describe('first-hit ipfs-hosted', () => {
 
       // then we should be redirected to the IPFS path
       const bodyTextLocator = page.locator('body')
-      await page.waitForURL(`${protocol}//bafkqablimvwgy3y.ipfs.${rootDomain}`)
+      await page.waitForURL('http://bafkqablimvwgy3y.ipfs.localhost:3334')
       await expect(bodyTextLocator).toContainText('Registering Helia service worker')
 
       await waitForServiceWorker(page)

--- a/test-e2e/ipfs-gateway.js
+++ b/test-e2e/ipfs-gateway.js
@@ -2,7 +2,7 @@
 /**
  * This file is used to simulate hosting the dist folder on an ipfs gateway, so we can handle _redirects
  */
-import { writeFile } from 'node:fs/promises'
+import { mkdir, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join, relative } from 'node:path'
 import { cwd } from 'node:process'
@@ -13,7 +13,7 @@ import { path } from 'kubo'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const tempDir = tmpdir()
-const IPFS_PATH = `${tempDir}/.ipfs`
+const IPFS_PATH = `${tempDir}/.ipfs/${Date.now()}`
 const kuboBin = path()
 
 const gatewayPort = Number(process.env.GATEWAY_PORT ?? 8088)
@@ -26,12 +26,14 @@ const execaOptions = {
   // cleanup: true,
   env: {
     IPFS_PATH,
-    GOLOG_LOG_LEVEL: 'debug'
+    GOLOG_LOG_LEVEL: 'debug,*=debug'
   }
 }
 
 try {
-  await $(execaOptions)`${kuboBin} init --profile test`
+  await mkdir(IPFS_PATH, { recursive: true })
+  await $(execaOptions)`${kuboBin} init`
+  console.log('done with init')
 } catch (_) {
   // ignore
 }
@@ -39,26 +41,51 @@ console.log('using IPFS_PATH: ', IPFS_PATH)
 const { stdout: cid } = await $(execaOptions)`${kuboBin} add -r -Q ${relative(cwd(), '../dist')} --cid-version 1`
 
 console.log('sw-gateway dist CID: ', cid.trim())
+const { stdout: pinStdout } = await $(execaOptions)`${kuboBin} pin add -r /ipfs/${cid.trim()}`
+console.log('pinStdout: ', pinStdout)
+
+const IPFS_NS_MAP = [['ipfs-host.local', `/ipfs/${cid.trim()}`]].map(([host, path]) => `${host}:${path}`).join(',')
+
+// @ts-expect-error - it's defined.
+execaOptions.env.IPFS_NS_MAP = IPFS_NS_MAP
 
 // write dist cid to file
 // await writeFile(join(__dirname, 'dist.cid'), cid.trim())
 
 await $(execaOptions)`${kuboBin} config Addresses.Gateway /ip4/127.0.0.1/tcp/${gatewayPort}`
 await $(execaOptions)`${kuboBin} config Addresses.API /ip4/127.0.0.1/tcp/0`
-// await $(execaOptions)`${kuboBin} config --json Bootstrap ${JSON.stringify([])}`
-// await $(execaOptions)`${kuboBin} config --json Swarm.DisableNatPortMap true`
-// await $(execaOptions)`${kuboBin} config --json Discovery.MDNS.Enabled false`
-// await $(execaOptions)`${kuboBin} config --json Gateway.NoFetch true`
-// await $(execaOptions)`${kuboBin} config --json Gateway.DeserializedResponses true`
-// await $(execaOptions)`${kuboBin} config --json Gateway.ExposeRoutingAPI false`
+await $(execaOptions)`${kuboBin} config --json Bootstrap ${JSON.stringify([])}`
+await $(execaOptions)`${kuboBin} config --json Swarm.DisableNatPortMap true`
+await $(execaOptions)`${kuboBin} config --json Discovery.MDNS.Enabled false`
+await $(execaOptions)`${kuboBin} config --json Gateway.NoFetch true`
+await $(execaOptions)`${kuboBin} config --json Gateway.DeserializedResponses true`
+await $(execaOptions)`${kuboBin} config --json Gateway.ExposeRoutingAPI false`
 await $(execaOptions)`${kuboBin} config --json Gateway.HTTPHeaders.Access-Control-Allow-Origin ${JSON.stringify(['*'])}`
 await $(execaOptions)`${kuboBin} config --json Gateway.HTTPHeaders.Access-Control-Allow-Methods  ${JSON.stringify(['GET', 'POST', 'PUT', 'OPTIONS'])}`
 await $(execaOptions)`${kuboBin} config --json Gateway.PublicGateways ${JSON.stringify({
+  localhost: {
+    // RootRedirect: 'index.html',
+    // NoDNSLink: true,
+    UseSubdomains: true,
+    Paths: ['/ipfs', '/ipns']
+  },
   'localhost:3334': {
-    RootRedirect: 'index.html',
+    // RootRedirect: 'index.html',
     NoDNSLink: true,
-    Paths: []
+    Paths: ['/ipfs', '/ipns']
+  },
+  'localhost:8088': {
+    // RootRedirect: 'index.html',
+    // NoDNSLink: true,
+    Paths: ['/ipfs', '/ipns']
   }
+  // [`${cid.trim()}.ipfs.localhost:8080`]: {
+  //   // RootRedirect: 'index.html',
+  //   NoDNSLink: true,
+  //   Paths: ['/ipfs', '/ipns'],
+  //   UseSubdomains: true,
+  //   DeserializedResponses: true
+  // }
 })}`
 console.log('starting kubo')
 // need to stand up kubo daemon to serve the dist folder
@@ -93,8 +120,8 @@ process.env.BACKEND_PORT = gatewayPort.toString()
 process.env.PROXY_PORT = '3334'
 // process.env.PREFIX_PATH = `/ipfs/${cid.trim()}`
 process.env.SUBDOMAIN = `${cid.trim()}.ipfs`
-process.env.DISABLE_TRY_FILES = 'true'
-process.env.X_FORWARDED_HOST = 'localhost:3334'
+// process.env.DISABLE_TRY_FILES = 'true'
+process.env.X_FORWARDED_HOST = 'ipfs-host.local'
 const reverseProxy = execa('node', [`${join(__dirname, 'reverse-proxy.js')}`], execaOptions)
 reverseProxy.stdout?.pipe(process.stdout)
 // start reverse-proxy.js to forward requests to kubo

--- a/test-e2e/ipfs-gateway.js
+++ b/test-e2e/ipfs-gateway.js
@@ -1,0 +1,103 @@
+/* eslint-disable no-console */
+/**
+ * This file is used to simulate hosting the dist folder on an ipfs gateway, so we can handle _redirects
+ */
+import { writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join, relative } from 'node:path'
+import { cwd } from 'node:process'
+import { fileURLToPath } from 'node:url'
+// import { execa, $ } from 'execa'
+import { $, execa } from 'execa'
+import { path } from 'kubo'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const tempDir = tmpdir()
+const IPFS_PATH = `${tempDir}/.ipfs`
+const kuboBin = path()
+
+const gatewayPort = Number(process.env.GATEWAY_PORT ?? 8088)
+
+/**
+ * @type {import('execa').Options}
+ */
+const execaOptions = {
+  cwd: __dirname,
+  // cleanup: true,
+  env: {
+    IPFS_PATH,
+    GOLOG_LOG_LEVEL: 'debug'
+  }
+}
+
+try {
+  await $(execaOptions)`${kuboBin} init --profile test`
+} catch (_) {
+  // ignore
+}
+console.log('using IPFS_PATH: ', IPFS_PATH)
+const { stdout: cid } = await $(execaOptions)`${kuboBin} add -r -Q ${relative(cwd(), '../dist')} --cid-version 1`
+
+console.log('sw-gateway dist CID: ', cid.trim())
+
+// write dist cid to file
+// await writeFile(join(__dirname, 'dist.cid'), cid.trim())
+
+await $(execaOptions)`${kuboBin} config Addresses.Gateway /ip4/127.0.0.1/tcp/${gatewayPort}`
+await $(execaOptions)`${kuboBin} config Addresses.API /ip4/127.0.0.1/tcp/0`
+// await $(execaOptions)`${kuboBin} config --json Bootstrap ${JSON.stringify([])}`
+// await $(execaOptions)`${kuboBin} config --json Swarm.DisableNatPortMap true`
+// await $(execaOptions)`${kuboBin} config --json Discovery.MDNS.Enabled false`
+// await $(execaOptions)`${kuboBin} config --json Gateway.NoFetch true`
+// await $(execaOptions)`${kuboBin} config --json Gateway.DeserializedResponses true`
+// await $(execaOptions)`${kuboBin} config --json Gateway.ExposeRoutingAPI false`
+await $(execaOptions)`${kuboBin} config --json Gateway.HTTPHeaders.Access-Control-Allow-Origin ${JSON.stringify(['*'])}`
+await $(execaOptions)`${kuboBin} config --json Gateway.HTTPHeaders.Access-Control-Allow-Methods  ${JSON.stringify(['GET', 'POST', 'PUT', 'OPTIONS'])}`
+await $(execaOptions)`${kuboBin} config --json Gateway.PublicGateways ${JSON.stringify({
+  'localhost:3334': {
+    RootRedirect: 'index.html',
+    NoDNSLink: true,
+    Paths: []
+  }
+})}`
+console.log('starting kubo')
+// need to stand up kubo daemon to serve the dist folder
+// const { stdout: daemonStartupStdin, stderr: daemonStartupStderr } = await $(execaOptions)`${kuboBin} daemon`
+const daemon = execa(kuboBin, ['daemon', '--offline'], execaOptions)
+
+if (daemon == null || (daemon.stdout == null || daemon.stderr == null)) {
+  throw new Error('failed to start kubo daemon')
+}
+daemon.stdout.pipe(process.stdout)
+daemon.stderr.pipe(process.stderr)
+
+// check for "daemon is ready" message
+await new Promise((resolve, reject) => {
+  daemon.stdout?.on('data', (data) => {
+    if (data.includes('Daemon is ready')) {
+      // @ts-expect-error - nothing needed here.
+      resolve()
+      console.log('Kubo daemon is ready')
+    }
+  })
+  const timeout = setTimeout(() => {
+    reject(new Error('kubo daemon failed to start'))
+    clearTimeout(timeout)
+  }, 5000)
+})
+
+// process.env.TARGET_HOST = `${cid.trim()}.ipfs.localhost:${gatewayPort}`
+// process.env.TARGET_HOST = '127.0.0.1'
+process.env.TARGET_HOST = 'localhost'
+process.env.BACKEND_PORT = gatewayPort.toString()
+process.env.PROXY_PORT = '3334'
+// process.env.PREFIX_PATH = `/ipfs/${cid.trim()}`
+process.env.SUBDOMAIN = `${cid.trim()}.ipfs`
+process.env.DISABLE_TRY_FILES = 'true'
+process.env.X_FORWARDED_HOST = 'localhost:3334'
+const reverseProxy = execa('node', [`${join(__dirname, 'reverse-proxy.js')}`], execaOptions)
+reverseProxy.stdout?.pipe(process.stdout)
+// start reverse-proxy.js to forward requests to kubo
+// const { stdout: proxyStdout, stderr: proxyStderr } = await $(execaOptions)`node ${join(__dirname, 'reverse-proxy.js')}`
+
+// console.log(proxyStdout, proxyStderr)

--- a/test-e2e/ipfs-gateway.js
+++ b/test-e2e/ipfs-gateway.js
@@ -2,15 +2,17 @@
 /**
  * This file is used to simulate hosting the dist folder on an ipfs gateway, so we can handle _redirects
  */
-import { mkdir, writeFile } from 'node:fs/promises'
+import { mkdir } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join, relative } from 'node:path'
 import { cwd } from 'node:process'
 import { fileURLToPath } from 'node:url'
-// import { execa, $ } from 'execa'
+import { logger } from '@libp2p/logger'
 import { $, execa } from 'execa'
 import { path } from 'kubo'
 
+const log = logger('ipfs-host.local')
+const daemonLog = logger('ipfs-host.local:kubo')
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const tempDir = tmpdir()
 const IPFS_PATH = `${tempDir}/.ipfs/${Date.now()}`
@@ -23,34 +25,32 @@ const gatewayPort = Number(process.env.GATEWAY_PORT ?? 8088)
  */
 const execaOptions = {
   cwd: __dirname,
-  // cleanup: true,
+  cleanup: true,
   env: {
     IPFS_PATH,
-    GOLOG_LOG_LEVEL: 'debug,*=debug'
+    GOLOG_LOG_LEVEL: 'debug,*=debug',
+    DEBUG: 'reverse-proxy,reverse-proxy:*'
   }
 }
 
 try {
   await mkdir(IPFS_PATH, { recursive: true })
   await $(execaOptions)`${kuboBin} init`
-  console.log('done with init')
+  log('done with init')
 } catch (_) {
   // ignore
 }
-console.log('using IPFS_PATH: ', IPFS_PATH)
+log('using IPFS_PATH: ', IPFS_PATH)
 const { stdout: cid } = await $(execaOptions)`${kuboBin} add -r -Q ${relative(cwd(), '../dist')} --cid-version 1`
 
-console.log('sw-gateway dist CID: ', cid.trim())
+log('sw-gateway dist CID: ', cid.trim())
 const { stdout: pinStdout } = await $(execaOptions)`${kuboBin} pin add -r /ipfs/${cid.trim()}`
-console.log('pinStdout: ', pinStdout)
+log('pinStdout: ', pinStdout)
 
 const IPFS_NS_MAP = [['ipfs-host.local', `/ipfs/${cid.trim()}`]].map(([host, path]) => `${host}:${path}`).join(',')
 
 // @ts-expect-error - it's defined.
 execaOptions.env.IPFS_NS_MAP = IPFS_NS_MAP
-
-// write dist cid to file
-// await writeFile(join(__dirname, 'dist.cid'), cid.trim())
 
 await $(execaOptions)`${kuboBin} config Addresses.Gateway /ip4/127.0.0.1/tcp/${gatewayPort}`
 await $(execaOptions)`${kuboBin} config Addresses.API /ip4/127.0.0.1/tcp/0`
@@ -62,41 +62,20 @@ await $(execaOptions)`${kuboBin} config --json Gateway.DeserializedResponses tru
 await $(execaOptions)`${kuboBin} config --json Gateway.ExposeRoutingAPI false`
 await $(execaOptions)`${kuboBin} config --json Gateway.HTTPHeaders.Access-Control-Allow-Origin ${JSON.stringify(['*'])}`
 await $(execaOptions)`${kuboBin} config --json Gateway.HTTPHeaders.Access-Control-Allow-Methods  ${JSON.stringify(['GET', 'POST', 'PUT', 'OPTIONS'])}`
-await $(execaOptions)`${kuboBin} config --json Gateway.PublicGateways ${JSON.stringify({
-  localhost: {
-    // RootRedirect: 'index.html',
-    // NoDNSLink: true,
-    UseSubdomains: true,
-    Paths: ['/ipfs', '/ipns']
-  },
-  'localhost:3334': {
-    // RootRedirect: 'index.html',
-    NoDNSLink: true,
-    Paths: ['/ipfs', '/ipns']
-  },
-  'localhost:8088': {
-    // RootRedirect: 'index.html',
-    // NoDNSLink: true,
-    Paths: ['/ipfs', '/ipns']
-  }
-  // [`${cid.trim()}.ipfs.localhost:8080`]: {
-  //   // RootRedirect: 'index.html',
-  //   NoDNSLink: true,
-  //   Paths: ['/ipfs', '/ipns'],
-  //   UseSubdomains: true,
-  //   DeserializedResponses: true
-  // }
-})}`
-console.log('starting kubo')
+
+log('starting kubo')
 // need to stand up kubo daemon to serve the dist folder
-// const { stdout: daemonStartupStdin, stderr: daemonStartupStderr } = await $(execaOptions)`${kuboBin} daemon`
 const daemon = execa(kuboBin, ['daemon', '--offline'], execaOptions)
 
 if (daemon == null || (daemon.stdout == null || daemon.stderr == null)) {
   throw new Error('failed to start kubo daemon')
 }
-daemon.stdout.pipe(process.stdout)
-daemon.stderr.pipe(process.stderr)
+daemon.stdout.on('data', (data) => {
+  daemonLog.trace(data.toString())
+})
+daemon.stderr.on('data', (data) => {
+  daemonLog.error(data.toString())
+})
 
 // check for "daemon is ready" message
 await new Promise((resolve, reject) => {
@@ -104,7 +83,7 @@ await new Promise((resolve, reject) => {
     if (data.includes('Daemon is ready')) {
       // @ts-expect-error - nothing needed here.
       resolve()
-      console.log('Kubo daemon is ready')
+      log('Kubo daemon is ready')
     }
   })
   const timeout = setTimeout(() => {
@@ -113,18 +92,16 @@ await new Promise((resolve, reject) => {
   }, 5000)
 })
 
-// process.env.TARGET_HOST = `${cid.trim()}.ipfs.localhost:${gatewayPort}`
-// process.env.TARGET_HOST = '127.0.0.1'
-process.env.TARGET_HOST = 'localhost'
-process.env.BACKEND_PORT = gatewayPort.toString()
-process.env.PROXY_PORT = '3334'
-// process.env.PREFIX_PATH = `/ipfs/${cid.trim()}`
-process.env.SUBDOMAIN = `${cid.trim()}.ipfs`
-// process.env.DISABLE_TRY_FILES = 'true'
-process.env.X_FORWARDED_HOST = 'ipfs-host.local'
+// @ts-expect-error - overwriting type of NodeJS.ProcessEnv
+execaOptions.env = {
+  ...execaOptions.env,
+  TARGET_HOST: 'localhost',
+  BACKEND_PORT: gatewayPort.toString(),
+  PROXY_PORT: process.env.PROXY_PORT ?? '3334',
+  SUBDOMAIN: `${cid.trim()}.ipfs`,
+  DISABLE_TRY_FILES: 'true',
+  X_FORWARDED_HOST: 'ipfs-host.local',
+  DEBUG: process.env.DEBUG ?? 'reverse-proxy*,reverse-proxy*:trace'
+}
 const reverseProxy = execa('node', [`${join(__dirname, 'reverse-proxy.js')}`], execaOptions)
 reverseProxy.stdout?.pipe(process.stdout)
-// start reverse-proxy.js to forward requests to kubo
-// const { stdout: proxyStdout, stderr: proxyStderr } = await $(execaOptions)`node ${join(__dirname, 'reverse-proxy.js')}`
-
-// console.log(proxyStdout, proxyStderr)

--- a/test-e2e/reverse-proxy.js
+++ b/test-e2e/reverse-proxy.js
@@ -64,7 +64,7 @@ const makeRequest = (options, req, res, attemptRootFallback = false) => {
   req.pipe(proxyReq, { end: true })
 
   proxyReq.on('error', (e) => {
-    console.error(`Problem with request: ${e.message}`)
+    log.error(`Problem with request: ${e.message}`)
     setCommonHeaders(res)
     res.writeHead(500)
     res.end(`Internal Server Error: ${e.message}`)

--- a/test-e2e/reverse-proxy.js
+++ b/test-e2e/reverse-proxy.js
@@ -1,5 +1,12 @@
 /* eslint-disable no-console */
 import { request, createServer } from 'node:http'
+import { logger } from '@libp2p/logger'
+import debug from 'debug'
+
+// TODO: debug logging is not showing up from this file for some reason.
+debug.enable(process.env.DEBUG ?? '')
+
+const log = logger('reverse-proxy')
 
 const TARGET_HOST = process.env.TARGET_HOST ?? 'localhost'
 const backendPort = Number(process.env.BACKEND_PORT ?? 3000)
@@ -32,7 +39,7 @@ const makeRequest = (options, req, res, attemptRootFallback = false) => {
   }
 
   // log where we're making the request to
-  console.log(`Proxying request to ${options.headers.Host}:${options.port}${options.path}`)
+  log('Proxying request to %s:%s%s', options.headers.Host, options.port, options.path)
 
   const proxyReq = request(options, proxyRes => {
     if (!disableTryFiles && proxyRes.statusCode === 404) { // poor mans attempt to implement nginx style try_files
@@ -84,5 +91,5 @@ const proxyServer = createServer((req, res) => {
 })
 
 proxyServer.listen(proxyPort, () => {
-  console.log(`Proxy server listening on port ${proxyPort}`)
+  log(`Proxy server listening on port ${proxyPort}`)
 })

--- a/test-e2e/reverse-proxy.js
+++ b/test-e2e/reverse-proxy.js
@@ -1,10 +1,6 @@
 /* eslint-disable no-console */
 import { request, createServer } from 'node:http'
 import { logger } from '@libp2p/logger'
-import debug from 'debug'
-
-// TODO: debug logging is not showing up from this file for some reason.
-debug.enable(process.env.DEBUG ?? '')
 
 const log = logger('reverse-proxy')
 


### PR DESCRIPTION
## Title

<!---
The title of the PR will be the commit message of the merge commit, so please make sure it is descriptive enough.
We utilize the Conventional Commits specification for our commit messages. See <https://www.conventionalcommits.org/en/v1.0.0/#specification> for more information.
The commit tag types can be of one of the following: feat, fix, deps, refactor, chore, docs. See <https://github.com/ipfs/helia/blob/main/.github/workflows/main.yml#L184-L192>
The title must also be fewer than 72 characters long or it will fail the Semantic PR check. See <https://github.com/ipfs/helia/blob/main/.github/workflows/semantic-pull-request.yml>
--->
fix: ipfs-hosted redirects are not infinite

## Description

<!--
Please write a summary of your changes and why you made them.
Please include any relevant issues in here, for example:
Related https://github.com/ipfs/helia/issues/ABCD.
Fixes https://github.com/ipfs/helia/issues/XYZ.
-->

Fixes https://github.com/ipfs-shipyard/service-worker-gateway/issues/211

### Summary of changes

1. Adds ipfs-gateway.js script that uses existing reverse-proxy (some updates were needed) to host static site via local kubo
1. Updates `ipfs-hosted` tests in first-hit.test.ts to use the above test server, so we are no longer only getting a ?helia-sw request. This should get us 99% closer to actual functionality when hosted in environments like inbrowser.tld
1. Resolves issues with infinite redirects by updating `src/pages/redirects-interstitial.tsx` and `src/pages/redirect-page.tsx`
1. Moves out service worker & config provider from the initial landing page into each sub-page, which reduces the total assets sent on first-hit for each scenario.
1. updates reverse-proxy logging to use @libp2p/logger, ~~but it's not actually working for some reason~~

## Notes & open questions



<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

1. ~~I could use an extra set of eyes on the updated use of @libp2p/logger in reverse-proxy.js~~ proxy-server logging fixed with [`688594e` (#215)](https://github.com/ipfs-shipyard/service-worker-gateway/pull/215/commits/688594e4824a91fdf206cc7c8d36494254aa5835)
2. Callout that maybe we don't want to display in `RedirectsInterstitial` because it's just going to be quick Flashes that aren't really visible, but on gateways where providing the assets are slow, it will be informative.
3. If you set the playback speed to very slow on the demo video you can see the redirect cycle pretty clearly

### Demo showing fix:

https://github.com/ipfs-shipyard/service-worker-gateway/assets/1173416/d06ebbd5-1270-4a21-9e5f-ba6a8f870791


## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
