### PR TITLE
fix: support base16 CIDs and IPNS names

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     }
   },
   "dependencies": {
+    "@chainsafe/is-ip": "^2.1.0",
     "@chainsafe/libp2p-noise": "^17.0.0",
     "@chainsafe/libp2p-yamux": "^8.0.1",
     "@helia/block-brokers": "^5.0.7",

--- a/src/sw/handlers/content-request-handler.ts
+++ b/src/sw/handlers/content-request-handler.ts
@@ -13,6 +13,7 @@ import { getInstallTime } from '../lib/install-time.js'
 import { getVerifiedFetch } from '../lib/verified-fetch.js'
 import { fetchErrorPageResponse } from '../pages/fetch-error-page.js'
 import { originIsolationWarningPageResponse } from '../pages/origin-isolation-warning-page.js'
+import { serverErrorPageResponse } from '../pages/server-error-page.js'
 import type { Handler } from './index.js'
 import type { UrlParts } from '../../lib/get-subdomain-parts.js'
 import type { Providers } from '../index.js'
@@ -169,7 +170,15 @@ async function fetchHandler ({ url, event, logs, subdomainGatewayRequest, pathGa
           }
         })
       }
-    } catch {
+    } catch (err: any) {
+      // the user supplied an unparseable/incorrect path or key
+      if (err.name === 'InvalidParametersError') {
+        return serverErrorPageResponse(url, err, logs, {
+          title: '400 Bad Request',
+          status: 400
+        })
+      }
+
       // URL was invalid (may have been an IP address which can't be translated
       // to a subdomain gateway URL)
     }

--- a/src/sw/pages/server-error-page.ts
+++ b/src/sw/pages/server-error-page.ts
@@ -17,10 +17,26 @@ function toErrorObject (error: any): any {
   }
 }
 
+export interface ServerErrorPageResponseOptions {
+  /**
+   * HTTP status code
+   *
+   * @default 500
+   */
+  status?: number
+
+  /**
+   * Error title to show on page
+   *
+   * @default '500 Internal Server Error'
+   */
+  title?: string
+}
+
 /**
  * Shows an error page to the user
  */
-export function serverErrorPageResponse (url: URL, error: Error, logs: string[]): Response {
+export function serverErrorPageResponse (url: URL, error: Error, logs: string[], opts?: ServerErrorPageResponseOptions): Response {
   const headers = new Headers()
   headers.set('content-type', 'text/html')
   headers.set('x-debug-request-uri', url.toString())
@@ -29,14 +45,14 @@ export function serverErrorPageResponse (url: URL, error: Error, logs: string[])
   const props = {
     url: url.toString(),
     error: toErrorObject(error),
-    title: '500 Internal Server Error',
+    title: opts?.title ?? '500 Internal Server Error',
     logs
   }
 
   const page = htmlPage(props.title, 'serverError', props)
 
   return new Response(page, {
-    status: 500,
+    status: opts?.status ?? 500,
     headers
   })
 }

--- a/test-e2e/fixtures/load-with-service-worker.ts
+++ b/test-e2e/fixtures/load-with-service-worker.ts
@@ -46,7 +46,7 @@ export async function loadWithServiceWorker (page: Page, resource: string, optio
       }
 
       // ignore redirects by status
-      if (response.status() > 299 || response.status() < 200) {
+      if (response.status() > 299 && response.status() < 399) {
         return false
       }
 

--- a/test-e2e/smoke-test.test.ts
+++ b/test-e2e/smoke-test.test.ts
@@ -177,7 +177,6 @@ test.describe('smoke test', () => {
     const response = await loadWithServiceWorker(page, `${protocol}//${rootDomain}/ipfs/${asBase16}`, {
       redirect: `${protocol}//${cid}.ipfs.${rootDomain}/`
     })
-
     expect(response.status()).toBe(200)
     expect(await response.text()).toContain('hello')
   })
@@ -191,5 +190,13 @@ test.describe('smoke test', () => {
     })
     expect(response.status()).toBe(200)
     expect(await response.text()).toContain('hello')
+  })
+
+  test('errors on invalid CIDs', async ({ page, protocol, rootDomain }) => {
+    const cid = '!bafkqablimvwgy3y'
+
+    const response = await loadWithServiceWorker(page, `${protocol}//${rootDomain}/ipfs/${cid}`)
+    expect(response.status()).toBe(400)
+    expect(await response.text()).toContain('Could not parse CID')
   })
 })

--- a/test-e2e/smoke-test.test.ts
+++ b/test-e2e/smoke-test.test.ts
@@ -1,3 +1,6 @@
+import { peerIdFromString } from '@libp2p/peer-id'
+import { base16 } from 'multiformats/bases/base16'
+import { CID } from 'multiformats/cid'
 import { CURRENT_CACHES } from '../src/constants.js'
 import { HASH_FRAGMENTS } from '../src/lib/constants.js'
 import { testSubdomainRouting as test, expect } from './fixtures/config-test-fixtures.js'
@@ -165,5 +168,28 @@ test.describe('smoke test', () => {
     })
 
     expect(noServiceWorkerRegistration).toBe(true)
+  })
+
+  test('normalizes base16 CIDs to base32', async ({ page, protocol, rootDomain }) => {
+    const cid = 'bafkqablimvwgy3y'
+    const asBase16 = CID.parse(cid).toString(base16)
+
+    const response = await loadWithServiceWorker(page, `${protocol}//${rootDomain}/ipfs/${asBase16}`, {
+      redirect: `${protocol}//${cid}.ipfs.${rootDomain}/`
+    })
+
+    expect(response.status()).toBe(200)
+    expect(await response.text()).toContain('hello')
+  })
+
+  test('normalizes base16 IPNS names to base36', async ({ page, protocol, rootDomain }) => {
+    const key = 'k51qzi5uqu5dk3v4rmjber23h16xnr23bsggmqqil9z2gduiis5se8dht36dam'
+    const asBase16 = peerIdFromString(key).toCID().toString(base16)
+
+    const response = await loadWithServiceWorker(page, `${protocol}//${rootDomain}/ipns/${asBase16}`, {
+      redirect: `${protocol}//${key}.ipns.${rootDomain}/`
+    })
+    expect(response.status()).toBe(200)
+    expect(await response.text()).toContain('hello')
   })
 })


### PR DESCRIPTION
Adds support for decoding base16 keys from path gateway requests and normalizng them to base32 (for CIDs) or base36 (for IPNS names).

Also fixes a bug whereby we'd treat anything that didn't parse as a CID/PeerId as a DNSLink name, even `/ipfs/random-garbage`.

Fixes #745


## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
