### PR TITLE
fix: support discovery of /tls/../ws|http  providers

### DIFF
--- a/src/lib/get-verified-fetch.ts
+++ b/src/lib/get-verified-fetch.ts
@@ -69,7 +69,7 @@ export async function getVerifiedFetch (config: ConfigDb, logger: ComponentLogge
     config.routers.forEach((router) => {
       routers.push(delegatedHTTPRouting(router, {
         // NOTE: in practice 'transport-ipfs-gateway-http' exists only in IPNI results, we won't have any DHT results like this unless..
-        // TODO: someguy starts doing active probing to identify peers which have funcitonal HTTP gateway
+        // TODO: someguy starts doing active probing (https://github.com/ipfs/someguy/issues/53) to identify peers which have functional HTTP gateway
         filterProtocols: ['transport-ipfs-gateway-http'],
         // Include both /https && /tls/../http
         filterAddrs: ['https', 'tls']

--- a/src/lib/get-verified-fetch.ts
+++ b/src/lib/get-verified-fetch.ts
@@ -95,7 +95,8 @@ export async function libp2pDefaults (config: Libp2pDefaultsOptions): Promise<Li
 
   if (config.enableWss) {
     transports.push(webSockets())
-    filterAddrs.push('wss')
+    filterAddrs.push('wss') // /dns4/sv15.bootstrap.libp2p.io/tcp/443/wss/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJ
+    filterAddrs.push('ws') // /ip4/A.B.C.D/tcp/4002/tls/sni/A-B-C-D.peerid.libp2p.direct/ws/p2p/peerid
   }
   if (config.enableWebTransport) {
     transports.push(webTransport())

--- a/src/lib/get-verified-fetch.ts
+++ b/src/lib/get-verified-fetch.ts
@@ -96,7 +96,7 @@ export async function libp2pDefaults (config: Libp2pDefaultsOptions): Promise<Li
   if (config.enableWss) {
     transports.push(webSockets())
     filterAddrs.push('wss') // /dns4/sv15.bootstrap.libp2p.io/tcp/443/wss/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJ
-    filterAddrs.push('ws') // /ip4/A.B.C.D/tcp/4002/tls/sni/A-B-C-D.peerid.libp2p.direct/ws/p2p/peerid
+    filterAddrs.push('tls') // /ip4/A.B.C.D/tcp/4002/tls/sni/A-B-C-D.peerid.libp2p.direct/ws/p2p/peerid
   }
   if (config.enableWebTransport) {
     transports.push(webTransport())


### PR DESCRIPTION
Opening this to start discussion, this may not be the right fix, see "Solution (B)" below.

cc @SgtPooki @2color for feedback / ideas 

## Problem description

We already support DNS-dependent `/wss` like `/dns4/sv15.bootstrap.libp2p.io/tcp/443/wss/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJ`, but we are filtering out `/ip.../tls/sni/../ws` where DNS resolution is not required. Those will be all p2p-forge peers once we deploy it in Kubo in a few releases.

Example: `/ip4/147.75.87.65/tcp/4002/tls/sni/147-75-87-65.k51qzi5uqu5dhb03btheentd9nmkaygwm4q3tfrm596s5thf1u87bc7gq0m2ia.libp2p.direct/ws/p2p/12D3KooWCrBiagtZMzpZePCr1tfBbrZTh4BRQf7JurRqNMRi8YHF`

## Solution TBD

### Solution A (this PR)

This PR ensures we are not filtering them out. Compare:

- `curl -H 'accept: application/x-ndjson' 'https://delegated-ipfs.dev/routing/v1/providers/bafybeihn2f7lhumh4grizksi2fl233cyszqadkn424ptjajfenykpsaiw4?filter-addrs=wss'`

with

- `curl -H 'accept: application/x-ndjson' 'https://delegated-ipfs.dev/routing/v1/providers/bafybeihn2f7lhumh4grizksi2fl233cyszqadkn424ptjajfenykpsaiw4?filter-addrs=ws,wss'`

or 

- `curl -H 'accept: application/x-ndjson' 'https://delegated-ipfs.dev/routing/v1/providers/bafybeihn2f7lhumh4grizksi2fl233cyszqadkn424ptjajfenykpsaiw4?filter-addrs=wss,tls'`

This comes with assumption that js-libp2p is smart enough to only dial `/ws` that have `/tls`, and skip  / log error when dialing unencrypted ones, similar to trustless gateways being announced with `/tls/.../http` 
If not, that has to be fixed upstream as well.

Feedback welcome. Alternative approach is (B) below.

### Solution (B) 

Augment `/routing/v1` implementation in boxo server (and someguy) and specs and make it clear that some filters have special meaning:
- `wss` should also include `/tls/../ws`
- `https` should also include `/tls/../http`

This is kinda easy, we can deploy this fix next week.

This feels more future-proof. I'm leaning towards (B) because it shifts responsibility of "doing the right thing" to /routing/v1 endpoint, and ensures even poorly written clients (other than ones we maintain) that dont know about `/tls/..` variants get these results. But lmk your thoughts.