### PR TITLE
fix: allow passthrough to for non-intercepted URLs

### DIFF
--- a/test-e2e/json.test.ts
+++ b/test-e2e/json.test.ts
@@ -109,8 +109,7 @@ test.describe('json', () => {
     })
 
     expect(cid.toString()).toContain('bafkreibrppizs3g7axs2jdlnjua6vgpmltv7k72l7v7sa6mmht6mne3qqe')
-
-    await page.goto(`${protocol}://${rootDomain}`, {
+    await page.goto(`${protocol}//${rootDomain}`, {
       waitUntil: 'networkidle'
     })
     await waitForServiceWorker(page)


### PR DESCRIPTION
Check the handlers before invoking `event.respondWith` to allow invoking global fetch.

If requesting a URL with a `/ipfs/` or `/ipns/` prefix in the path from a different origin, ensure it can be processed as a path gateway request, otherwise let the remote handle it.

Fixes #947

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
