### PR TITLE
fix: improve binary onboarding experience 

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -82,6 +82,7 @@ jobs:
         run: |
           echo "Building for GOOS=${GOOS} GOARCH=${GOARCH}"
           go build -o service-worker-gateway-${{ matrix.arch }}${{ matrix.output_suffix }} main.go
+          chmod +x service-worker-gateway-${{ matrix.arch }}${{ matrix.output_suffix }}
 
       # ###
       # # Windows signing -- disabled because we don't have a valid cert

--- a/main.go
+++ b/main.go
@@ -88,7 +88,8 @@ func main() {
 	mux.Handle("/", distHandler)
 
 	addr := ":3000"
-	log.Printf("Service‑worker gateway listening on %s", addr)
+	log.Printf("Service Worker Gateway listening on %s", addr)
+	log.Printf("Open http://gateway.localhost%s in your browser", addr)
 	if err := http.ListenAndServe(addr, mux); err != nil {
 		log.Fatalf("server error: %v", err)
 	}


### PR DESCRIPTION
## What

- Improve the message we log by printing out a valid URL that can be opened directly in the browser.
- Make the binary executable (update permissions) right after it's compiled in an attempt to fix the lack of execute permissions in the release binary.

## Why

See #695