### PR TITLE
chore: deploy CI completes when new site is up

### DIFF
--- a/.github/scripts/wait-for-deploy.sh
+++ b/.github/scripts/wait-for-deploy.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ "$#" -lt 2 ]; then
+  echo "Usage: $0 <endpoint> <git-short-hash>"
+  exit 1
+fi
+
+ENDPOINT="$1"
+TARGET_HASH="$2"
+# If no third argument is provided, no delay is applied
+if [ "$#" -ge 3 ]; then
+  MAX_DELAY="$3"
+fi
+
+# Initial delay in seconds (60, then doubles each time)
+DELAY=60
+
+echo "Watching $ENDPOINT for Build: staging@$TARGET_HASH ..."
+while true
+do
+  PAGE_CONTENT="$(curl -s "$ENDPOINT")"
+
+  # If the page contains the line with the hash:
+  if echo "$PAGE_CONTENT" | grep -q "Build: staging@${TARGET_HASH}"; then
+    echo "Found Build: staging@${TARGET_HASH}!"
+    exit 0
+  fi
+
+  echo "Not found yet. Sleeping for ${DELAY} seconds..."
+  sleep "$DELAY"
+
+  # Exponential backoff
+  DELAY=$((DELAY * 2))
+
+  # cap the delay if a maximum delay is provided
+  if [ -n "$MAX_DELAY" ] && [ $DELAY -gt $MAX_DELAY ]; then
+    DELAY=$MAX_DELAY
+  fi
+done

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -18,3 +18,10 @@ jobs:
       environment: production
     secrets:
       DEPLOYMENT_GITHUB_TOKEN: ${{ secrets.UCI_GITHUB_TOKEN }}
+  wait-for-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Wait for deployment to complete
+        run: |
+          ./.github/scripts/wait-for-deploy.sh https://inbrowser.link ${{ inputs.tag }}

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -18,3 +18,10 @@ jobs:
       environment: staging
     secrets:
       DEPLOYMENT_GITHUB_TOKEN: ${{ secrets.UCI_GITHUB_TOKEN }}
+  wait-for-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Wait for deployment to complete
+        run: |
+          ./.github/scripts/wait-for-deploy.sh https://inbrowser.dev ${{ inputs.tag }}


### PR DESCRIPTION
i've been wanting this for a while.

github CI action for deploy to staging and prod only completes once the new hash is seen in the index.html