### PR TITLE
fix: internal error page styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,12 @@ The main goals of this project are:
 You can build and run the project locally:
 
 ```console
-> npm ci
+> npm i
+> npm run build
 > npm start
 ```
 
-Now open your browser and go to `http://localhost:3333`
+Now open your browser and go to `http://localhost:3000`
 
 Below is an explanation of the different URLs and what they do:
 
@@ -137,4 +138,3 @@ This project is dual-licensed under
 `SPDX-License-Identifier: Apache-2.0 OR MIT`
 
 See [LICENSE](./LICENSE) for more details.
-

--- a/public/ipfs-sw-504.html
+++ b/public/ipfs-sw-504.html
@@ -104,7 +104,8 @@ This file is used to display a 504 error page when a gateway timeout occurs.
             $anchor.classList.add('dib')
           }
         }
-        checkUrl()
+      }
+      checkUrl()
     </script>
 </body>
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -41,10 +41,11 @@ async function renderUi (): Promise<void> {
 
   const LazyConfig = React.lazy(async () => import('./pages/config.jsx'))
   const LazyHelperUi = React.lazy(async () => import('./pages/helper-ui.jsx'))
-  const LazyServiceWorkerErrorPage = React.lazy(async () => import('./pages/errors/no-service-worker.jsx'))
+  const LazyNoServiceWorkerErrorPage = React.lazy(async () => import('./pages/errors/no-service-worker.jsx'))
   const LazySubdomainWarningPage = React.lazy(async () => import('./pages/subdomain-warning.jsx'))
 
-  let ErrorPage: null | React.LazyExoticComponent<() => ReactElement> = LazyServiceWorkerErrorPage
+  let ErrorPage: null | React.LazyExoticComponent<() => ReactElement> = LazyNoServiceWorkerErrorPage
+
   if ('serviceWorker' in navigator) {
     ErrorPage = null
   }
@@ -52,7 +53,7 @@ async function renderUi (): Promise<void> {
   const routes: Route[] = [
     { default: true, component: ErrorPage ?? LazyHelperUi },
     { shouldRender: async () => renderChecks.shouldRenderConfigPage(), component: LazyConfig },
-    { shouldRender: async () => renderChecks.shouldRenderNoServiceWorkerError(), component: LazyServiceWorkerErrorPage },
+    { shouldRender: async () => renderChecks.shouldRenderNoServiceWorkerError(), component: LazyNoServiceWorkerErrorPage },
     { shouldRender: renderChecks.shouldRenderSubdomainWarningPage, component: LazySubdomainWarningPage }
   ]
 

--- a/src/button.tsx
+++ b/src/button.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import type { PropsWithChildren, ReactElement } from 'react'
+
+export interface ButtonProps extends PropsWithChildren {
+  onClick: any
+  className?: string
+}
+
+export function Button ({ onClick, className, children }: ButtonProps): ReactElement {
+  return (
+    <>
+      <button className={`button bn br2 mr2 pa2 pl3 pr3 snow-muted ${className ?? ''}`} onClick={onClick}>{children}</button>
+    </>
+  )
+}

--- a/src/components/content-box.tsx
+++ b/src/components/content-box.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import type { PropsWithChildren, ReactElement } from 'react'
+
+export interface ContentBoxProps extends PropsWithChildren {
+  title: string
+}
+
+export default function ContentBox ({ title, children }: ContentBoxProps): ReactElement {
+  return (
+    <main className='ma3 br2 ba sans-serif ba br2 b--gray-muted'>
+      <header className='pt2 pb2 pl3 pr3 bg-snow bb b--gray-muted'>
+        <strong>{title}</strong>
+      </header>
+      <section className='pt2 pb2 pl3 pr3 bg-white'>
+        {children}
+      </section>
+    </main>
+  )
+}

--- a/src/components/terminal.tsx
+++ b/src/components/terminal.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import type { PropsWithChildren, ReactElement } from 'react'
+
+export default function Terminal ({ children }: PropsWithChildren): ReactElement {
+  return (
+    <pre className='terminal br2 ma2 pa3 snow-muted'>
+      {children}
+    </pre>
+  )
+}

--- a/src/internal-error.tsx
+++ b/src/internal-error.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import { hydrateRoot } from 'react-dom/client'
+import { InternalErrorPage } from './pages/errors/internal-error.jsx'
+import { Page } from './pages/page.js'
+
+hydrateRoot(document, (
+  <>
+    <Page>
+      <InternalErrorPage />
+    </Page>
+  </>
+))

--- a/src/ipfs-sw-first-hit.ts
+++ b/src/ipfs-sw-first-hit.ts
@@ -1,16 +1,19 @@
 /**
- * This script is injected into the ipfs-sw-first-hit.html file. This was added when addressing an issue with redirects not preserving query parameters.
+ * This script is injected into the ipfs-sw-first-hit.html file. This was added
+ * when addressing an issue with redirects not preserving query parameters.
  *
- * The solution we're moving forward with is, instead of using 302 redirects with ipfs _redirects file, we are
- * using 200 responses with the ipfs-sw-first-hit.html file. That file will include the ipfs-sw-first-hit.js script
- * which will be injected into the index.html file, and handle the redirect logic for us.
+ * The solution we're moving forward with is, instead of using 302 redirects
+ * with ipfs _redirects file, we are using 200 responses with the
+ * ipfs-sw-first-hit.html file. That file will include the ipfs-sw-first-hit.js
+ * script which will be injected into the index.html file, and handle the
+ * redirect logic for us.
  *
  * It handles the logic for the first hit to the service worker and should only
  * ever run when _redirects file redirects to ipfs-sw-first-hit.html for /ipns
  * or /ipfs paths when the service worker is not yet intercepting requests.
  *
- * Sometimes, redirect solutions do not support redirecting directly to this page, in which case it should be handled
- * by index.tsx instead.
+ * Sometimes, redirect solutions do not support redirecting directly to this
+ * page, in which case it should be handled by index.tsx instead.
  *
  * @see https://github.com/ipfs/service-worker-gateway/issues/628
  */

--- a/src/lib/path-or-subdomain.ts
+++ b/src/lib/path-or-subdomain.ts
@@ -36,7 +36,7 @@ export const findOriginIsolationRedirect = async (location: Pick<Location, 'prot
       log?.trace('subdomain support is disabled')
     }
   }
-  log?.trace('no need to check for subdomain support', isPathGatewayRequest(location), isSubdomainGatewayRequest(location))
+  log?.trace('no need to check for subdomain support - is path gateway request %s, is subdomain gateway request %s', isPathGatewayRequest(location), isSubdomainGatewayRequest(location))
   return null
 }
 

