### PR TITLE
fix: handle service worker registration edge cases

### DIFF
--- a/src/lib/register-service-worker.ts
+++ b/src/lib/register-service-worker.ts
@@ -29,23 +29,16 @@ export async function registerServiceWorker (): Promise<ServiceWorkerRegistratio
  * hang the page forever with no feedback.
  *
  * To handle these, we track all existing workers (installing, waiting, active)
- * plus any new ones via 'updatefound', use a settled flag to prevent double
- * resolution, and enforce a 30-second timeout with a clear error message.
+ * plus any new ones via 'updatefound', and enforce a 30-second timeout.
  */
 async function waitForActivation (swRegistration: ServiceWorkerRegistration): Promise<ServiceWorkerRegistration> {
   return new Promise((resolve, reject) => {
-    let settled = false
-
     const succeed = (): void => {
-      if (settled) { return }
-      settled = true
       clearTimeout(timeoutId)
       resolve(swRegistration)
     }
 
     const fail = (msg: string): void => {
-      if (settled) { return }
-      settled = true
       clearTimeout(timeoutId)
       reject(new Error(msg))
     }

--- a/src/lib/register-service-worker.ts
+++ b/src/lib/register-service-worker.ts
@@ -13,28 +13,60 @@ export async function registerServiceWorker (): Promise<ServiceWorkerRegistratio
   return waitForActivation(swRegistration)
 }
 
+/**
+ * Waits for a service worker to reach the 'activated' state.
+ *
+ * The naive approach of only listening for 'updatefound' has edge cases that
+ * can leave users stuck on a loading screen forever:
+ *
+ * 1. Race condition: a worker may already be in 'installing' or 'waiting' state
+ * when we start listening, so we'd miss the activation event.
+ *
+ * 2. Silent failures: if a worker becomes 'redundant' (e.g., replaced by a
+ * newer version mid-install), we need to detect this and fail explicitly.
+ *
+ * 3. Indefinite hangs: without a timeout, a stuck worker activation would
+ * hang the page forever with no feedback.
+ *
+ * To handle these, we track all existing workers (installing, waiting, active)
+ * plus any new ones via 'updatefound', use a settled flag to prevent double
+ * resolution, and enforce a 30-second timeout with a clear error message.
+ */
 async function waitForActivation (swRegistration: ServiceWorkerRegistration): Promise<ServiceWorkerRegistration> {
   return new Promise((resolve, reject) => {
-    const timeoutId = setTimeout(() => {
-      reject(new Error('Service worker failed to activate within 30 seconds. Refresh the page to retry.'))
-    }, 30_000)
+    let settled = false
 
-    const onStateChange = (e: Event): void => {
-      const sw = e.target as ServiceWorker
-      if (sw.state === 'activated') {
-        clearTimeout(timeoutId)
-        resolve(swRegistration)
-      } else if (sw.state === 'redundant') {
-        clearTimeout(timeoutId)
-        reject(new Error('Service worker became redundant. Refresh the page to retry.'))
-      }
+    const succeed = (): void => {
+      if (settled) { return }
+      settled = true
+      clearTimeout(timeoutId)
+      resolve(swRegistration)
     }
 
-    // track workers that may already be installing or waiting
-    swRegistration.installing?.addEventListener('statechange', onStateChange)
-    swRegistration.waiting?.addEventListener('statechange', onStateChange)
+    const fail = (msg: string): void => {
+      if (settled) { return }
+      settled = true
+      clearTimeout(timeoutId)
+      reject(new Error(msg))
+    }
+
+    const timeoutId = setTimeout(() => {
+      fail('Service worker failed to activate within 30 seconds. Refresh the page to retry.')
+    }, 30_000)
+
+    const trackWorker = (sw: ServiceWorker | null): void => {
+      if (sw == null) { return }
+      sw.addEventListener('statechange', () => {
+        if (sw.state === 'activated') { succeed() } else if (sw.state === 'redundant') { fail('Service worker became redundant. Refresh the page to retry.') }
+      })
+      if (sw.state === 'activated') { succeed() }
+    }
+
+    trackWorker(swRegistration.installing)
+    trackWorker(swRegistration.waiting)
+    trackWorker(swRegistration.active)
     swRegistration.addEventListener('updatefound', () => {
-      swRegistration.installing?.addEventListener('statechange', onStateChange)
+      trackWorker(swRegistration.installing)
     })
   })
 }

--- a/test-e2e/service-worker-registration.test.ts
+++ b/test-e2e/service-worker-registration.test.ts
@@ -1,0 +1,81 @@
+import { test, expect } from './fixtures/config-test-fixtures.js'
+import { swScopeVerification } from './fixtures/sw-scope-verification.js'
+import { waitForServiceWorker } from './fixtures/wait-for-service-worker.js'
+
+test.describe('service worker registration', () => {
+  test('activates successfully on fresh registration', async ({ page, baseURL }) => {
+    // Unregister any existing service worker
+    await page.goto(baseURL ?? 'http://localhost:3333')
+    await page.evaluate(async () => {
+      const registrations = await navigator.serviceWorker.getRegistrations()
+      await Promise.all(registrations.map(r => r.unregister()))
+    })
+
+    // Navigate to trigger fresh registration
+    await page.goto(baseURL ?? 'http://localhost:3333')
+
+    // Wait for SW to activate
+    await waitForServiceWorker(page)
+
+    // Verify SW is properly registered
+    await swScopeVerification(page, expect)
+  })
+
+  test('re-registers after being unregistered', async ({ page, baseURL }) => {
+    // First ensure SW is registered
+    await page.goto(baseURL ?? 'http://localhost:3333')
+    await waitForServiceWorker(page)
+
+    // Unregister SW
+    await page.evaluate(async () => {
+      const registrations = await navigator.serviceWorker.getRegistrations()
+      await Promise.all(registrations.map(r => r.unregister()))
+    })
+
+    // Verify SW is unregistered
+    const hasNoRegistration = await page.evaluate(async () => {
+      return await navigator.serviceWorker.getRegistration() === undefined
+    })
+    expect(hasNoRegistration).toBe(true)
+
+    // Navigate to root to trigger re-registration (avoid IPFS path which causes redirects)
+    await page.goto(baseURL ?? 'http://localhost:3333', { waitUntil: 'networkidle' })
+
+    // Wait for SW to activate again
+    await waitForServiceWorker(page)
+
+    // Verify SW is properly registered
+    await swScopeVerification(page, expect)
+  })
+
+  test('handles multiple register/unregister cycles', async ({ page, baseURL }) => {
+    for (let i = 0; i < 3; i++) {
+      // Navigate and wait for SW
+      await page.goto(baseURL ?? 'http://localhost:3333')
+      await waitForServiceWorker(page)
+
+      // Verify SW is registered
+      await swScopeVerification(page, expect)
+
+      // Unregister
+      await page.evaluate(async () => {
+        const registrations = await navigator.serviceWorker.getRegistrations()
+        await Promise.all(registrations.map(r => r.unregister()))
+      })
+
+      // Verify unregistered
+      const hasNoRegistration = await page.evaluate(async () => {
+        return await navigator.serviceWorker.getRegistration() === undefined
+      })
+      expect(hasNoRegistration).toBe(true)
+    }
+  })
+
+  // NOTE: Testing the activation timeout error page is not possible in E2E because
+  // Playwright cannot intercept service worker script fetches:
+  // "Requests for updated Service Worker main script code currently cannot be routed"
+  // @see https://playwright.dev/docs/service-workers
+  //
+  // The timeout functionality is tested implicitly - if waitForActivation hangs
+  // indefinitely, the tests above would fail.
+})


### PR DESCRIPTION
this PR is belt and suspenders protection against edge cases that could leave users stuck on loading screen. 

i've seen crazy bugs in Google Chrome shipping in production, and then they silently fixed them month later, wasting peoples time on debug

these should not impact normal operation, but will save debugging time if we ever hit them thanks to clear error messages and timeout