### PR TITLE
fix: ensure IPNS results go in the mutable cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@libp2p/interface": "^3.1.0",
     "@libp2p/keychain": "^6.0.7",
     "@libp2p/logger": "^6.2.0",
+    "@libp2p/peer-id": "^6.0.4",
     "@libp2p/ping": "^3.0.7",
     "@libp2p/websockets": "^10.1.0",
     "@libp2p/webtransport": "^6.0.9",

--- a/src/sw/handlers/config-reload-handler.ts
+++ b/src/sw/handlers/config-reload-handler.ts
@@ -5,7 +5,7 @@ import type { Handler } from './index.js'
 export const configReloadHandler: Handler = {
   name: 'config-reload-handler',
 
-  canHandle (url, event) {
+  canHandle (url) {
     return url.searchParams.has(QUERY_PARAMS.RELOAD_CONFIG)
   },
 

--- a/src/sw/handlers/config-update-handler.ts
+++ b/src/sw/handlers/config-update-handler.ts
@@ -6,7 +6,7 @@ import type { Handler } from './index.js'
 export const configUpdateHandler: Handler = {
   name: 'config-update-handler',
 
-  canHandle (url, event) {
+  canHandle (url) {
     return url.searchParams.has(QUERY_PARAMS.CONFIG)
   },
 

--- a/src/sw/handlers/unregister-handler.ts
+++ b/src/sw/handlers/unregister-handler.ts
@@ -10,7 +10,7 @@ export const unregisterHandler: Handler = {
     return isUnregisterRequest(event.request.url)
   },
 
-  handle (url: URL, event: FetchEvent) {
+  handle (url, event) {
     event.waitUntil(self.registration.unregister())
 
     return new Response('Service worker unregistered', {

--- a/src/sw/pages/fetch-error-page.ts
+++ b/src/sw/pages/fetch-error-page.ts
@@ -1,4 +1,4 @@
-import { APP_VERSION, GIT_REVISION } from '../../version.js'
+import { APP_NAME, APP_VERSION, GIT_REVISION } from '../../version.js'
 import { htmlPage } from './page.js'
 import type { ConfigDb } from '../../lib/config-db.js'
 import type { Providers as ErrorPageProviders } from '../../ui/pages/fetch-error.jsx'
@@ -112,8 +112,8 @@ export function fetchErrorPageResponse (resource: string, request: RequestInit, 
 
   const responseDetails = getResponseDetails(fetchResponse, responseBody)
   const mergedHeaders = new Headers(fetchResponse.headers)
-  mergedHeaders.set('Content-Type', 'text/html')
-  mergedHeaders.set('ipfs-sw', 'true')
+  mergedHeaders.set('content-type', 'text/html')
+  mergedHeaders.set('server', `${APP_NAME}/${APP_VERSION}#${GIT_REVISION}`)
 
   const props = {
     request: getRequestDetails(resource, request),

--- a/src/sw/pages/origin-isolation-warning-page.ts
+++ b/src/sw/pages/origin-isolation-warning-page.ts
@@ -1,3 +1,4 @@
+import { APP_NAME, APP_VERSION, GIT_REVISION } from '../../version.js'
 import { htmlPage } from './page.js'
 
 /**
@@ -13,7 +14,8 @@ export function originIsolationWarningPageResponse (location: string): Response 
     status: 307,
     statusText: 'Temporary Redirect',
     headers: {
-      'Content-Type': 'text/html'
+      'Content-Type': 'text/html',
+      Server: `${APP_NAME}/${APP_VERSION}#${GIT_REVISION}`
     }
   })
 }

--- a/src/sw/pages/server-error-page.ts
+++ b/src/sw/pages/server-error-page.ts
@@ -1,3 +1,4 @@
+import { APP_NAME, APP_VERSION, GIT_REVISION } from '../../version.js'
 import { htmlPage } from './page.js'
 
 function isAggregateError (obj?: any): obj is AggregateError {
@@ -21,9 +22,9 @@ function toErrorObject (error: any): any {
  */
 export function serverErrorPageResponse (url: URL, error: Error, logs: string[]): Response {
   const headers = new Headers()
-  headers.set('Content-Type', 'text/html')
-  headers.set('ipfs-sw', 'true')
+  headers.set('content-type', 'text/html')
   headers.set('x-debug-request-uri', url.toString())
+  headers.set('server', `${APP_NAME}/${APP_VERSION}#${GIT_REVISION}`)
 
   const props = {
     url: url.toString(),

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,3 @@
-export const APP_NAME = 'app-name'
-export const APP_VERSION = 'app-version'
-export const GIT_REVISION = 'git-revision'
+export const APP_NAME = '@helia/service-worker'
+export const APP_VERSION = '1.0.0'
+export const GIT_REVISION = 'HEAD'

--- a/test-e2e/fixtures/capture-all-sw-responses.ts
+++ b/test-e2e/fixtures/capture-all-sw-responses.ts
@@ -22,9 +22,10 @@ export async function * captureAllSwResponses (page: Page, signal: AbortSignal):
 
   // Set up the response listener
   const onResponse = (response: Response): void => {
-    if (response.headers()['ipfs-sw'] !== 'true') {
+    if (response.headers()['server']?.includes('@helia/service-worker') !== true) {
       return
     }
+
     if (resolveNext != null) {
       resolveNext(response)
       resolveNext = null

--- a/test-e2e/fixtures/config-test-fixtures.ts
+++ b/test-e2e/fixtures/config-test-fixtures.ts
@@ -121,7 +121,8 @@ export const testPathRouting = test.extend<TestOptions>({
       routers: [process.env.KUBO_GATEWAY],
       dnsJsonResolvers: {
         '.': 'https://delegated-ipfs.dev/dns-query'
-      }
+      },
+      debug: '*,*:trace'
     })
 
     await use(page)

--- a/test-e2e/fixtures/create-kubo-node.ts
+++ b/test-e2e/fixtures/create-kubo-node.ts
@@ -113,7 +113,7 @@ export async function createKuboNode (IPFS_NS_MAP?: string): Promise<KuboNode> {
         Gateway: {
           NoFetch: true,
           DeserializedResponses: true,
-          ExposeRoutingAPI: false,
+          ExposeRoutingAPI: true,
           HTTPHeaders: {
             'Access-Control-Allow-Origin': ['*'],
             'Access-Control-Allow-Methods': ['GET', 'POST', 'PUT', 'OPTIONS']

--- a/test-e2e/fixtures/has-cache-entry.ts
+++ b/test-e2e/fixtures/has-cache-entry.ts
@@ -1,0 +1,18 @@
+import type { Page } from 'playwright'
+
+export async function hasCacheEntry (page: Page, cacheName: string, key: string): Promise<boolean> {
+  return page.evaluate(async ({ cacheName, key }) => {
+    const cache = await caches.open(cacheName)
+
+    for (const req of await cache.keys()) {
+      if (req.url.includes(key)) {
+        return true
+      }
+    }
+
+    return false
+  }, {
+    cacheName,
+    key
+  })
+}

--- a/test-e2e/fixtures/load-with-service-worker.ts
+++ b/test-e2e/fixtures/load-with-service-worker.ts
@@ -1,0 +1,66 @@
+import { QUERY_PARAMS } from '../../src/lib/constants.js'
+import type { Page, Response } from 'playwright'
+
+export interface LoadWithServiceWorkerOptions {
+  /**
+   * Specify the final URL here, if different to `resource`
+   */
+  redirect?: string
+
+  /**
+   * See Playwright Page.goto args
+   */
+  referer?: string
+
+  /**
+   * SeemPlaywright Page.goto args
+   */
+  timeout?: number
+
+  /**
+   * See Playwright Page.goto args
+   */
+  waitUntil?: 'load' | 'domcontentloaded' | 'networkidle' | 'commit'
+}
+
+/**
+ * Navigates to the passed resource and waits for a response from the service
+ * worker that does not include a URL param to redirect to
+ */
+export async function loadWithServiceWorker (page: Page, resource: string, options?: LoadWithServiceWorkerOptions): Promise<Response> {
+  const expected = options?.redirect ?? resource
+
+  const [
+    response
+  ] = await Promise.all([
+    page.waitForResponse((response) => {
+      // ignore responses from the UI
+      // if (!response.fromServiceWorker()) {  <-- does not work in Firefox :(
+      if (response.headers()['server']?.includes('@helia/service-worker-gateway') !== true) {
+        return false
+      }
+
+      // ignore redirects by param
+      if (new URL(response.url()).searchParams.has(QUERY_PARAMS.REDIRECT)) {
+        return false
+      }
+
+      // ignore redirects by status
+      if (response.status() > 299 || response.status() < 200) {
+        return false
+      }
+
+      return response.url() === expected
+    }, options),
+    page.goto(resource, options)
+  ])
+
+  // not sure why this is necessary - the response has come from the service
+  // worker and is the URL we expect but it takes a little time for the page to
+  // catch up?
+  if (page.url() !== expected) {
+    await page.waitForURL(options?.redirect ?? resource, options)
+  }
+
+  return response
+}

--- a/test-e2e/global-setup.ts
+++ b/test-e2e/global-setup.ts
@@ -1,9 +1,8 @@
 import { enable } from '@libp2p/logger'
 import { serve } from '../serve.js'
-import type { Config } from '@playwright/test'
 
-export default async function globalSetup (config: Config): Promise<void> {
-  enable('kubo-init*,kubo-init*:trace,ipfs-host.local*,ipfs-host.local*:trace,serve*,serve*:trace')
+export default async function globalSetup (): Promise<void> {
+  enable('*,*:trace,-pw:*,-reverse-proxy*,-ipfs-gateway*')
 
   process.env.PLAYWRIGHT = 'true'
 

--- a/test-e2e/reverse-proxy.ts
+++ b/test-e2e/reverse-proxy.ts
@@ -5,7 +5,7 @@ import type { Server, ServerResponse, IncomingMessage, RequestOptions, OutgoingH
 
 const setCommonHeaders = (res: ServerResponse): void => {
   res.setHeader('Access-Control-Allow-Origin', '*')
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Range, User-Agent, X-Requested-With')
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Range, User-Agent, X-Requested-With, Server')
   res.setHeader('Access-Control-Allow-Methods', 'GET, HEAD, OPTIONS')
 }
 

--- a/test-e2e/video.test.ts
+++ b/test-e2e/video.test.ts
@@ -13,11 +13,8 @@ test.describe('video', () => {
   })
 
   const testConfig: Partial<ConfigDbWithoutPrivateFields> = {
-
     gateways: [process.env.KUBO_GATEWAY!],
-
     routers: [process.env.KUBO_GATEWAY!],
-    debug: '*,*:trace',
     enableWss: true,
     enableWebTransport: false,
     enableRecursiveGateways: true,


### PR DESCRIPTION
..and IPFS results go in the immutable cache.

Also improve redirect detection to only take the last few seconds into account.

Also add a `loadWithServiceWorker` function to ensure a page has a service worker loaded and that it has returned the requested resource.

This fixes a bug with the tests where IPNS resolution was broken but the tests pass because they assert on the status code being 200.  It was 200 because what was being tested was an interstitial page and not the final lookup result.

Also add a `Server` header to every service worker response so we can detect what served the request instead of the non-standard "ipfs-sw" header.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
