### PR TITLE
fix: service worker logs are visible again

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -8,9 +8,6 @@ const createlibp2pLogger = (prefix: string): Logger => {
   const mainLogger = debug(prefix)
   return Object.assign(debug(prefix), {
     error: mainLogger.extend('error'),
-    // warn: mainLogger.extend('warn'),
-    // info: mainLogger.extend('info'),
-    // debug: mainLogger.extend('debug'),
     trace: mainLogger.extend('trace')
   })
 }

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,5 +1,26 @@
-import { prefixLogger, type ComponentLogger } from '@libp2p/logger'
+import { type ComponentLogger, type Logger } from '@libp2p/logger'
+import debug from 'debug'
 
+/**
+ * Hack to get around @libp2p/logger not working inside a service worker.
+ */
+const createlibp2pLogger = (prefix: string): Logger => {
+  const mainLogger = debug(prefix)
+  return Object.assign(debug(prefix), {
+    error: mainLogger.extend('error'),
+    // warn: mainLogger.extend('warn'),
+    // info: mainLogger.extend('info'),
+    // debug: mainLogger.extend('debug'),
+    trace: mainLogger.extend('trace')
+  })
+}
+export function prefixLogger (prefix: string): ComponentLogger {
+  return {
+    forComponent (name: string) {
+      return createlibp2pLogger(`${prefix}:${name}`)
+    }
+  }
+}
 const host = globalThis.location.host.replace(':', '_')
 
 const swLogPrefix = `helia:sw-gateway:sw:${host}`


### PR DESCRIPTION
## Title

<!---
The title of the PR will be the commit message of the merge commit, so please make sure it is descriptive enough.
We utilize the Conventional Commits specification for our commit messages. See <https://www.conventionalcommits.org/en/v1.0.0/#specification> for more information.
The commit tag types can be of one of the following: feat, fix, deps, refactor, chore, docs. See <https://github.com/ipfs/helia/blob/main/.github/workflows/main.yml#L184-L192>
The title must also be fewer than 72 characters long or it will fail the Semantic PR check. See <https://github.com/ipfs/helia/blob/main/.github/workflows/semantic-pull-request.yml>
--->
fix: service worker logs are visible again

## Description

<!--
Please write a summary of your changes and why you made them.
Please include any relevant issues in here, for example:
Related https://github.com/ipfs/helia/issues/ABCD.
Fixes https://github.com/ipfs/helia/issues/XYZ.
-->

@libp2p/logger has some issue with rendering inside of a service worker. I forgot about this bug when we switched to @libp2p/logger and now just found it again while looking at https://github.com/ipfs/service-worker-gateway/pull/391

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
