### PR TITLE
fix: prevent config UI flash on subdomain first load

### DIFF
--- a/src/pages/redirect-page.tsx
+++ b/src/pages/redirect-page.tsx
@@ -1,97 +1,148 @@
-import React, { useCallback, useContext, useEffect, useMemo, useState, type ReactElement } from 'react'
-import Header from '../components/Header.jsx'
-import { ConfigProvider } from '../context/config-context.jsx'
-import { ServiceWorkerContext, ServiceWorkerProvider } from '../context/service-worker-context.jsx'
-import { setConfig, type ConfigDb } from '../lib/config-db.js'
-import { getSubdomainParts } from '../lib/get-subdomain-parts.js'
-import { isConfigPage } from '../lib/is-config-page.js'
-import { getUiComponentLogger, uiLogger } from '../lib/logger.js'
-import { tellSwToReloadConfig } from '../lib/sw-comms.js'
-import { translateIpfsRedirectUrl } from '../lib/translate-ipfs-redirect-url.js'
-import './default-page-styles.css'
-import LoadingPage from './loading.jsx'
-import './loading.css'
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactElement,
+} from "react";
+import Header from "../components/Header.jsx";
+import { ConfigProvider } from "../context/config-context.jsx";
+import {
+  ServiceWorkerContext,
+  ServiceWorkerProvider,
+} from "../context/service-worker-context.jsx";
+import { setConfig, type ConfigDb } from "../lib/config-db.js";
+import { getSubdomainParts } from "../lib/get-subdomain-parts.js";
+import { isConfigPage } from "../lib/is-config-page.js";
+import { getUiComponentLogger, uiLogger } from "../lib/logger.js";
+import { tellSwToReloadConfig } from "../lib/sw-comms.js";
+import { translateIpfsRedirectUrl } from "../lib/translate-ipfs-redirect-url.js";
+import "./default-page-styles.css";
+import LoadingPage from "./loading.jsx";
+import "./loading.css";
 
-const uiComponentLogger = getUiComponentLogger('redirect-page')
-const log = uiLogger.forComponent('redirect-page')
+const uiComponentLogger = getUiComponentLogger("redirect-page");
+const log = uiLogger.forComponent("redirect-page");
 
 const ConfigIframe: React.FC = () => {
-  const { parentDomain } = getSubdomainParts(window.location.href)
-  let iframeSrc
+  const { parentDomain } = getSubdomainParts(window.location.href);
+  const { isServiceWorkerRegistered } = useContext(ServiceWorkerContext);
+  let iframeSrc;
   if (parentDomain == null || parentDomain === window.location.href) {
-    const url = new URL(window.location.href)
-    url.pathname = '/'
-    url.hash = `#/ipfs-sw-config@origin=${encodeURIComponent(window.location.origin)}`
-    iframeSrc = url.href
+    const url = new URL(window.location.href);
+    url.pathname = "/";
+    url.hash = `#/ipfs-sw-config@origin=${encodeURIComponent(
+      window.location.origin
+    )}`;
+    iframeSrc = url.href;
   } else {
-    const portString = window.location.port === '' ? '' : `:${window.location.port}`
-    iframeSrc = `${window.location.protocol}//${parentDomain}${portString}/#/ipfs-sw-config@origin=${encodeURIComponent(window.location.origin)}`
+    const portString =
+      window.location.port === "" ? "" : `:${window.location.port}`;
+    iframeSrc = `${
+      window.location.protocol
+    }//${parentDomain}${portString}/#/ipfs-sw-config@origin=${encodeURIComponent(
+      window.location.origin
+    )}`;
   }
 
-  return (
-    <iframe id="redirect-config-iframe" src={iframeSrc} style={{ width: '100vw', height: '100vh', border: 'none' }} />
-  )
-}
+  const [isVisible, setIsVisible] = useState(false);
 