--- a/src/pages/default-page-styles.css
+++ b/src/pages/default-page-styles.css
@@ -1,5 +1,50 @@
 @import 'tachyons';
 @import 'ipfs-css';
 
+body {
+  --navy: #0b3a53;
+  --navy-muted: #244e66;
+  --aqua: #69c4cd;
+  --aqua-muted: #9ad4db;
+  --gray: #b7bbc8;
+  --gray-muted: #d9dbe2;
+  --charcoal: #34373f;
+  --charcoal-muted: #7f8491;
+  --red: #ea5037;
+  --red-muted: #f36149;
+  --yellow: #f39021;
+  --yellow-muted: #f9a13e;
+  --teal: #378085;
+  --teal-muted: #439a9d;
+  --green: #0cb892;
+  --green-muted: #0aca9f;
+  --snow: #edf0f4;
+  --snow-muted: #f7f8fa;
+  --link: #117eb3;
+  --washed-blue: #F0F6FA;
+  --steel-gray: #3f5667;
+}
+
 /* ensure we don't fetch any external fonts */
-.sans-serif { font-family: system-ui, sans-serif; }
+.sans-serif {
+  font-family: system-ui, sans-serif;
+}
+
+.button {
+  display: inline-block;
+  cursor: pointer;
+}
+
+.button:hover {
+  background-color: var(--navy);
+}
+
+.terminal {
+  background-color: var(--steel-gray);
+  overflow: scroll;
+}
+
+.link:hover {
+  text-decoration: underline;
+  color: var(--aqua-muted);
+}

