### PR TITLE
fix: remove hashes from build outputs and simplify build

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,8 +24,10 @@
     <meta name="description" content="A static HTML page that initializes an instance of IPFS Service Worker Gateway" />
     <meta name="robots" content="noindex" />
     <link rel="manifest" href="/manifest.json">
+    <link rel="stylesheet" href="ipfs-sw-index.css">
   </head>
   <body>
     <div id="root" class="sans-serif f5"></div>
+    <script type="module" src="ipfs-sw-index.js"></script>
   </body>
 </html>

--- a/src/service-worker-utils.ts
+++ b/src/service-worker-utils.ts
@@ -5,9 +5,7 @@ import { uiLogger } from './lib/logger.js'
  */
 export async function registerServiceWorker (): Promise<ServiceWorkerRegistration> {
   const log = uiLogger.forComponent('register-service-worker')
-  const swRegistration = await navigator.serviceWorker.register(new URL('ipfs-sw-sw.js', import.meta.url), {
-    type: 'module'
-  })
+  const swRegistration = await navigator.serviceWorker.register(new URL('ipfs-sw-sw.js', import.meta.url))
   return new Promise((resolve, reject) => {
     swRegistration.addEventListener('updatefound', () => {
       const newWorker = swRegistration.installing


### PR DESCRIPTION
This PR attempts to simplify the build by removing hashes from filenames of build outputs.

## How important is it to have the hashes in the script outputs? 

Since we have the cache headers set to `Cache-control: public, max-age=0, must-revalidate` set from, we might want to consider removing the additional logic (which seems a bit flaky) for removing the hash for the service worker, and injecting the scripts into the index.html.

However, since we also cache assets in the service worker, this makes things more complicated, because we have no expiry mechanism for sw assets in the service worker.