-function RedirectPage ({ showConfigIframe = true }: { showConfigIframe?: boolean }): ReactElement {
-  const [isAutoReloadEnabled] = useState(true)
-  const { isServiceWorkerRegistered } = useContext(ServiceWorkerContext)
-  const [reloadUrl, setReloadUrl] = useState(translateIpfsRedirectUrl(window.location.href).href)
-  const [isLoadingContent, setIsLoadingContent] = useState(false)
+  useEffect(() => {
+    // Only show iframe after service worker is registered
+    if (isServiceWorkerRegistered) {
+      setIsVisible(true);
+    }
+  }, [isServiceWorkerRegistered]);
+
+  return (
+    <div style={{ display: isVisible ? "block" : "none" }}>
+      <iframe
+        id="redirect-config-iframe"
+        src={iframeSrc}
+        style={{ width: "100vw", height: "100vh", border: "none" }}
+      />
+    </div>
+  );
+};
+
+function RedirectPage({
+  showConfigIframe = true,
+}: {
+  showConfigIframe?: boolean;
+}): ReactElement {
+  const [isAutoReloadEnabled] = useState(true);
+  const { isServiceWorkerRegistered } = useContext(ServiceWorkerContext);
+  const [reloadUrl, setReloadUrl] = useState(
+    translateIpfsRedirectUrl(window.location.href).href
+  );
+  const [isLoadingContent, setIsLoadingContent] = useState(false);
+  const [isConfigLoading, setIsConfigLoading] = useState(true);
 
   useEffect(() => {
     if (isConfigPage(window.location.hash)) {
-      setReloadUrl(window.location.href.replace('#/ipfs-sw-config', ''))
+      setReloadUrl(window.location.href.replace("#/ipfs-sw-config", ""));
     }
 
-    async function doWork (config: ConfigDb): Promise<void> {
+    async function doWork(config: ConfigDb): Promise<void> {
       try {
-        await setConfig(config, uiComponentLogger)
-        await tellSwToReloadConfig()
-        log.trace('redirect-page: RELOAD_CONFIG_SUCCESS on %s', window.location.origin)
+        await setConfig(config, uiComponentLogger);
+        await tellSwToReloadConfig();
+        log.trace(
+          "redirect-page: RELOAD_CONFIG_SUCCESS on %s",
+          window.location.origin
+        );
       } catch (err) {
-        log.error('redirect-page: error setting config on subdomain', err)
+        log.error("redirect-page: error setting config on subdomain", err);
       }
     }
     const listener = (event: MessageEvent): void => {
-      if (event.data?.source === 'helia-sw-config-iframe') {
-        log.trace('redirect-page: received RELOAD_CONFIG message from iframe', event.data)
-        const config = event.data?.config
+      if (event.data?.source === "helia-sw-config-iframe") {
+        log.trace(
+          "redirect-page: received RELOAD_CONFIG message from iframe",
+          event.data
+        );
+        const config = event.data?.config;
         if (config != null) {
-          void doWork(config as ConfigDb)
+          void doWork(config as ConfigDb);
         }
+        setIsConfigLoading(false);
       }
-    }
-    window.addEventListener('message', listener)
+    };
+    window.addEventListener("message", listener);
     return () => {
-      window.removeEventListener('message', listener)
-    }
-  }, [])
+      window.removeEventListener("message", listener);
+    };
+  }, []);
 
   const displayString = useMemo(() => {
     if (!isServiceWorkerRegistered) {
-      return 'Registering Helia service worker...'
+      return "Registering Helia service worker...";
     }
     if (isAutoReloadEnabled && !isConfigPage(window.location.hash)) {
-      return 'Redirecting you because Auto Reload is enabled.'
+      return "Redirecting you because Auto Reload is enabled.";
     }
 
-    return 'Click below to load the content with the specified config.'
-  }, [isAutoReloadEnabled, isServiceWorkerRegistered])
+    return "Click below to load the content with the specified config.";
+  }, [isAutoReloadEnabled, isServiceWorkerRegistered]);
 
   const loadContent = useCallback(() => {
-    setIsLoadingContent(true)
-    window.location.href = reloadUrl
-  }, [reloadUrl])
+    setIsLoadingContent(true);
+    window.location.href = reloadUrl;
+  }, [reloadUrl]);
 
   useEffect(() => {
-    if (isAutoReloadEnabled && isServiceWorkerRegistered && !isConfigPage(window.location.hash)) {
-      loadContent()
+    if (
+      isAutoReloadEnabled &&
+      isServiceWorkerRegistered &&
+      !isConfigPage(window.location.hash)
+    ) {
+      loadContent();
     }
-  }, [isAutoReloadEnabled, isServiceWorkerRegistered, loadContent])
+  }, [isAutoReloadEnabled, isServiceWorkerRegistered, loadContent]);
 
