### PR TITLE
fix: include dir index config in cache key

### DIFF
--- a/src/lib/config-db.ts
+++ b/src/lib/config-db.ts
@@ -265,9 +265,7 @@ export class Config {
         enable(debug)
 
         gateways = config.gateways
-
         routers = config.routers
-
         dnsJsonResolvers = config.dnsJsonResolvers
         enableRecursiveGateways = config.enableRecursiveGateways
         enableWss = config.enableWss

--- a/src/sw/handlers/content-request-handler.ts
+++ b/src/sw/handlers/content-request-handler.ts
@@ -47,8 +47,8 @@ interface FetchHandlerArg {
 
 const ONE_HOUR_IN_SECONDS = 3600
 
-function getCacheKey (event: FetchEvent, renderPreview: boolean): string {
-  return `${event.request.url}-${event.request.headers.get('accept') ?? ''}-preview-${renderPreview}`
+function getCacheKey (url: URL, headers: Headers, renderPreview: boolean, config: ConfigDb): string {
+  return `${url}-${headers.get('accept') ?? ''}-preview-${renderPreview}-indexes-${config.supportDirectoryIndexes}-redirects-${config.supportWebRedirects}`
 }
 
 async function getResponseFromCacheOrFetch (args: FetchHandlerArg): Promise<Response> {
@@ -505,7 +505,7 @@ export const contentRequestHandler: Handler = {
       subdomainGatewayRequest,
       pathGatewayRequest,
       logs,
-      cacheKey: getCacheKey(event, renderPreview),
+      cacheKey: getCacheKey(url, headers, renderPreview, config),
       isMutable: urlParts.protocol === 'ipns',
       renderPreview
     })

--- a/src/sw/pages/fetch-error-page.ts
+++ b/src/sw/pages/fetch-error-page.ts
@@ -112,7 +112,7 @@ export function fetchErrorPageResponse (resource: string, request: RequestInit, 
 
   const responseDetails = getResponseDetails(fetchResponse, responseBody)
   const mergedHeaders = new Headers(fetchResponse.headers)
-  mergedHeaders.set('content-type', 'text/html')
+  mergedHeaders.set('content-type', 'text/html; charset=utf-8')
   mergedHeaders.set('server', `${APP_NAME}/${APP_VERSION}#${GIT_REVISION}`)
 
   const props = {

--- a/src/sw/pages/origin-isolation-warning-page.ts
+++ b/src/sw/pages/origin-isolation-warning-page.ts
@@ -14,8 +14,8 @@ export function originIsolationWarningPageResponse (location: string): Response 
     status: 307,
     statusText: 'Temporary Redirect',
     headers: {
-      'Content-Type': 'text/html',
-      Server: `${APP_NAME}/${APP_VERSION}#${GIT_REVISION}`
+      'content-type': 'text/html; charset=utf-8',
+      server: `${APP_NAME}/${APP_VERSION}#${GIT_REVISION}`
     }
   })
 }

--- a/src/sw/pages/render-entity.ts
+++ b/src/sw/pages/render-entity.ts
@@ -19,7 +19,7 @@ export function renderEntityPageResponse (url: URL, headers: Headers, response: 
   const mergedHeaders = new Headers(response.headers)
   const contentType = mergedHeaders.get('content-type')
 
-  mergedHeaders.set('content-type', 'text/html')
+  mergedHeaders.set('content-type', 'text/html; charset=utf-8')
   mergedHeaders.set('server', `${APP_NAME}/${APP_VERSION}#${GIT_REVISION}`)
   mergedHeaders.delete('content-disposition')
 

--- a/src/sw/pages/server-error-page.ts
+++ b/src/sw/pages/server-error-page.ts
@@ -38,7 +38,7 @@ export interface ServerErrorPageResponseOptions {
  */
 export function serverErrorPageResponse (url: URL, error: Error, logs: string[], opts?: ServerErrorPageResponseOptions): Response {
   const headers = new Headers()
-  headers.set('content-type', 'text/html')
+  headers.set('content-type', 'text/html; charset=utf-8')
   headers.set('x-debug-request-uri', url.toString())
   headers.set('server', `${APP_NAME}/${APP_VERSION}#${GIT_REVISION}`)
 

--- a/test-e2e/dag-pb.test.ts
+++ b/test-e2e/dag-pb.test.ts
@@ -1,5 +1,6 @@
 import { stop } from '@libp2p/interface'
 import { createKuboRPCClient } from 'kubo-rpc-client'
+import { HASH_FRAGMENTS } from '../src/lib/constants.ts'
 import { testPathRouting as test, expect } from './fixtures/config-test-fixtures.js'
 import { loadWithServiceWorker } from './fixtures/load-with-service-worker.js'
 import type { KuboRPCClient } from 'kubo-rpc-client'
@@ -27,5 +28,36 @@ test.describe('dag-pb', () => {
     const headers = await response.allHeaders()
     expect(headers['content-type']).toContain('text/plain')
     expect(headers['cache-control']).toBe('public, max-age=29030400, immutable')
+  })
+
+  test('should return directory listing after turning off index.html support', async ({ page, protocol, rootDomain }) => {
+    const cid = 'bafybeib3ffl2teiqdncv3mkz4r23b5ctrwkzrrhctdbne6iboayxuxk5ui'
+    const path = 'root2/root3/root4'
+    const indexPage = await loadWithServiceWorker(page, `${protocol}//${rootDomain}/ipfs/${cid}/${path}/`, {
+      redirect: rootDomain.includes('localhost') ? `${protocol}//${cid}.ipfs.${rootDomain}/${path}/` : undefined
+    })
+    expect(indexPage.status()).toBe(200)
+    expect(indexPage.headers()['content-type']).toBe('text/html; charset=utf-8')
+    expect(await indexPage.text()).toContain('hello')
+
+    // turn off directory index support - this has to happen in the same
+    // subdomain as the directory view
+    await page.goto(rootDomain.includes('localhost') ? `${protocol}//${cid}.ipfs.${rootDomain}/#${HASH_FRAGMENTS.IPFS_SW_CONFIG_UI}` : `${protocol}//${rootDomain}/#${HASH_FRAGMENTS.IPFS_SW_CONFIG_UI}`, {
+      waitUntil: 'networkidle'
+    })
+
+    await page.click('.e2e-config-page-input-supportDirectoryIndexes label')
+    await page.click('#save-config')
+
+    await page.waitForTimeout(1_000)
+
+    const directoryListing = await loadWithServiceWorker(page, `${protocol}//${rootDomain}/ipfs/${cid}/${path}/`, {
+      redirect: rootDomain.includes('localhost') ? `${protocol}//${cid}.ipfs.${rootDomain}/${path}/` : undefined
+    })
+    expect(directoryListing.status()).toBe(200)
+    expect(directoryListing.headers()['content-type']).toContain('text/html')
+
+    const header = await page.waitForSelector('main header')
+    expect(await header?.innerText()).toContain(`Index of /ipfs/${cid}/${path}`)
   })
 })


### PR DESCRIPTION
Include the config settings that change the output type in the cache key.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
