### PR TITLE
feat: probe and use local gateway if available

### DIFF
--- a/src/lib/local-gateway.ts
+++ b/src/lib/local-gateway.ts
@@ -1,0 +1,32 @@
+import { uiLogger } from './logger'
+
+export const localGwUrl = 'http://127.0.0.1:8080'
+const localGwTestUrl = `${localGwUrl}/ipfs/bafkqablimvwgy3y?format=raw`
+const expectedContentType = 'application/vnd.ipld.raw'
+const expectedResponseBody = 'hello'
+
+const log = uiLogger.forComponent('local-gateway-prober')
+
+export async function hasLocalGateway (): Promise<boolean> {
+  try {
+    log(`probing for local trustless gateway at ${localGwTestUrl}`)
+    const resp = await fetch(localGwTestUrl)
+    if (!resp.ok) {
+      return false
+    }
+    if (resp.headers.get('Content-Type') !== expectedContentType) {
+      return false
+    }
+    const respBody = await resp.text()
+
+    if (respBody === expectedResponseBody) {
+      log(`found local trustless gateway at ${localGwTestUrl}`)
+      return true
+    } else {
+      return false
+    }
+  } catch (e: unknown) {
+    log.error('failed to probe trustless gateway', e)
+    return false
+  }
+}

--- a/src/lib/local-gateway.ts
+++ b/src/lib/local-gateway.ts
@@ -1,4 +1,4 @@
-import { uiLogger } from './logger'
+import { uiLogger } from './logger.js'
 
 export const localGwUrl = 'http://127.0.0.1:8080'
 const localGwTestUrl = `${localGwUrl}/ipfs/bafkqablimvwgy3y?format=raw`

--- a/src/pages/config.tsx
+++ b/src/pages/config.tsx
@@ -141,7 +141,7 @@ function ConfigPage (): React.JSX.Element | null {
   }, [])
 
   return (
-  <main className='e2e-config-page pa4-l bg-snow mw7 center pa4'>
+    <main className='e2e-config-page pa4-l bg-snow mw7 center pa4'>
       <Collapsible collapsedLabel="View config" expandedLabel='Hide config' collapsed={isLoadedInIframe}>
         <LocalStorageInput className="e2e-config-page-input e2e-config-page-input-gateways" localStorageKey={LOCAL_STORAGE_KEYS.config.gateways} label='Gateways' validationFn={urlValidationFn} defaultValue={JSON.stringify(defaultGateways)} resetKey={resetKey} />
         <LocalStorageInput className="e2e-config-page-input e2e-config-page-input-routers" localStorageKey={LOCAL_STORAGE_KEYS.config.routers} label='Routers' validationFn={urlValidationFn} defaultValue={JSON.stringify(defaultRouters)} resetKey={resetKey} />


### PR DESCRIPTION
## Description

This PR checks if there's a local trustless gateway available (from IPFS Desktop or Kubo running on the user's machine) and adds it to the configuration. 

Fixes #299

Adding it to the config on load is convoluted due to the way we persist and pass config from across origins into service workers.

## Notes & open questions

- In all my tests, I haven't been able to get the service worker to actually make requests to the local gateway. I couldn't find any such restriction in the [service worker docs](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API). 

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
