### PR TITLE
chore: add benchmark

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -42,7 +42,8 @@ export default {
       '.aegir.js',
       '/test',
       'dist',
-      'build.js'
+      'build.js',
+      '/benchmark'
     ]
   }
 }

--- a/benchmark/benchmark.test.ts
+++ b/benchmark/benchmark.test.ts
@@ -1,0 +1,66 @@
+/* eslint-disable max-nested-callbacks,no-console */
+
+import { test, expect } from '@playwright/test'
+import { loadWithServiceWorker } from '../test-e2e/fixtures/load-with-service-worker.ts'
+
+test.describe.configure({ mode: 'serial' })
+
+const REPEAT = 10
+const CID = 'bafybeigocr7lc57bjw3b7jkv2y3mtggcvfiebs5wq5b7epfwtb5wgwgzm4'
+
+test.describe('@helia/service-worker-gateway - benchmark', () => {
+  const tests = [{
+    name: 'inbrowser.link (subdomain gateway)',
+    url: (cid: string): string => `https://${cid}.ipfs.inbrowser.link/`
+  }, {
+    name: 'inbrowser.link (path gateway)',
+    url: (cid: string): string => `https://inbrowser.link/ipfs/${cid}/`
+  }, {
+    name: 'inbrowser.dev (subdomain gateway)',
+    url: (cid: string): string => `https://${cid}.ipfs.inbrowser.dev/`
+  }, {
+    name: 'inbrowser.dev (path gateway',
+    url: (cid: string): string => `https://inbrowser.dev/ipfs/${cid}/`
+  }]
+
+  tests.forEach(t => {
+    test(`${t.name}`, async ({ browser }) => {
+      // this test takes some time to run
+      test.setTimeout(640_000_000)
+
+      let time = 0
+
+      for (let i = 0; i < REPEAT; i++) {
+        const context = await browser.newContext()
+
+        // should not have any service workers installed
+        expect(context.serviceWorkers().length).toBe(0)
+
+        const page = await context.newPage()
+
+        // start recording
+        const start = Date.now()
+        const response = await loadWithServiceWorker(page, t.url(CID), {
+          // 'commit' means the response headers have been received and the page
+          // is starting to load
+          waitUntil: 'commit'
+        })
+        time += (Date.now() - start)
+        process.stdout.write('.')
+
+        // check response
+        expect(response.status()).toBe(200)
+        expect(response.headers()['content-length']).toBe('8895')
+        expect(response.headers()['content-type']).toBe('image/jpeg')
+
+        // should have service worker(s)
+        expect(context.serviceWorkers().length).not.toBe(0)
+
+        await context.close()
+      }
+
+      process.stdout.write('\n')
+      console.info(t.name, Math.round(time / REPEAT), 'ms')
+    })
+  })
+})

--- a/benchmark/playwright.config.js
+++ b/benchmark/playwright.config.js
@@ -1,0 +1,32 @@
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: '.',
+  testMatch: '*.test.ts',
+
+  // Very long timeout to run the conformance suite
+  timeout: 640_000_000,
+
+  // no retries
+  retries: 0,
+
+  // Reporter to use. See https://playwright.dev/docs/test-reporters
+  // reporter: 'html', // Uncomment to generate HTML report
+  use: {
+    // Base URL to use in actions like `await page.goto('/')`
+    baseURL: `http://localhost:3000`,
+
+    // Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer
+    trace: 'on-first-retry',
+
+    // 'allow' serviceWorkers is the default, but we want to be explicit
+    serviceWorkers: 'allow'
+  },
+
+  projects: [{
+    name: 'chromium',
+    use: {
+      ...devices['Desktop Chrome']
+    }
+  }]
+})

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "test:conformance": "npm run build:test && playwright test -c ./test-conformance/playwright.config.js --project chromium",
     "update-conformance": "node --experimental-strip-types ./test-conformance/fixtures/update-expected-tests.ts",
     "postinstall": "patch-package",
-    "generate-fixtures": "node --experimental-strip-types ./test-e2e/fixtures/data/generate.ts"
+    "generate-fixtures": "node --experimental-strip-types ./test-e2e/fixtures/data/generate.ts",
+    "benchmark": "playwright test -c ./benchmark/playwright.config.js --project chromium"
   },
   "browser": "./dist/src/index.js",
   "browserslist": [

--- a/test-e2e/fixtures/load-with-service-worker.ts
+++ b/test-e2e/fixtures/load-with-service-worker.ts
@@ -10,16 +10,22 @@ export interface LoadWithServiceWorkerOptions {
 
   /**
    * See Playwright Page.goto args
+   *
+   * @see {Page.goto}
    */
   referer?: string
 
   /**
    * See Playwright Page.goto args
+   *
+   * @see {Page.goto}
    */
   timeout?: number
 
   /**
    * See Playwright Page.goto args
+   *
+   * @see {Page.goto}
    */
   waitUntil?: 'load' | 'domcontentloaded' | 'networkidle' | 'commit'
 }


### PR DESCRIPTION
Adds a benchmark that loads a jpeg from inbrowser.link and inbrowser.dev a few times and prints the average time.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
