### PR TITLE
feat: re-enable code splitting

### DIFF
--- a/build.js
+++ b/build.js
@@ -108,6 +108,11 @@ const renameSwPlugin = {
       const newPath = 'dist/ipfs-sw-sw.js'
       await fs.promises.rename(oldPath, newPath)
         .then(() => console.log(`Renamed ${oldPath} to ${newPath}`))
+
+      // make sure that oldPath.map exists
+      if (!fs.existsSync(oldPath + '.map')) {
+        return
+      }
       await fs.promises.rename(oldPath + '.map', newPath + '.map')
         .then(() => console.log(`Renamed ${oldPath}.map to ${newPath}.map`))
 
@@ -146,7 +151,7 @@ const baseOptions = {
     '.svg': 'file'
   },
   minify: true,
-  sourcemap: !(process.argv.includes('--serve') || process.argv.includes('--watch')),
+  sourcemap: process.argv.includes('--serve') || process.argv.includes('--watch'),
   metafile: true,
   splitting: true,
   target: ['es2020'],

--- a/src/context/service-worker-context.tsx
+++ b/src/context/service-worker-context.tsx
@@ -50,18 +50,14 @@ export const ServiceWorkerProvider = ({ children }): React.JSX.Element => {
           log.error('service worker not registered, cannot deregister')
         }
       }
-      const registration = await navigator.serviceWorker.getRegistration()
 
-      if (registration != null) {
+      try {
+        await registerServiceWorker()
         setIsServiceWorkerRegistered(true)
-      } else {
-        try {
-          await registerServiceWorker()
-          setIsServiceWorkerRegistered(true)
-        } catch (err) {
-          log.error('error registering service worker', err)
-        }
+      } catch (err) {
+        log.error('error registering service worker', err)
       }
+      // }
     }
     void doWork()
   }, [isServiceWorkerRegistered])

--- a/src/service-worker-utils.ts
+++ b/src/service-worker-utils.ts
@@ -3,7 +3,11 @@ import { uiLogger } from './lib/logger.js'
 async function supportsESMInServiceWorkers (): Promise<ServiceWorkerRegistration | null> {
   try {
     const scriptURL = new URL('ipfs-sw-sw.js', import.meta.url)
-    const registration = await navigator.serviceWorker.register(scriptURL, { type: 'module', updateViaCache: 'imports' })
+    const registration = await navigator.serviceWorker.register(scriptURL, {
+      type: 'module',
+      // don't use the cache for this registration
+      updateViaCache: 'none'
+    })
     // await registration.unregister()
     console.log('supportsESMInServiceWorkers', registration)
     return registration

--- a/src/service-worker-utils.ts
+++ b/src/service-worker-utils.ts
@@ -8,29 +8,23 @@ async function supportsESMInServiceWorkers (): Promise<ServiceWorkerRegistration
       // don't use the cache for this registration
       updateViaCache: 'none'
     })
-    // await registration.unregister()
-    console.log('supportsESMInServiceWorkers', registration)
     return registration
   } catch (e) {
-    console.error('error', e)
     return null
   }
 }
+
 /**
  * This function is always and only used from the UI
  */
 export async function registerServiceWorker (): Promise<ServiceWorkerRegistration> {
   const log = uiLogger.forComponent('register-service-worker')
   const esmRegistration = await supportsESMInServiceWorkers()
-  console.log('esmRegistration', esmRegistration)
   const swToLoad = (esmRegistration != null) ? 'ipfs-sw-sw.js' : 'ipfs-sw-sw-es5.js'
   const swUrl = new URL(swToLoad, import.meta.url)
   log.trace('loading service worker', swToLoad)
   const currentRegistration = await navigator.serviceWorker.getRegistration()
   if (currentRegistration != null) {
-    currentRegistration.addEventListener('updatefound', () => {
-      console.log('update found 1')
-    })
     const currentScriptURL = currentRegistration.active?.scriptURL ?? currentRegistration.waiting?.scriptURL ?? currentRegistration.installing?.scriptURL
 
     // If the current service worker is different, unregister it
@@ -46,9 +40,7 @@ export async function registerServiceWorker (): Promise<ServiceWorkerRegistratio
 
   return new Promise((resolve, reject) => {
     swRegistration.addEventListener('updatefound', () => {
-      console.log('update found 2')
       const newWorker = swRegistration.installing
-      console.log('newWorker', newWorker)
       newWorker?.addEventListener('statechange', () => {
         if (newWorker.state === 'activated') {
           log('service worker activated')

--- a/src/service-worker-utils.ts
+++ b/src/service-worker-utils.ts
@@ -5,6 +5,7 @@ async function supportsESMInServiceWorkers (): Promise<ServiceWorkerRegistration
     const scriptURL = new URL('ipfs-sw-sw.js', import.meta.url)
     const registration = await navigator.serviceWorker.register(scriptURL, { type: 'module' })
     // await registration.unregister()
+    console.log('supportsESMInServiceWorkers', registration)
     return registration
   } catch (e) {
     console.error('error', e)
@@ -17,6 +18,7 @@ async function supportsESMInServiceWorkers (): Promise<ServiceWorkerRegistration
 export async function registerServiceWorker (): Promise<ServiceWorkerRegistration> {
   const log = uiLogger.forComponent('register-service-worker')
   const esmRegistration = await supportsESMInServiceWorkers()
+  console.log('esmRegistration', esmRegistration)
   const swToLoad = (esmRegistration != null) ? 'ipfs-sw-sw.js' : 'ipfs-sw-sw-es5.js'
   const swUrl = new URL(swToLoad, import.meta.url)
   log.trace('loading service worker', swToLoad)


### PR DESCRIPTION
- **feat: add code splitting back**
- **chore: debugging**
- **chore: debugging**
- **chore: debugging**
- **fix: firefox properly replaces old service worker**


To debug this, follow this process:

```shell
npm run clean && npm run start
# load the page

# if you need to reload the old SW...
git checkout main
npm run clean && npm run start
# load the page

git checkout fix/splitting-sw
npm run clean && npm run start
# load the page

# repeat as needed
```
