### PR TITLE
fix: use separate logger for ui/sw

### DIFF
--- a/src/context/service-worker-context.tsx
+++ b/src/context/service-worker-context.tsx
@@ -13,9 +13,11 @@
  */
 import React, { createContext, useEffect, useState } from 'preact/compat'
 import { getRedirectUrl, isDeregisterRequest } from '../lib/deregister-request.js'
-import { error, trace } from '../lib/logger.js'
+import { uiLogger } from '../lib/logger.js'
 import { findOriginIsolationRedirect } from '../lib/path-or-subdomain.js'
 import { registerServiceWorker } from '../service-worker-utils.js'
+
+const log = uiLogger.forComponent('service-worker-context')
 
 export const ServiceWorkerContext = createContext({
   isServiceWorkerRegistered: false
@@ -39,13 +41,13 @@ export const ServiceWorkerProvider = ({ children }): React.JSX.Element => {
     }
     async function doWork (): Promise<void> {
       if (isDeregisterRequest(window.location.href)) {
-        trace('UI: deregistering service worker')
+        log.trace('deregistering service worker')
         const registration = await navigator.serviceWorker.getRegistration()
         if (registration != null) {
           await registration.unregister()
           window.location.replace(getRedirectUrl(window.location.href).href)
         } else {
-          error('UI: service worker not registered, cannot deregister')
+          log.error('service worker not registered, cannot deregister')
         }
       }
       const registration = await navigator.serviceWorker.getRegistration()
@@ -57,7 +59,7 @@ export const ServiceWorkerProvider = ({ children }): React.JSX.Element => {
           await registerServiceWorker()
           setIsServiceWorkerRegistered(true)
         } catch (err) {
-          error('error registering service worker', err)
+          log.error('error registering service worker', err)
         }
       }
     }

--- a/src/lib/channel.ts
+++ b/src/lib/channel.ts
@@ -1,5 +1,5 @@
-import { error } from './logger.js'
 import type { ChannelActions } from './common.js'
+import type { ComponentLogger, Logger } from '@libp2p/logger'
 
 export enum ChannelUsers {
   SW = 'SW',
@@ -34,11 +34,14 @@ export interface ChannelMessage<Source extends ChannelUserValues, Data = Record<
 export class HeliaServiceWorkerCommsChannel<S extends ChannelUserValues = 'EMITTER_ONLY'> {
   channel: BroadcastChannel
   debug = false
-  constructor (public source: S, private readonly channelName = 'helia:sw') {
+  log: Logger
+  channelName = 'helia:sw'
+  constructor (public source: S, logger: ComponentLogger) {
+    this.log = logger.forComponent('comms-channel')
     // NOTE: We're supposed to close the channel when we're done with it, but we're not doing that anywhere yet.
     this.channel = new BroadcastChannel(this.channelName)
     this.channel.onmessageerror = (e) => {
-      error('onmessageerror', e)
+      this.log.error('onmessageerror', e)
     }
   }
 

--- a/src/lib/config-db.ts
+++ b/src/lib/config-db.ts
@@ -1,7 +1,7 @@
 import debugLib from 'debug'
 import { GenericIDB, type BaseDbConfig } from './generic-db.js'
 import { LOCAL_STORAGE_KEYS } from './local-storage.js'
-import { log } from './logger.js'
+import type { ComponentLogger } from '@libp2p/logger'
 
 export interface ConfigDb extends BaseDbConfig {
   gateways: string[]
@@ -32,7 +32,8 @@ export async function loadConfigFromLocalStorage (): Promise<void> {
   }
 }
 
-export async function setConfig (config: ConfigDb): Promise<void> {
+export async function setConfig (config: ConfigDb, logger: ComponentLogger): Promise<void> {
+  const log = logger.forComponent('set-config')
   debugLib.enable(config.debug ?? '') // set debug level first.
   log('config-debug: setting config %O for domain %s', config, window.location.origin)
 

--- a/src/lib/deregister-request.ts
+++ b/src/lib/deregister-request.ts
@@ -1,10 +1,8 @@
-import { trace } from './logger.js'
-
 // things are wonky with hash routes for deregistering.
 export function isDeregisterRequest (url: string): boolean {
   const urlObj = new URL(url)
   const result = urlObj.search.includes('ipfs-sw-deregister')
-  trace('isDeregisterRequest: ', url, result)
+
   return result
 }
 

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,7 +1,3 @@
-import { logger } from '@libp2p/logger'
+import { prefixLogger } from '@libp2p/logger'
 
-const logObj = logger('helia:service-worker-gateway')
-
-export const log = logObj
-export const error = logObj.error
-export const trace = logObj.trace
+export const logger = prefixLogger('helia:service-worker-gateway')

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,6 +1,13 @@
-import { prefixLogger } from '@libp2p/logger'
+import { prefixLogger, type ComponentLogger } from '@libp2p/logger'
 
 const host = globalThis.location.host.replace(':', '_')
-export const swLogger = prefixLogger(`helia:service-worker-gateway:sw:${host}`)
 
-export const uiLogger = prefixLogger(`helia:service-worker-gateway:ui:${host}`)
+const swLogPrefix = `helia:service-worker-gateway:sw:${host}`
+const uiLogPrefix = `helia:service-worker-gateway:ui:${host}`
+
+export const swLogger = prefixLogger(swLogPrefix)
+export const uiLogger = prefixLogger(uiLogPrefix)
+
+export const getUiComponentLogger = (component: string): ComponentLogger => {
+  return prefixLogger(`${uiLogPrefix}:${component}`)
+}

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,3 +1,6 @@
 import { prefixLogger } from '@libp2p/logger'
 
-export const logger = prefixLogger('helia:service-worker-gateway')
+const host = globalThis.location.host.replace(':', '_')
+export const swLogger = prefixLogger(`helia:service-worker-gateway:sw:${host}`)
+
+export const uiLogger = prefixLogger(`helia:service-worker-gateway:ui:${host}`)

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -2,8 +2,8 @@ import { prefixLogger, type ComponentLogger } from '@libp2p/logger'
 
 const host = globalThis.location.host.replace(':', '_')
 
-const swLogPrefix = `helia:service-worker-gateway:sw:${host}`
-const uiLogPrefix = `helia:service-worker-gateway:ui:${host}`
+const swLogPrefix = `helia:sw-gateway:sw:${host}`
+const uiLogPrefix = `helia:sw-gateway:ui:${host}`
 
 export const swLogger = prefixLogger(swLogPrefix)
 export const uiLogger = prefixLogger(uiLogPrefix)

--- a/src/pages/config.tsx
+++ b/src/pages/config.tsx
@@ -9,10 +9,11 @@ import { ServiceWorkerProvider } from '../context/service-worker-context.jsx'
 import { HeliaServiceWorkerCommsChannel } from '../lib/channel.js'
 import { getConfig, loadConfigFromLocalStorage } from '../lib/config-db.js'
 import { LOCAL_STORAGE_KEYS } from '../lib/local-storage.js'
-import { uiLogger } from '../lib/logger.js'
+import { getUiComponentLogger, uiLogger } from '../lib/logger.js'
 
+const uiComponentLogger = getUiComponentLogger('config-page')
 const log = uiLogger.forComponent('config-page')
-const channel = new HeliaServiceWorkerCommsChannel('WINDOW', uiLogger)
+const channel = new HeliaServiceWorkerCommsChannel('WINDOW', uiComponentLogger)
 
 const urlValidationFn = (value: string): Error | null => {
   try {

--- a/src/pages/redirect-page.tsx
+++ b/src/pages/redirect-page.tsx
@@ -6,9 +6,10 @@ import { HeliaServiceWorkerCommsChannel } from '../lib/channel.js'
 import { setConfig, type ConfigDb } from '../lib/config-db.js'
 import { getSubdomainParts } from '../lib/get-subdomain-parts.js'
 import { isConfigPage } from '../lib/is-config-page.js'
-import { uiLogger } from '../lib/logger.js'
+import { getUiComponentLogger, uiLogger } from '../lib/logger.js'
 import { translateIpfsRedirectUrl } from '../lib/translate-ipfs-redirect-url.js'
 
+const uiComponentLogger = getUiComponentLogger('redirect-page')
 const log = uiLogger.forComponent('redirect-page')
 
 const ConfigIframe = (): React.JSX.Element => {
@@ -29,7 +30,7 @@ const ConfigIframe = (): React.JSX.Element => {
   )
 }
 
-const channel = new HeliaServiceWorkerCommsChannel('WINDOW', uiLogger)
+const channel = new HeliaServiceWorkerCommsChannel('WINDOW', uiComponentLogger)
 
 function RedirectPage ({ showConfigIframe = true }: { showConfigIframe?: boolean }): React.JSX.Element {
   const [isAutoReloadEnabled, setIsAutoReloadEnabled] = useState(false)
@@ -43,7 +44,7 @@ function RedirectPage ({ showConfigIframe = true }: { showConfigIframe?: boolean
 
     async function doWork (config: ConfigDb): Promise<void> {
       try {
-        await setConfig(config, uiLogger)
+        await setConfig(config, uiComponentLogger)
         // TODO: show spinner / disable buttons while waiting for response
         await channel.messageAndWaitForResponse('SW', { target: 'SW', action: 'RELOAD_CONFIG' })
         log.trace('redirect-page: RELOAD_CONFIG_SUCCESS on %s', window.location.origin)

--- a/src/service-worker-utils.ts
+++ b/src/service-worker-utils.ts
@@ -1,6 +1,10 @@
-import { log } from './lib/logger.js'
+import { uiLogger } from './lib/logger.js'
 
+/**
+ * This function is always and only used from the UI
+ */
 export async function registerServiceWorker (): Promise<ServiceWorkerRegistration> {
+  const log = uiLogger.forComponent('register-service-worker')
   const swRegistration = await navigator.serviceWorker.register(new URL(/* webpackChunkName: "sw" */'sw.js', import.meta.url))
   return new Promise((resolve, reject) => {
     swRegistration.addEventListener('updatefound', () => {

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -142,7 +142,7 @@ self.addEventListener('activate', (event) => {
       case 'RELOAD_CONFIG':
         void updateVerifiedFetch().then(async () => {
           channel.postMessage<any>({ action: 'RELOAD_CONFIG_SUCCESS', data: { config: await getConfig() } })
-          log.trace('sw: RELOAD_CONFIG_SUCCESS for %s', self.location.origin)
+          log.trace('RELOAD_CONFIG_SUCCESS for %s', self.location.origin)
         })
         break
       default:
@@ -330,9 +330,9 @@ async function fetchAndUpdateCache (event: FetchEvent, url: URL, cacheKey: strin
 
   try {
     await storeReponseInCache({ response, isMutable: true, cacheKey, event })
-    log.trace('helia-ws: updated cache for %s', cacheKey)
+    log.trace('updated cache for %s', cacheKey)
   } catch (err) {
-    log.error('helia-ws: failed updating response in cache for %s', cacheKey, err)
+    log.error('failed updating response in cache for %s', cacheKey, err)
   }
 
   return response
@@ -349,7 +349,7 @@ async function getResponseFromCacheOrFetch (event: FetchEvent): Promise<Response
   const validCacheHit = cachedResponse != null && !hasExpired(cachedResponse)
 
   if (validCacheHit) {
-    log('helia-ws: cached response HIT for %s (expires: %s) %o', cacheKey, cachedResponse.headers.get('sw-cache-expires'), cachedResponse)
+    log('cached response HIT for %s (expires: %s) %o', cacheKey, cachedResponse.headers.get('sw-cache-expires'), cachedResponse)
 
     if (isMutable) {
       // If the response is mutable, update the cache in the background.
@@ -359,7 +359,7 @@ async function getResponseFromCacheOrFetch (event: FetchEvent): Promise<Response
     return cachedResponse
   }
 
-  log('helia-ws: cached response MISS for %s', cacheKey)
+  log('cached response MISS for %s', cacheKey)
 
   return fetchAndUpdateCache(event, url, cacheKey)
 }
@@ -385,7 +385,7 @@ async function storeReponseInCache ({ response, isMutable, cacheKey, event }: St
   if (!shouldCacheResponse({ event, response })) {
     return
   }
-  log.trace('helia-ws: updating cache for %s in the background', cacheKey)
+  log.trace('updating cache for %s in the background', cacheKey)
 
   const cache = await caches.open(isMutable ? CURRENT_CACHES.mutable : CURRENT_CACHES.immutable)
 
@@ -393,14 +393,14 @@ async function storeReponseInCache ({ response, isMutable, cacheKey, event }: St
   const respToCache = response.clone()
 
   if (isMutable) {
-    log.trace('helia-ws: setting expires header on response key %s before storing in cache', cacheKey)
+    log.trace('setting expires header on response key %s before storing in cache', cacheKey)
     // 👇 Set expires header to an hour from now for mutable (ipns://) resources
     // Note that this technically breaks HTTP semantics, whereby the cache-control max-age takes precendence
     // Setting this header is only used by the service worker using a mechanism similar to stale-while-revalidate
     setExpiresHeader(respToCache, ONE_HOUR_IN_SECONDS)
   }
 
-  log('helia-ws: storing response for key %s in cache', cacheKey)
+  log('storing response for key %s in cache', cacheKey)
   // do not await this.. large responses will delay [TTFB](https://web.dev/articles/ttfb) and [TTI](https://web.dev/articles/tti)
   void cache.put(cacheKey, respToCache)
 }


### PR DESCRIPTION
- chore: use prefixLogger
- chore: use new logger in sw.ts
- fix: use separate logger for ui/sw

## Title

<!---
The title of the PR will be the commit message of the merge commit, so please make sure it is descriptive enough.
We utilize the Conventional Commits specification for our commit messages. See <https://www.conventionalcommits.org/en/v1.0.0/#specification> for more information.
The commit tag types can be of one of the following: feat, fix, deps, refactor, chore, docs. See <https://github.com/ipfs/helia/blob/main/.github/workflows/main.yml#L184-L192>
The title must also be fewer than 72 characters long or it will fail the Semantic PR check. See <https://github.com/ipfs/helia/blob/main/.github/workflows/semantic-pull-request.yml>
--->
fix: use separate logger for ui/sw

## Description

<!--
Please write a summary of your changes and why you made them.
Please include any relevant issues in here, for example:
Related https://github.com/ipfs/helia/issues/ABCD.
Fixes https://github.com/ipfs/helia/issues/XYZ.
-->

Fixes https://github.com/ipfs-shipyard/service-worker-gateway/issues/139

All logs now:

1. include the host.
    - For UI: useful for redirect and config page where things are logged from iframe
    - For SW: useful for debugging different messages from service worker loaded on page in iframe vs main page.
1. have a global prefix: `helia:service-worker-gateway:`
1. have a distinct prefix.
    - For UI: `helia:service-worker-gateway:ui`
    - For SW: `helia:service-worker-gateway:sw`
1. are injected into components that need them

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

### On redirect page

#### filtering console logs by `helia:service-worker-gateway:sw`

<img width="836" alt="image" src="https://github.com/ipfs-shipyard/service-worker-gateway/assets/1173416/f1e8e26b-51aa-4824-bfda-8d35beb42a1c">

#### filtering console logs by `helia:service-worker-gateway:ui`

<img width="847" alt="image" src="https://github.com/ipfs-shipyard/service-worker-gateway/assets/1173416/3a53596b-ed37-44d9-a79d-a9e5c61b3834">


## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
