### PR TITLE
chore: skip ttl test when offline

### DIFF
--- a/test-e2e/smoke-test.test.ts
+++ b/test-e2e/smoke-test.test.ts
@@ -142,6 +142,16 @@ test.describe('smoke test', () => {
       return
     }
 
+    const isOnline = await page.evaluate(() => {
+      return window.navigator.onLine
+    })
+
+    if (!isOnline) {
+      // running tests offline so the service worker will not unregister itself
+      test.skip()
+      return
+    }
+
     async function hasRegistration (): Promise<boolean> {
       return page.evaluate(async () => {
         return await window.navigator.serviceWorker.getRegistration() != null


### PR DESCRIPTION
The service worker will not unregister itself if offline, so skip the test if you are running the suite on an aeroplane or similar.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
