### PR TITLE
chore: unify redirects file

### DIFF
--- a/build.js
+++ b/build.js
@@ -141,17 +141,20 @@ const injectHtmlPages = async (metafile, revision) => {
 
 /**
  * Asynchronously modify the _redirects file by appending entries for all files
- * in the dist folder except for index.html, _redirects, and _kubo_redirects.
+ * in the dist folder except for index.html and _redirects.
  */
 const modifyRedirects = async () => {
   const redirectsFilePath = path.resolve('dist/_redirects')
   const redirectsContent = await fs.readFile(redirectsFilePath, 'utf8')
   const distFiles = await fs.readdir(path.resolve('dist'))
-  const files = distFiles.filter(file => !['_redirects', 'index.html', '_kubo_redirects'].includes(file))
+  const files = distFiles.filter(file => !['_redirects', 'index.html'].includes(file))
   const lines = redirectsContent.split('\n')
+    .filter(line => line.trim() !== '')
+
   files.forEach(file => {
     lines.push(`/*/${file} /${file}`)
   })
+
   await fs.writeFile(redirectsFilePath, lines.join('\n'))
 }
 

--- a/public/_kubo_redirects
+++ b/public/_kubo_redirects
@@ -1,6 +1,0 @@
-# https://specs.ipfs.tech/http-gateways/web-redirects-file/
-# Used in the e2e test suite - different to _redirects because kubo handles 302s
-# and the :splat differently to cloudflare
-/ipns/* /index.html 200
-/ipfs/* /index.html 200
-/* /index.html 200

--- a/test-e2e/fixtures/create-kubo-node.ts
+++ b/test-e2e/fixtures/create-kubo-node.ts
@@ -49,7 +49,14 @@ export async function getKuboDistCid (): Promise<string> {
   await mkdir(kuboDistPath, { recursive: true })
   await cp(join(cwd(), './dist'), kuboDistPath, { recursive: true })
 
-  const kuboRedirects = await readFile(join(kuboDistPath, '_kubo_redirects'), 'utf-8')
+  let kuboRedirects = await readFile(join(kuboDistPath, '_redirects'), 'utf-8')
+
+  // strip comments and any entries where the 'from' part doesn't end with a
+  // wildcard since Kubo can't read them
+  kuboRedirects = kuboRedirects.split('\n')
+    .filter(line => !line.trim().startsWith('#'))
+    .filter(line => line.split(' ')[0].endsWith('*'))
+    .join('\n')
 
   await writeFile(join(kuboDistPath, '_redirects'), kuboRedirects)
   await mkdir(IPFS_PATH, { recursive: true })


### PR DESCRIPTION
To prevent regressions caused by not using the `_redirects` file during testing, have kubo read the same file as cloudflare.

The build script adds additional redirects to enable loading assets from relative paths, we should probably not allow this and load everything from absolute paths instead, otherwise we increase the chance of collision with website assets.

Also kubo can't read the asset redirects as the 'from' part doesn't end with an asterisk.

Refs: https://github.com/ipfs/service-worker-gateway/issues/934

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
