### PR TITLE
chore: add issue templates with need/triage label

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Getting Help on IPFS
+    url: https://ipfs.tech/help
+    about: All information about how and where to get help on IPFS.
+  - name: IPFS Discussion Forum
+    url: https://discuss.ipfs.tech
+    about: Please post general questions, support requests, and discussions here.

--- a/.github/ISSUE_TEMPLATE/issue.yml
+++ b/.github/ISSUE_TEMPLATE/issue.yml
@@ -1,0 +1,17 @@
+name: Issue
+description: Report a bug, request a feature, or ask a question.
+labels:
+  - need/triage
+body:
+  - type: checkboxes
+    attributes:
+      label: Checklist
+      options:
+        - label: I have searched the [issue tracker](https://github.com/ipfs/service-worker-gateway/issues?q=is%3Aissue) for existing issues.
+          required: true
+  - type: textarea
+    attributes:
+      label: Description
+      description: Please describe your issue, feature request, or question.
+    validations:
+      required: true


### PR DESCRIPTION
ensures all new issues are assigned the need/triage label and disables blank issues to guide users through the template.