--- a/src/pages/errors/internal-error.tsx
+++ b/src/pages/errors/internal-error.tsx
@@ -72,10 +72,10 @@ export function InternalErrorPage ({ error, response, config }: InternalErrorPag
       <ContentBox title='Internal Error'>
         <>
           <p>An error occurred in the service worker gateway.</p>
-          <p>Please <a href='https://github.com/ipfs/service-worker-gateway/issues' className='link' target='_blank' rel='noopener noreferrer'>open an issue</a> and include the URL you tried to access and any debugging information displayed below.</p>
+          <p>Please <a href='https://github.com/ipfs/service-worker-gateway/issues' className='link' target='_blank' rel='noopener noreferrer'>open an issue</a> with the URL you tried to access and any debugging information displayed below.</p>
           <p>
-            <Button className='bg-navy-muted' onClick={goBack}>Go back</Button>
             <Button className='bg-teal' onClick={retry}>Retry</Button>
+            <Button className='bg-navy-muted' onClick={goBack}>Go back</Button>
           </p>
           {errorDisplay}
           {responseDisplay}

--- a/src/pages/errors/internal-error.tsx
+++ b/src/pages/errors/internal-error.tsx
@@ -1,0 +1,87 @@
+/**
+ * Page to display a user friendly message when `navigator.serviceWorker` is not available.
+ */
+
+import React from 'react'
+import { Button } from '../../button.jsx'
+import Header from '../../components/Header.jsx'
+import ContentBox from '../../components/content-box.jsx'
+import Terminal from '../../components/terminal.jsx'
+import type { ReactElement } from 'react'
+
+declare global {
+  var props: any
+}
+
+export interface InternalErrorPageProps {
+  error?: any,
+  response?: any
+  config?: any
+}
+
+export function InternalErrorPage ({ error, response, config }: InternalErrorPageProps): ReactElement {
+  function retry (): void {
+    // @ts-expect-error boolean argument is firefox-only
+    window.location.reload(true)
+  }
+
+  function goBack (): void {
+    window.history.back()
+  }
+
+  error = error ?? globalThis.props?.error
+  response = response ?? globalThis.props?.response
+  config = config ?? globalThis.props?.config
+
+  let errorDisplay = <></>
+
+  if (error != null) {
+    errorDisplay = (
+      <>
+        <h3>Error</h3>
+        <Terminal>{error.stack ?? error.message ?? error.toString()}</Terminal>
+      </>
+    )
+  }
+
+  let responseDisplay = <></>
+
+  if (response != null) {
+    responseDisplay = (
+      <>
+        <h3>Response</h3>
+        <Terminal>{JSON.stringify(response, null, 2)}</Terminal>
+      </>
+    )
+  }
+
+  let configDisplay = <></>
+
+  if (config != null) {
+    configDisplay = (
+      <>
+        <h3>Configuration</h3>
+        <Terminal>{JSON.stringify(config, null, 2)}</Terminal>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <Header />
+      <ContentBox title='Internal Error'>
+        <>
+          <p>An error occurred in the service worker gateway.</p>
+          <p>Please <a href='https://github.com/ipfs/service-worker-gateway/issues' className='link' target='_blank' rel='noopener noreferrer'>open an issue</a> and include the URL you tried to access and any debugging information displayed below.</p>
+          <p>
+            <Button className='bg-navy-muted' onClick={goBack}>Go back</Button>
+            <Button className='bg-teal' onClick={retry}>Retry</Button>
+          </p>
+          {errorDisplay}
+          {responseDisplay}
+          {configDisplay}
+        </>
+      </ContentBox>
+    </>
+  )
+}

--- a/src/pages/page.tsx
+++ b/src/pages/page.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import type { PropsWithChildren, ReactElement } from 'react'
+
+declare global {
+  var props: any
+}
+
+export interface PageProps extends PropsWithChildren {
+  title?: string
+  stylesheet?: string
+  script?: string
+}
+
+export function Page ({ title, stylesheet, script, children }: PageProps): ReactElement {
+  title = title ?? globalThis.props?.title
+  stylesheet = stylesheet ?? globalThis.props?.stylesheet
+  script = script ?? globalThis.props?.script
+
+  return (
+    <html lang='en'>
+      <head>
+        <meta charSet='utf-8' />
+        <meta name='viewport' content='width=device-width, initial-scale=1.0' />
+        <link rel='shortcut icon' href='data:image/x-icon;base64,AAABAAEAEBAAAAEAIABoBAAAFgAAACgAAAAQAAAAIAAAAAEAIAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAlo89/56ZQ/8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACUjDu1lo89/6mhTP+zrVP/nplD/5+aRK8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHNiIS6Wjz3/ubFY/761W/+vp1D/urRZ/8vDZf/GvmH/nplD/1BNIm8AAAAAAAAAAAAAAAAAAAAAAAAAAJaPPf+knEj/vrVb/761W/++tVv/r6dQ/7q0Wf/Lw2X/y8Nl/8vDZf+tpk7/nplD/wAAAAAAAAAAAAAAAJaPPf+2rVX/vrVb/761W/++tVv/vrVb/6+nUP+6tFn/y8Nl/8vDZf/Lw2X/y8Nl/8G6Xv+emUP/AAAAAAAAAACWjz3/vrVb/761W/++tVv/vrVb/761W/+vp1D/urRZ/8vDZf/Lw2X/y8Nl/8vDZf/Lw2X/nplD/wAAAAAAAAAAlo89/761W/++tVv/vrVb/761W/++tVv/r6dQ/7q0Wf/Lw2X/y8Nl/8vDZf/Lw2X/y8Nl/56ZQ/8AAAAAAAAAAJaPPf++tVv/vrVb/761W/++tVv/vbRa/5aPPf+emUP/y8Nl/8vDZf/Lw2X/y8Nl/8vDZf+emUP/AAAAAAAAAACWjz3/vrVb/761W/++tVv/vrVb/5qTQP+inkb/op5G/6KdRv/Lw2X/y8Nl/8vDZf/Lw2X/nplD/wAAAAAAAAAAlo89/761W/++tVv/sqlS/56ZQ//LxWb/0Mlp/9DJaf/Kw2X/oJtE/7+3XP/Lw2X/y8Nl/56ZQ/8AAAAAAAAAAJaPPf+9tFr/mJE+/7GsUv/Rymr/0cpq/9HKav/Rymr/0cpq/9HKav+xrFL/nplD/8vDZf+emUP/AAAAAAAAAACWjz3/op5G/9HKav/Rymr/0cpq/9HKav/Rymr/0cpq/9HKav/Rymr/0cpq/9HKav+inkb/nplD/wAAAAAAAAAAAAAAAKKeRv+3slb/0cpq/9HKav/Rymr/0cpq/9HKav/Rymr/0cpq/9HKav+1sFX/op5G/wAAAAAAAAAAAAAAAAAAAAAAAAAAop5GUKKeRv/Nxmf/0cpq/9HKav/Rymr/0cpq/83GZ/+inkb/op5GSAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAop5G16KeRv/LxWb/y8Vm/6KeRv+inkaPAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAop5G/6KeRtcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/n8AAPgfAADwDwAAwAMAAIABAACAAQAAgAEAAIABAACAAQAAgAEAAIABAACAAQAAwAMAAPAPAAD4HwAA/n8AAA==' />
+        <title>{title}</title>
+        <link rel='stylesheet' href={stylesheet} />
+      </head>
+      <body className='san-serif charcoal'>
+        {children}
+        <script type='text/javascript' src={script} />
+      </body>
+    </html>
+  )
+}

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -709,7 +709,7 @@ async function errorPageResponse (fetchResponse: Response): Promise<Response> {
   // inject props as a page global
   const script = `<script type="text/javascript">globalThis.props = ${JSON.stringify(props, null, 2)}</script>`
 
-  const string = renderToString(
+  const string = '<!DOCTYPE html>\n' + renderToString(
     Page({
       ...props,
       children: InternalErrorPage(props)

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -1,3 +1,4 @@
+import { renderToString } from 'react-dom/server'
 import { getConfig } from './lib/config-db.js'
 import { HASH_FRAGMENTS, QUERY_PARAMS } from './lib/constants.js'
 import { getHeliaSwRedirectUrl } from './lib/first-hit-helpers.js'
@@ -9,6 +10,8 @@ import { isConfigPage } from './lib/is-config-page.js'
 import { swLogger } from './lib/logger.js'
 import { findOriginIsolationRedirect, isPathGatewayRequest, isSubdomainGatewayRequest } from './lib/path-or-subdomain.js'
 import { isUnregisterRequest } from './lib/unregister-request.js'
+import { InternalErrorPage } from './pages/errors/internal-error.jsx'
+import { Page } from './pages/page.jsx'
 import type { ConfigDb } from './lib/config-db.js'
 import type { VerifiedFetch } from '@helia/verified-fetch'
 
@@ -31,7 +34,7 @@ interface FetchHandlerArg {
   event: FetchEvent
 }
 
-interface StoreReponseInCacheOptions {
+interface StoreResponseInCacheOptions {
   response: Response
   cacheKey: string
   isMutable: boolean
@@ -177,6 +180,7 @@ self.addEventListener('fetch', (event) => {
   const request = event.request
   const urlString = request.url
   const url = new URL(urlString)
+
   if (firstInstallTime == null) {
     // if service worker is shut down, the firstInstallTime may be null
     log('firstInstallTime is null, getting install timestamp')
@@ -197,8 +201,10 @@ self.addEventListener('fetch', (event) => {
               log('Service worker registration TTL expired, unregistering after response consumed')
             }).finally(() => self.registration.unregister())
           )
+
           return response
         }
+
         return response
       }))
     } else {
@@ -218,15 +224,19 @@ async function requestRouting (event: FetchEvent, url: URL): Promise<boolean> {
     event.respondWith(new Response('Service worker unregistered', {
       status: 200
     }))
+
     return false
   } else if (isSubdomainConfigRequest(event)) {
     log.trace('subdomain config request, ignoring and letting index.html handle it', event.request.url)
+
     return false
   } else if (isConfigPageRequest(url)) {
     log.trace('config page request, ignoring ', event.request.url)
+
     return false
   } else if (isSwConfigReloadRequest(event)) {
     log.trace('sw-config reload request, updating verifiedFetch')
+
     // Wait for the update to complete before sending response
     event.respondWith(
       updateVerifiedFetch()
@@ -243,6 +253,7 @@ async function requestRouting (event: FetchEvent, url: URL): Promise<boolean> {
           })
         })
     )
+
     return false
   } else if (isAcceptOriginIsolationWarningRequest(event)) {
     event.waitUntil(setOriginIsolationWarningAccepted().then(() => {
@@ -250,6 +261,7 @@ async function requestRouting (event: FetchEvent, url: URL): Promise<boolean> {
     }).catch((err) => {
       log.error('origin isolation warning accepted, error', err)
     }))
+
     return false
   } else if (isSwConfigGETRequest(event)) {
     // TODO: remove? I don't think we need this anymore.
@@ -263,6 +275,7 @@ async function requestRouting (event: FetchEvent, url: URL): Promise<boolean> {
         }
       }))
     }))
