### PR TITLE
fix: use home icon instead of download

### DIFF
--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import ReactDOMClient from 'react-dom/client'
 import './index.css'
-import { FaInfoCircle, FaCog, FaGithub, FaDownload, FaExclamationTriangle, FaExclamationCircle } from 'react-icons/fa'
+import { FaInfoCircle, FaCog, FaGithub, FaExclamationTriangle, FaExclamationCircle, FaHome } from 'react-icons/fa'
 import { HashRouter, Route, Routes, NavLink } from 'react-router-dom'
 import { Config } from '../lib/config-db.js'
 import { HASH_FRAGMENTS } from '../lib/constants.js'
@@ -80,7 +80,7 @@ function Header (): React.ReactElement {
         <h1 className='e2e-header-title f3 fw2 ttu sans-serif'>Service Worker Gateway</h1>
         {errorPageLink}
         <NavLink to={`/${HASH_FRAGMENTS.IPFS_SW_LOAD_UI}`} className={({ isActive }) => (isActive || (errorPageLink == null && globalThis.location.hash === '')) ? 'white' : ''}>
-          <FaDownload className='ml2 f3' />
+          <FaHome className='ml2 f3' />
         </NavLink>
         <NavLink to={`/${HASH_FRAGMENTS.IPFS_SW_ABOUT_UI}`} className={({ isActive }) => isActive ? 'white' : ''}>
           <FaInfoCircle className='ml2 f3' />


### PR DESCRIPTION
Use a more obvious icon.

<img width="491" height="229" alt="image" src="https://github.com/user-attachments/assets/43347545-762d-4fdc-8b6b-f5ab725ab670" />

Fixes #916

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
