### PR TITLE
fix: strip root hash from URL on error page

### DIFF
--- a/src/lib/remove-root-hash.ts
+++ b/src/lib/remove-root-hash.ts
@@ -1,0 +1,13 @@
+/**
+ * Error pages live on the page root but React's HashRouter makes the page hash
+ * "#/" which can interfere with CTRL+R-style page reloads so remove the hash
+ * without causing a page reload so we are on a bare URL.
+ */
+export function removeRootHashIfPresent (): void {
+  if (window.location.hash === '#/') {
+    // const base = document.querySelector('base');
+    // base?.setAttribute('href', '');
+    // remove any UI-added navigation info
+    history.pushState('', document.title, window.location.pathname + window.location.search)
+  }
+}

--- a/src/pages/fetch-error.tsx
+++ b/src/pages/fetch-error.tsx
@@ -4,6 +4,7 @@ import ContentBox from '../components/content-box.jsx'
 import { Link } from '../components/link.jsx'
 import Terminal from '../components/terminal.jsx'
 import { HASH_FRAGMENTS } from '../lib/constants.js'
+import { removeRootHashIfPresent } from '../lib/remove-root-hash.js'
 import { toGatewayRoot } from '../lib/to-gateway-root.js'
 import type { ConfigDb } from '../lib/config-db.js'
 import type { RequestDetails, ResponseDetails } from '../sw/fetch-error-page.js'
@@ -166,6 +167,8 @@ export function FetchErrorPage ({ request, response, config, logs, providers }: 
       <></>
     )
   }
+
+  removeRootHashIfPresent()
 
   const defaultShowDebugInfo = response.status === 500
 

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -6,9 +6,12 @@ import { dnsLinkLabelDecoder, isInlinedDnsLink } from '../lib/dns-link-labels.js
 import { LOCAL_STORAGE_KEYS } from '../lib/local-storage.js'
 import './default-page-styles.css'
 import { pathRegex, subdomainRegex } from '../lib/regex.js'
+import { removeRootHashIfPresent } from '../lib/remove-root-hash.js'
 import type { ReactElement } from 'react'
 
 function LoadContent (): ReactElement {
+  removeRootHashIfPresent()
+
   let initialPath = localStorage.getItem(LOCAL_STORAGE_KEYS.forms.requestPath) ?? ''
 
   if (initialPath === '') {

--- a/src/pages/origin-isolation-warning.tsx
+++ b/src/pages/origin-isolation-warning.tsx
@@ -3,6 +3,7 @@ import { ServiceWorkerReadyButton } from '../components/sw-ready-button.jsx'
 import { ConfigContext } from '../context/config-context.jsx'
 import { QUERY_PARAMS } from '../lib/constants.js'
 import './default-page-styles.css'
+import { removeRootHashIfPresent } from '../lib/remove-root-hash.js'
 import { toGatewayRoot } from '../lib/to-gateway-root.js'
 import type { ReactNode } from 'react'
 
@@ -54,6 +55,8 @@ export default function SubdomainWarningPage (): ReactNode {
       <></>
     )
   }
+
+  removeRootHashIfPresent()
 
   const [isSaving, setIsSaving] = useState(false)
   const configContext = useContext(ConfigContext)

--- a/src/pages/server-error.tsx
+++ b/src/pages/server-error.tsx
@@ -3,6 +3,7 @@ import { Button } from '../button.jsx'
 import ContentBox from '../components/content-box.jsx'
 import { Link } from '../components/link.jsx'
 import Terminal from '../components/terminal.jsx'
+import { removeRootHashIfPresent } from '../lib/remove-root-hash.js'
 import { toGatewayRoot } from '../lib/to-gateway-root.js'
 import type { ReactElement } from 'react'
 
@@ -94,6 +95,8 @@ export function ServerErrorPage ({ url, error, title, logs }: ServerErrorPagePro
       <></>
     )
   }
+
+  removeRootHashIfPresent()
 
   function retry (): void {
     // remove any UI-added navigation info

--- a/test-e2e/first-hit.test.ts
+++ b/test-e2e/first-hit.test.ts
@@ -18,7 +18,7 @@ test.describe('first-hit ipfs-hosted', () => {
       }
     })
 
-    test('redirects are handled', async ({ page }) => {
+    test('loads the index page from the root when an path is present', async ({ page }) => {
       const response = await page.goto('http://127.0.0.1:3334/ipfs/bafkqablimvwgy3y', {
         waitUntil: 'networkidle'
       })
@@ -27,9 +27,7 @@ test.describe('first-hit ipfs-hosted', () => {
       expect(response?.status()).toBe(200)
       const headers = await response?.allHeaders()
 
-      // we redirect to the root path with query param so sw can be registered at the root path
-      await expect(page).toHaveURL('http://127.0.0.1:3334/ipfs/bafkqablimvwgy3y#/ipfs-sw-origin-isolation-warning')
-
+      // accept the warning
       await handleOriginIsolationWarning(page)
 
       expect(headers?.['content-type']).toContain('text/html')

--- a/test-e2e/origin-isolation-warning.test.ts
+++ b/test-e2e/origin-isolation-warning.test.ts
@@ -1,4 +1,3 @@
-import { HASH_FRAGMENTS } from '../src/lib/constants.js'
 import { testPathRouting as test, expect } from './fixtures/config-test-fixtures.js'
 import { handleOriginIsolationWarning } from './fixtures/handle-origin-isolation-warning.js'
 
@@ -8,15 +7,9 @@ test.describe('origin isolation warning', () => {
       waitUntil: 'networkidle'
     })
     const testUrl = 'http://127.0.0.1:3333/ipfs/bafkqablimvwgy3y'
-    const testURL = new URL(testUrl)
     await page.goto(testUrl, {
       waitUntil: 'networkidle'
     })
-
-    const warningUrl = new URL(testURL)
-    warningUrl.hash = `/${HASH_FRAGMENTS.IPFS_SW_ORIGIN_ISOLATION_WARNING}`
-
-    await expect(page).toHaveURL(warningUrl.toString())
 
     // accept warning
     await handleOriginIsolationWarning(page)


### PR DESCRIPTION
To not interfere with `CTRL+R`-style page reloads, when we there is an error to be shown, ensure we are on the bare URL and not `#/`.

Fixes #817 though this was also partially handled by #906 and #902

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
