### PR TITLE
fix: go server handles requests with paths

### DIFF
--- a/main.go
+++ b/main.go
@@ -84,8 +84,8 @@ func main() {
 	mux.HandleFunc("/ipfs/", ipfsLikeHandler)
 	mux.HandleFunc("/ipns/", ipfsLikeHandler)
 
-	// Everything else from dist/ (root path “/” included).
-	mux.Handle("/", distHandler)
+	// Everything else - check if file exists, otherwise redirect to SW
+	mux.HandleFunc("/", ipfsLikeHandler)
 
 	addr := ":3000"
 	log.Printf("Service Worker Gateway listening on %s", addr)


### PR DESCRIPTION
Previously, the go server would fail when you try something like http://specs-ipfs-tech.ipns.localhost:3000/architecture/principles/

This fixes that
