### PR TITLE
fix(ci): timeout and cache playwright deps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,7 +67,16 @@ jobs:
         with:
           node-version: lts/*
       - uses: ipfs/aegir/actions/cache-node-modules@main
+      - name: Cache Playwright dependencies
+        id: playwright-cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
       - run: npx playwright install --with-deps
+        timeout-minutes: 15 # should take no logner than 2min
       - run: npm run --if-present test:chrome
       - uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         with:
@@ -98,7 +107,16 @@ jobs:
         with:
           node-version: lts/*
       - uses: ipfs/aegir/actions/cache-node-modules@main
+      - name: Cache Playwright dependencies
+        id: playwright-cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
       - run: npx playwright install --with-deps
+        timeout-minutes: 15 # should take no logner than 2min
       - run: npm run --if-present test:firefox
       - uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,7 +76,7 @@ jobs:
           restore-keys: |
             playwright-${{ runner.os }}-
       - run: npx playwright install --with-deps
-        timeout-minutes: 15 # should take no logner than 2min
+        timeout-minutes: 10 # should take no longer than 2min
       - run: npm run --if-present test:chrome
       - uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         with:
@@ -116,7 +116,7 @@ jobs:
           restore-keys: |
             playwright-${{ runner.os }}-
       - run: npx playwright install --with-deps
-        timeout-minutes: 15 # should take no logner than 2min
+        timeout-minutes: 10 # should take no longer than 2min
       - run: npm run --if-present test:firefox
       - uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,7 @@ jobs:
       - uses: ipfs/aegir/actions/cache-node-modules@main
       - name: Cache Playwright dependencies
         id: playwright-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
@@ -109,7 +109,7 @@ jobs:
       - uses: ipfs/aegir/actions/cache-node-modules@main
       - name: Cache Playwright dependencies
         id: playwright-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}


### PR DESCRIPTION
Applying fix to avoid running for 6h like it did in https://github.com/ipfs/service-worker-gateway/actions/runs/12890491077/job/35940260584 (thx @galargh  for flag)

There is also cache in `.cache/ms-playwright` that is not covered by npm specific cache handling.
Added it so its shared across runs, this way we fetch one version of each browser only once per OS.