### PR TITLE
chore: fix hamt test

### DIFF
--- a/test-e2e/fixtures/load-with-service-worker.ts
+++ b/test-e2e/fixtures/load-with-service-worker.ts
@@ -1,6 +1,9 @@
 import { QUERY_PARAMS } from '../../src/lib/constants.js'
 import type { Page, Response } from 'playwright'
 
+const ORIGIN_ISOLATION_WARNING = '.e2e-subdomain-warning'
+const ACCEPT_ORIGIN_ISOLATION_WARNING = '#accept-warning'
+
 export interface LoadWithServiceWorkerOptions {
   /**
    * Specify the final URL here, if different to `resource`
@@ -29,6 +32,17 @@ export interface LoadWithServiceWorkerOptions {
  */
 export async function loadWithServiceWorker (page: Page, resource: string, options?: LoadWithServiceWorkerOptions): Promise<Response> {
   const expected = options?.redirect ?? resource
+
+  // accept origin isolation warning if it appears
+  page.on('load', (page) => {
+    Promise.resolve()
+      .then(async () => {
+        if (await page.isVisible(ORIGIN_ISOLATION_WARNING)) {
+          await page.click(ACCEPT_ORIGIN_ISOLATION_WARNING)
+        }
+      })
+      .catch(() => {})
+  })
 
   const [
     response

--- a/test-e2e/hamt-dir.test.ts
+++ b/test-e2e/hamt-dir.test.ts
@@ -1,16 +1,13 @@
-import { allowInsecureWebsiteAccess } from './allow-insecure-website-access.js'
 import { testPathRouting as test, expect } from './fixtures/config-test-fixtures.js'
-import { waitForServiceWorker } from './fixtures/wait-for-service-worker.js'
+import { loadWithServiceWorker } from './fixtures/load-with-service-worker.js'
 
 test.describe('hamt-dir', () => {
-  test.beforeEach(async ({ page, baseURL }) => {
-    await waitForServiceWorker(page)
-    await allowInsecureWebsiteAccess(page)
-  })
+  test('can open UnixFS file from HAMT-sharded directory', async ({ page, protocol, rootDomain, baseURL }) => {
+    const cid = 'bafybeidbclfqleg2uojchspzd4bob56dqetqjsj27gy2cq3klkkgxtpn4i'
+    const path = '685.txt'
 
-  test('can open UnixFS file from HAMT-sharded directory', async ({ page, baseURL }) => {
-    const response = await page.goto('http://127.0.0.1:3333/ipfs/bafybeidbclfqleg2uojchspzd4bob56dqetqjsj27gy2cq3klkkgxtpn4i/685.txt', {
-      waitUntil: 'networkidle'
+    const response = await loadWithServiceWorker(page, `${protocol}//${rootDomain}/ipfs/${cid}/${path}`, {
+      redirect: rootDomain.includes('localhost') ? `${protocol}//${cid}.ipfs.${rootDomain}/${path}` : undefined
     })
 
     expect(response?.status()).toBe(200)


### PR DESCRIPTION
Sometimes this causes firefox to fail as the assertions occur while the page is still loading the service worker.

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
