### PR TITLE
feat: add strict CSP policy

### DIFF
--- a/build.js
+++ b/build.js
@@ -73,7 +73,6 @@ const calculateFileHash = (filePath) => {
  */
 const injectAssets = (metafile) => {
   const htmlFilePath = path.resolve('dist/index.html')
-  const nonce = gitRevision() // Use the git revision as the CSP nonce
 
   // Extract the output file names from the metafile
   const outputs = metafile.outputs
@@ -89,7 +88,7 @@ const injectAssets = (metafile) => {
   console.log(`Script hash (sha256): ${scriptHash}`)
   console.log(`CSS hash (sha256): ${cssHash}`)
 
-  const scriptTag = `<script type="module" nonce="${nonce}" src="${path.basename(scriptFile)}"></script>`
+  const scriptTag = `<script type="module" src="${path.basename(scriptFile)}"></script>`
   const linkTag = `<link rel="stylesheet" href="${path.basename(cssFile)}">`
 
   // Read the index.html file

--- a/public/index.html
+++ b/public/index.html
@@ -20,6 +20,8 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- CSP header will be updated during build with calculated hashes -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; manifest-src 'self'; connect-src 'self';">
     <title>IPFS Service Worker Gateway | <%= GIT_VERSION %></title>
     <meta name="description" content="A static HTML page that initializes an instance of IPFS Service Worker Gateway" />
     <meta name="robots" content="noindex" />


### PR DESCRIPTION
## Description

- This PR explores adding a strict CSP policy to improve the security of the service worker gateway and resilience to attacks. 

## Notes & open questions

- This breaks global config iframe. But maybe this is a desired trade-off? 


## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
