### PR TITLE
feat: implement URI router for registerProtocolHandler

### DIFF
--- a/public/ipfs-sw-manifest.json
+++ b/public/ipfs-sw-manifest.json
@@ -14,5 +14,15 @@
   "display": "standalone",
   "scope": "/",
   "theme_color": "#0B3A53",
-  "description": "An experimental IPFS Gateway implemented as a Service Worker with @helia/verified-fetch"
+  "description": "An experimental IPFS Gateway implemented as a Service Worker with @helia/verified-fetch",
+  "protocol_handlers": [
+    {
+      "protocol": "ipfs",
+      "url": "/ipfs/?uri=%s"
+    },
+    {
+      "protocol": "ipns",
+      "url": "/ipns/?uri=%s"
+    }
+  ]
 }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -34,7 +34,15 @@ export const QUERY_PARAMS = {
    * Instructs the service worker to recreate it's verified-fetch instance with
    * config freshly loaded from the database
    */
-  RELOAD_CONFIG: 'ipfs-sw-config-reload'
+  RELOAD_CONFIG: 'ipfs-sw-config-reload',
+
+  /**
+   * When the path is `/ipfs/` or `/ipns/` and this query parameter is present,
+   * we should parse the URI and redirect to the resource.
+   *
+   * @see https://specs.ipfs.tech/http-gateways/subdomain-gateway/#uri-router
+   */
+  URI_ROUTER: 'uri'
 }
 
 /**

--- a/src/sw/handlers/index.ts
+++ b/src/sw/handlers/index.ts
@@ -3,6 +3,7 @@ import { configReloadHandler } from './config-reload-handler.js'
 import { configUpdateHandler } from './config-update-handler.js'
 import { contentRequestHandler } from './content-request-handler.js'
 import { unregisterHandler } from './unregister-handler.js'
+import { uriRouterHandler } from './uri-router-handler.ts'
 
 export interface Handler {
   name: string
@@ -18,6 +19,7 @@ export interface Handler {
  */
 export const handlers: Handler[] = [
   unregisterHandler,
+  uriRouterHandler,
   configUpdateHandler,
   configReloadHandler,
   assetRequestHandler,

--- a/src/sw/handlers/uri-router-handler.ts
+++ b/src/sw/handlers/uri-router-handler.ts
@@ -1,0 +1,34 @@
+import { QUERY_PARAMS } from '../../lib/constants.ts'
+import { getSwLogger } from '../../lib/logger.js'
+import type { Handler } from './index.js'
+
+export const uriRouterHandler: Handler = {
+  name: 'uri-router-handler',
+
+  canHandle (url) {
+    return (url.pathname === '/ipfs/' || url.pathname === '/ipns/') && url.searchParams.has(QUERY_PARAMS.URI_ROUTER)
+  },
+
+  async handle (url: URL, event: FetchEvent) {
+    const log = getSwLogger('uri-router')
+
+    const uri = new URL(url.searchParams.get(QUERY_PARAMS.URI_ROUTER) ?? '')
+
+    if (uri.protocol === 'ipfs:' || uri.protocol === 'ipns:') {
+      const location = `/${uri.protocol.substring(0, 4)}/${uri.hostname}${uri.pathname}${uri.search}${uri.hash}`
+      log('redirecting %s to %s', uri, location)
+
+      return new Response('', {
+        status: 301,
+        headers: {
+          location
+        }
+      })
+    }
+
+    log('could not redirect %s', uri)
+    return new Response('', {
+      status: 400
+    })
+  }
+}

--- a/src/sw/index.ts
+++ b/src/sw/index.ts
@@ -26,10 +26,11 @@ export interface Providers {
 declare let self: ServiceWorkerGlobalScope
 
 self.addEventListener('install', (event) => {
+  const log = getSwLogger('install')
+
   // 👇 When a new version of the SW is installed, activate immediately
   self.skipWaiting()
     .catch(err => {
-      const log = getSwLogger('fetch')
       log.error('error skipping waiting - %e', err)
     })
   event.waitUntil(setInstallTime())


### PR DESCRIPTION
Implements the URI router to handle `ipfs://` and `ipns://` links on third-party web pages.

Closes #214

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
