### PR TITLE
fix: allow injection of trustless config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,6 @@
         "ipfs-css": "^1.4.0",
         "ipfsd-ctl": "^15.0.2",
         "libp2p": "^2.8.12",
-        "lz-string": "^1.5.0",
         "multiformats": "^13.3.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -18179,15 +18178,6 @@
       "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/lz-string": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
-      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "license": "MIT",
-      "bin": {
-        "lz-string": "bin/bin.js"
-      }
     },
     "node_modules/magic-string": {
       "version": "0.30.17",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "ipfs-css": "^1.4.0",
     "ipfsd-ctl": "^15.0.2",
     "libp2p": "^2.8.12",
-    "lz-string": "^1.5.0",
     "multiformats": "^13.3.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/src/lib/config-db.ts
+++ b/src/lib/config-db.ts
@@ -236,7 +236,7 @@ export async function isConfigSet (logger?: ComponentLogger): Promise<boolean> {
   return false
 }
 
-export async function compressConfig (config: ConfigDb): Promise<string> {
+export async function compressConfig (config: ConfigDb | ConfigDbWithoutPrivateFields): Promise<string> {
   const timestamp = Date.now()
   const configJson = JSON.stringify({ ...config, t: timestamp })
   const base64Encoded = btoa(configJson)

--- a/test-e2e/config-loading.test.ts
+++ b/test-e2e/config-loading.test.ts
@@ -1,7 +1,7 @@
+import { compressConfig } from '../src/lib/config-db.js'
 import { test, expect } from './fixtures/config-test-fixtures.js'
 import { getConfig, setConfig } from './fixtures/set-sw-config.js'
 import { waitForServiceWorker } from './fixtures/wait-for-service-worker.js'
-import { compressConfig } from '../src/lib/config-db.js'
 import type { ConfigDbWithoutPrivateFields } from '../src/lib/config-db.js'
 import type { Response as PlaywrightResponse } from 'playwright'
 
@@ -123,5 +123,4 @@ test.describe('ipfs-sw configuration', () => {
     expect(config.enableRecursiveGateways).toBe(newConfig.enableRecursiveGateways)
     expect(config.enableGatewayProviders).toBe(newConfig.enableGatewayProviders)
   })
-
 })

--- a/test-e2e/config-loading.test.ts
+++ b/test-e2e/config-loading.test.ts
@@ -1,7 +1,9 @@
 import { test, expect } from './fixtures/config-test-fixtures.js'
 import { getConfig, setConfig } from './fixtures/set-sw-config.js'
 import { waitForServiceWorker } from './fixtures/wait-for-service-worker.js'
+import { compressConfig } from '../src/lib/config-db.js'
 import type { ConfigDbWithoutPrivateFields } from '../src/lib/config-db.js'
+import type { Response as PlaywrightResponse } from 'playwright'
 
 test.describe('ipfs-sw configuration', () => {
   const testConfig: ConfigDbWithoutPrivateFields = {
@@ -72,4 +74,54 @@ test.describe('ipfs-sw configuration', () => {
 
     expect(serviceWorkerConfigJson).toMatchObject(testConfig)
   })
+
+  test('config can be injected from an untrusted source', async ({ page, baseURL, rootDomain, protocol }) => {
+    const newConfig: ConfigDbWithoutPrivateFields = {
+      ...testConfig,
+      gateways: [
+        ...testConfig.gateways,
+        'https://malicious.com'
+      ],
+      routers: [
+        ...testConfig.routers,
+        'https://malicious.com/routing/v1'
+      ],
+      dnsJsonResolvers: {
+        ...testConfig.dnsJsonResolvers,
+        '.': 'https://malicious.com/dns-query'
+      },
+      fetchTimeout: 1 * 1000,
+      debug: 'foobar123',
+      enableWss: !testConfig.enableWss,
+      enableWebTransport: !testConfig.enableWebTransport,
+      enableRecursiveGateways: !testConfig.enableRecursiveGateways,
+      enableGatewayProviders: !testConfig.enableGatewayProviders
+    }
+    const compressedConfig = await compressConfig(newConfig)
+    const responses: PlaywrightResponse[] = []
+    page.on('response', (response) => {
+      responses.push(response)
+    })
+    await page.goto(`${protocol}//bafkqablimvwgy3y.ipfs.${rootDomain}/?ipfs-sw-cfg=${compressedConfig}`)
+    await waitForServiceWorker(page, `${protocol}//bafkqablimvwgy3y.ipfs.${rootDomain}`)
+    await page.waitForLoadState('networkidle')
+
+    // we injected the config and were never redirected to the root domain
+    expect(responses.map(r => r.url())).not.toContain(`${protocol}//${rootDomain}/`)
+
+    const config = await getConfig({ page })
+    // malicious urls should not exist in the config
+    expect(config.gateways).not.toContain('https://malicious.com')
+    expect(config.routers).not.toContain('https://malicious.com/routing/v1')
+    expect(config.dnsJsonResolvers).not.toContain('https://malicious.com/dns-query')
+
+    // things we allow to be overridden are overridden
+    expect(config.fetchTimeout).toBe(newConfig.fetchTimeout)
+    expect(config.debug).toBe(newConfig.debug)
+    expect(config.enableWss).toBe(newConfig.enableWss)
+    expect(config.enableWebTransport).toBe(newConfig.enableWebTransport)
+    expect(config.enableRecursiveGateways).toBe(newConfig.enableRecursiveGateways)
+    expect(config.enableGatewayProviders).toBe(newConfig.enableGatewayProviders)
+  })
+
 })


### PR DESCRIPTION
- **fix: allow injection of trustless config**
- **test: ensure injected config works as expected**

## Title

<!---
The title of the PR will be the commit message of the merge commit, so please make sure it is descriptive enough.
We utilize the Conventional Commits specification for our commit messages. See <https://www.conventionalcommits.org/en/v1.0.0/#specification> for more information.
The commit tag types can be of one of the following: feat, fix, deps, refactor, chore, docs. See <https://github.com/ipfs/helia/blob/main/.github/workflows/main.yml#L184-L192>
The title must also be fewer than 72 characters long or it will fail the Semantic PR check. See <https://github.com/ipfs/helia/blob/main/.github/workflows/semantic-pull-request.yml>
--->

fix: allow injection of trustless config

## Description

<!--
Please write a summary of your changes and why you made them.
Please include any relevant issues in here, for example:
Related https://github.com/ipfs/helia/issues/ABCD.
Fixes https://github.com/ipfs/helia/issues/XYZ.
-->

Allows injection of config that is considered untrusted, but only overrides settings that are allowed to be overridden.

We do not allow injection of URLs if the config is considered untrusted.

See discussion at https://github.com/ipfs/helia/discussions/824 for more details


## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

This PR also removes the dependency on lz-string, reducing initial javascript loaded by about 10kb, but increases size of the `ipfs-sw-cfg` content by about 200 bytes. This should result in a net reduction in bandwidth usage.

* bandwidth used *was* +10kb for every new subdomain + 10kb for uncached root domain js.
* bandwidth used *is* now _reduced_ by 10kb-200bytes for every new subdomain after redirect dance, -10kb for any uncached root domain js

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