-  if (isLoadingContent) {
-    return <LoadingPage />
+  if (isLoadingContent || isConfigLoading) {
+    return <LoadingPage />;
   }
 
   return (
@@ -104,7 +155,7 @@ function RedirectPage ({ showConfigIframe = true }: { showConfigIframe?: boolean
         {showConfigIframe && <ConfigIframe />}
       </div>
     </>
-  )
+  );
 }
 
 export default (): ReactElement => {
@@ -114,5 +165,5 @@ export default (): ReactElement => {
         <RedirectPage />
       </ConfigProvider>
     </ServiceWorkerProvider>
-  )
-}
+  );
+};

--- a/src/pages/redirect-page.tsx
+++ b/src/pages/redirect-page.tsx
@@ -41,13 +41,13 @@ const ConfigIframe: React.FC = () => {
   }, [isServiceWorkerRegistered])
 
   return (
-    <div style={{ display: isVisible ? "block" : "none" }}>
+    <div style={{ display: isVisible ? 'block' : 'none' }}>
       <iframe id="redirect-config-iframe" src={iframeSrc} style={{ width: '100vw', height: '100vh', border: 'none' }} />
     </div>
   )
 }
 
-function RedirectPage({ showConfigIframe = true }: { showConfigIframe?: boolean }): ReactElement {
+function RedirectPage ({ showConfigIframe = true }: { showConfigIframe?: boolean }): ReactElement {
   const [isAutoReloadEnabled] = useState(true)
   const { isServiceWorkerRegistered } = useContext(ServiceWorkerContext)
   const [reloadUrl, setReloadUrl] = useState(translateIpfsRedirectUrl(window.location.href).href)
@@ -59,7 +59,7 @@ function RedirectPage({ showConfigIframe = true }: { showConfigIframe?: boolean 
       setReloadUrl(window.location.href.replace('#/ipfs-sw-config', ''))
     }
 
-    async function doWork(config: ConfigDb): Promise<void> {
+    async function doWork (config: ConfigDb): Promise<void> {
       try {
         await setConfig(config, uiComponentLogger)
         await tellSwToReloadConfig()

--- a/src/pages/redirect-page.tsx
+++ b/src/pages/redirect-page.tsx
@@ -1,148 +1,113 @@
-import React, {
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-  type ReactElement,
-} from "react";
-import Header from "../components/Header.jsx";
-import { ConfigProvider } from "../context/config-context.jsx";
-import {
-  ServiceWorkerContext,
-  ServiceWorkerProvider,
-} from "../context/service-worker-context.jsx";
-import { setConfig, type ConfigDb } from "../lib/config-db.js";
-import { getSubdomainParts } from "../lib/get-subdomain-parts.js";
-import { isConfigPage } from "../lib/is-config-page.js";
-import { getUiComponentLogger, uiLogger } from "../lib/logger.js";
-import { tellSwToReloadConfig } from "../lib/sw-comms.js";
-import { translateIpfsRedirectUrl } from "../lib/translate-ipfs-redirect-url.js";
-import "./default-page-styles.css";
-import LoadingPage from "./loading.jsx";
-import "./loading.css";
+import React, { useCallback, useContext, useEffect, useMemo, useState, type ReactElement } from 'react'
+import Header from '../components/Header.jsx'
+import { ConfigProvider } from '../context/config-context.jsx'
+import { ServiceWorkerContext, ServiceWorkerProvider } from '../context/service-worker-context.jsx'
+import { setConfig, type ConfigDb } from '../lib/config-db.js'
+import { getSubdomainParts } from '../lib/get-subdomain-parts.js'
+import { isConfigPage } from '../lib/is-config-page.js'
+import { getUiComponentLogger, uiLogger } from '../lib/logger.js'
+import { tellSwToReloadConfig } from '../lib/sw-comms.js'
+import { translateIpfsRedirectUrl } from '../lib/translate-ipfs-redirect-url.js'
+import './default-page-styles.css'
+import LoadingPage from './loading.jsx'
+import './loading.css'
 
-const uiComponentLogger = getUiComponentLogger("redirect-page");
-const log = uiLogger.forComponent("redirect-page");
+const uiComponentLogger = getUiComponentLogger('redirect-page')
+const log = uiLogger.forComponent('redirect-page')
 
 const ConfigIframe: React.FC = () => {
-  const { parentDomain } = getSubdomainParts(window.location.href);
-  const { isServiceWorkerRegistered } = useContext(ServiceWorkerContext);
-  let iframeSrc;
+  const { parentDomain } = getSubdomainParts(window.location.href)
+  const { isServiceWorkerRegistered } = useContext(ServiceWorkerContext)
+
+  let iframeSrc
   if (parentDomain == null || parentDomain === window.location.href) {
-    const url = new URL(window.location.href);
-    url.pathname = "/";
-    url.hash = `#/ipfs-sw-config@origin=${encodeURIComponent(
-      window.location.origin
-    )}`;
-    iframeSrc = url.href;
+    const url = new URL(window.location.href)
+    url.pathname = '/'
+    url.hash = `#/ipfs-sw-config@origin=${encodeURIComponent(window.location.origin)}`
+
+    iframeSrc = url.href
   } else {
-    const portString =
-      window.location.port === "" ? "" : `:${window.location.port}`;
-    iframeSrc = `${
-      window.location.protocol
-    }//${parentDomain}${portString}/#/ipfs-sw-config@origin=${encodeURIComponent(
-      window.location.origin
-    )}`;
+    const portString = window.location.port === '' ? '' : `:${window.location.port}`
+    iframeSrc = `${window.location.protocol}//${parentDomain}${portString}/#/ipfs-sw-config@origin=${encodeURIComponent(window.location.origin)}`
   }
 
-  const [isVisible, setIsVisible] = useState(false);
+  const [isVisible, setIsVisible] = useState(false)
 
   useEffect(() => {
     // Only show iframe after service worker is registered
     if (isServiceWorkerRegistered) {
-      setIsVisible(true);
+      setIsVisible(true)
     }
-  }, [isServiceWorkerRegistered]);
+  }, [isServiceWorkerRegistered])
 
   return (
     <div style={{ display: isVisible ? "block" : "none" }}>
-      <iframe
-        id="redirect-config-iframe"
-        src={iframeSrc}
-        style={{ width: "100vw", height: "100vh", border: "none" }}
-      />
+      <iframe id="redirect-config-iframe" src={iframeSrc} style={{ width: '100vw', height: '100vh', border: 'none' }} />
     </div>
-  );
-};
+  )
+}
 
-function RedirectPage({
-  showConfigIframe = true,
-}: {
-  showConfigIframe?: boolean;
-}): ReactElement {
-  const [isAutoReloadEnabled] = useState(true);
-  const { isServiceWorkerRegistered } = useContext(ServiceWorkerContext);
-  const [reloadUrl, setReloadUrl] = useState(
-    translateIpfsRedirectUrl(window.location.href).href
-  );
-  const [isLoadingContent, setIsLoadingContent] = useState(false);
-  const [isConfigLoading, setIsConfigLoading] = useState(true);
+function RedirectPage({ showConfigIframe = true }: { showConfigIframe?: boolean }): ReactElement {
+  const [isAutoReloadEnabled] = useState(true)
+  const { isServiceWorkerRegistered } = useContext(ServiceWorkerContext)
+  const [reloadUrl, setReloadUrl] = useState(translateIpfsRedirectUrl(window.location.href).href)
+  const [isLoadingContent, setIsLoadingContent] = useState(false)
+  const [isConfigLoading, setIsConfigLoading] = useState(true)
 
   useEffect(() => {
     if (isConfigPage(window.location.hash)) {
-      setReloadUrl(window.location.href.replace("#/ipfs-sw-config", ""));
+      setReloadUrl(window.location.href.replace('#/ipfs-sw-config', ''))
     }
 
     async function doWork(config: ConfigDb): Promise<void> {
       try {
-        await setConfig(config, uiComponentLogger);
-        await tellSwToReloadConfig();
-        log.trace(
-          "redirect-page: RELOAD_CONFIG_SUCCESS on %s",
-          window.location.origin
-        );
+        await setConfig(config, uiComponentLogger)
+        await tellSwToReloadConfig()
+        log.trace('redirect-page: RELOAD_CONFIG_SUCCESS on %s', window.location.origin)
       } catch (err) {
-        log.error("redirect-page: error setting config on subdomain", err);
+        log.error('redirect-page: error setting config on subdomain', err)
       }
     }
     const listener = (event: MessageEvent): void => {
-      if (event.data?.source === "helia-sw-config-iframe") {
-        log.trace(
-          "redirect-page: received RELOAD_CONFIG message from iframe",
-          event.data
-        );
-        const config = event.data?.config;
+      if (event.data?.source === 'helia-sw-config-iframe') {
+        log.trace('redirect-page: received RELOAD_CONFIG message from iframe', event.data)
+        const config = event.data?.config
         if (config != null) {
-          void doWork(config as ConfigDb);
+          void doWork(config as ConfigDb)
         }
-        setIsConfigLoading(false);
+        setIsConfigLoading(false)
       }
-    };
-    window.addEventListener("message", listener);
+    }
+    window.addEventListener('message', listener)
     return () => {
-      window.removeEventListener("message", listener);
-    };
-  }, []);
+      window.removeEventListener('message', listener)
+    }
+  }, [])
 
   const displayString = useMemo(() => {
     if (!isServiceWorkerRegistered) {
-      return "Registering Helia service worker...";
+      return 'Registering Helia service worker...'
     }
     if (isAutoReloadEnabled && !isConfigPage(window.location.hash)) {
-      return "Redirecting you because Auto Reload is enabled.";
+      return 'Redirecting you because Auto Reload is enabled.'
     }
 
-    return "Click below to load the content with the specified config.";
-  }, [isAutoReloadEnabled, isServiceWorkerRegistered]);
+    return 'Click below to load the content with the specified config.'
+  }, [isAutoReloadEnabled, isServiceWorkerRegistered])
 
   const loadContent = useCallback(() => {
-    setIsLoadingContent(true);
-    window.location.href = reloadUrl;
-  }, [reloadUrl]);
+    setIsLoadingContent(true)
+    window.location.href = reloadUrl
+  }, [reloadUrl])
 
   useEffect(() => {
-    if (
-      isAutoReloadEnabled &&
-      isServiceWorkerRegistered &&
-      !isConfigPage(window.location.hash)
-    ) {
-      loadContent();
+    if (isAutoReloadEnabled && isServiceWorkerRegistered && !isConfigPage(window.location.hash)) {
+      loadContent()
     }
-  }, [isAutoReloadEnabled, isServiceWorkerRegistered, loadContent]);
+  }, [isAutoReloadEnabled, isServiceWorkerRegistered, loadContent])
 
   if (isLoadingContent || isConfigLoading) {
-    return <LoadingPage />;
+    return <LoadingPage />
   }
 
   return (
@@ -155,7 +120,7 @@ function RedirectPage({
         {showConfigIframe && <ConfigIframe />}
       </div>
     </>
-  );
+  )
 }
 
 export default (): ReactElement => {
@@ -165,5 +130,5 @@ export default (): ReactElement => {
         <RedirectPage />
       </ConfigProvider>
     </ServiceWorkerProvider>
-  );
-};
+  )
+}


### PR DESCRIPTION
## fix: prevent config UI flash on subdomain first load

## Description

When opening a page on a subdomain for the first time, the config UI would flash at the bottom of the page while loading the default index.html in an iframe to read the config. This PR fixes the issue by:

- Adding visibility control for the config iframe
- Only showing iframe after service worker is registered
- Adding loading state coordination between config loading and service worker registration
- Showing loading screen until both config is loaded and service worker is ready

Fixes https://github.com/ipfs/service-worker-gateway/issues/530

## Notes & open questions

The solution improves both the visual experience and loading performance by better coordinating the states between service worker registration and config loading.

Changes are focused on:
- src/pages/redirect-page.tsx

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works