+
     return false
   } else if (isSwAssetRequest(event)) {
     log.trace('sw-asset request, returning cached response ', event.request.url)
@@ -272,17 +285,21 @@ async function requestRouting (event: FetchEvent, url: URL): Promise<boolean> {
     event.respondWith(caches.open(CURRENT_CACHES.swAssets).then(async (cache) => {
       try {
         const cachedResponse = await cache.match(event.request)
+
         if (cachedResponse != null) {
           return cachedResponse
         }
       } catch (err) {
         log.error('error matching cached response', err)
       }
+
       let response: Response
+
       try {
         response = await fetch(event.request)
       } catch (err) {
         log.error('error fetching response', err)
+
         return new Response('No response', {
           status: 500,
           headers: {
@@ -290,6 +307,7 @@ async function requestRouting (event: FetchEvent, url: URL): Promise<boolean> {
           }
         })
       }
+
       try {
         await cache.put(event.request, response.clone())
         return response
@@ -298,6 +316,7 @@ async function requestRouting (event: FetchEvent, url: URL): Promise<boolean> {
       }
       return response
     }))
+
     return false
   } else if (!isValidRequestForSW(event)) {
     log.trace('not a valid request for helia-sw, ignoring ', event.request.url)
@@ -417,7 +436,7 @@ async function fetchAndUpdateCache (event: FetchEvent, url: URL, cacheKey: strin
   log('response status: %s', response.status)
 
   try {
-    await storeReponseInCache({ response, isMutable: true, cacheKey, event })
+    await storeResponseInCache({ response, isMutable: true, cacheKey, event })
     log.trace('updated cache for %s', cacheKey)
   } catch (err) {
     log.error('failed updating response in cache for %s', cacheKey, err)
@@ -470,7 +489,7 @@ function shouldCacheResponse ({ event, response }: { event: FetchEvent, response
   return true
 }
 
-async function storeReponseInCache ({ response, isMutable, cacheKey, event }: StoreReponseInCacheOptions): Promise<void> {
+async function storeResponseInCache ({ response, isMutable, cacheKey, event }: StoreResponseInCacheOptions): Promise<void> {
   if (!shouldCacheResponse({ event, response })) {
     return
   }
@@ -543,7 +562,7 @@ async function fetchHandler ({ path, request, event }: FetchHandlerArg): Promise
   headers.forEach((value, key) => {
     log.trace('fetchHandler: request headers: %s: %s', key, value)
   })
-  log('verifiedFetch for ', event.request.url)
+  log('verifiedFetch for %s', event.request.url)
 
   /**
    * Note that there are existing bugs regarding service worker signal handling:
@@ -678,37 +697,26 @@ async function errorPageResponse (fetchResponse: Response): Promise<Response> {
   mergedHeaders.set('Content-Type', 'text/html')
   mergedHeaders.set('ipfs-sw', 'true')
 
-  return new Response(`<!DOCTYPE html>
-    <html>
-      <head>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>Error - Service Worker IPFS Gateway</title>
-      </head>
-      <body>
-        <div id="root" class="sans-serif f5">
-          <h1>Oops! Something went wrong inside of Service Worker IPFS Gateway.</h1>
-          <p>
-            <button onclick="window.history.back();">Go back</button>
-            <button onclick="window.location.reload(true);">Click here to retry</button>
-          </p>
-          <p>
-            <h2>Error details:</h2>
-            <p><b>Message: </b>${json.error.message}</p>
-            <b>Stacktrace: </b><pre>${json.error.stack}</pre>
-          </p>
-          <p>
-            <h2>Response details:</h2>
-            <h3>${responseDetails.status} ${responseDetails.statusText}</h3>
-            <pre>${JSON.stringify(responseDetails, null, 2)}</pre>
-          </p>
-          <p>
-            <h2>Service worker details:</h2>
-            <pre>${JSON.stringify(await getServiceWorkerDetails(), null, 2)}</pre>
-          </p>
-        </div>
-      </body>
-    </html>`, {
+  const props = {
+    response: responseDetails,
+    error: json.error,
+    config: await getServiceWorkerDetails(),
+    title: responseDetails.statusText,
+    stylesheet: '<%-- src/app.css --%>',
+    script: '<%-- src/internal-error.tsx --%>'
+  }
+
+  // inject props as a page global
+  const script = `<script type="text/javascript">globalThis.props = ${JSON.stringify(props, null, 2)}</script>`
+
+  const string = renderToString(
+    Page({
+      ...props,
+      children: InternalErrorPage(props)
+    })
+  ).replace('</head>', `${script}</head>`)
+
+  return new Response(string, {
     status: fetchResponse.status,
     statusText: fetchResponse.statusText,
     headers: mergedHeaders

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,9 +9,7 @@
     "jsx": "preserve",
     "lib": ["WebWorker", "ES6", "DOM"],
     "strictNullChecks": true,
-
     "moduleResolution": "bundler",
-
     "ignoreDeprecations": "5.0" // needed due to deprecated usage in tsconfig.aegir.json
   },
   "include": [
@@ -20,6 +18,7 @@
     "test",
     "test-e2e",
     "playwright.config.js",
-    "serve.ts"
+    "serve.ts",
+    "dist/ipfs-sw-build-config.js"
   ]
 }


### PR DESCRIPTION
Adds styling to the internal error page to bring it closer to the boxo gateway.

Before:

<img width="1244" height="1726" alt="Image" src="https://github.com/user-attachments/assets/25539d33-3a62-4c08-8d3a-b920e2b47a93" />

After:

<img width="825" height="687" alt="image" src="https://github.com/user-attachments/assets/7a6e5b54-cecf-461b-87f1-6687980ae6fd" />

Refs #875

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
