### PR TITLE
fix: show provider routing source

### DIFF
--- a/src/sw/index.ts
+++ b/src/sw/index.ts
@@ -15,17 +15,19 @@ import type { Handler } from './handlers/index.ts'
 
 weald.enable(config.debug)
 
+export interface Provider {
+  type: string
+  routing: string
+  provider: any
+}
+
 /**
  * These are block/car providers that were used while downloading data
  */
 export interface Providers {
   total: number
-  bitswap: Map<string, Set<string>>
-  trustlessGateway: Set<string>
-
-  // this is limited to 5x entries to prevent new routing systems causing OOMs
-  other: any[]
-  otherCount: number
+  // this is limited to 10x entries to prevent new routing systems causing OOMs
+  providers: Provider[]
 }
 
 declare let self: ServiceWorkerGlobalScope

--- a/src/sw/pages/fetch-error-page.ts
+++ b/src/sw/pages/fetch-error-page.ts
@@ -1,7 +1,6 @@
 import { APP_NAME, APP_VERSION, GIT_REVISION } from '../../version.ts'
 import { htmlPage } from './page.ts'
 import type { ContentURI } from '../../lib/parse-request.ts'
-import type { Providers as ErrorPageProviders } from '../../ui/pages/fetch-error.tsx'
 import type { Providers } from '../index.ts'
 
 declare let self: ServiceWorkerGlobalScope
@@ -37,22 +36,6 @@ function getServiceWorkerDetails (firstInstallTime: number): ServiceWorkerDetail
     version: APP_VERSION,
     commit: GIT_REVISION
   }
-}
-
-function toErrorPageProviders (providers: Providers): ErrorPageProviders {
-  const output: ErrorPageProviders = {
-    total: providers.total,
-    other: providers.other,
-    otherCount: providers.otherCount,
-    trustlessGateway: [...providers.trustlessGateway],
-    bitswap: {}
-  }
-
-  for (const [key, addresses] of providers.bitswap) {
-    output.bitswap[key] = [...addresses]
-  }
-
-  return output
 }
 
 export interface RequestDetails {
@@ -117,7 +100,7 @@ export function fetchErrorPageResponse (request: ContentURI, requestInit: Reques
     request: getRequestDetails(request, requestInit),
     response: responseDetails,
     config: getServiceWorkerDetails(installTime),
-    providers: toErrorPageProviders(providers),
+    providers,
     title: `${responseDetails.status} ${responseDetails.statusText}`,
     logs
   }

--- a/src/ui/pages/fetch-error.tsx
+++ b/src/ui/pages/fetch-error.tsx
@@ -7,6 +7,7 @@ import ContentBox from '../components/content-box.tsx'
 import { Link } from '../components/link.tsx'
 import Terminal from '../components/terminal.tsx'
 import { createLink } from '../utils/links.ts'
+import type { Providers } from '../../sw/index.ts'
 import type { RequestDetails, ResponseDetails } from '../../sw/pages/fetch-error-page.ts'
 import type { ReactElement } from 'react'
 
@@ -68,16 +69,6 @@ function findCid (request: RequestDetails): string | void {
       return req.cid.toString()
     }
   } catch {}
-}
-
-export interface Providers {
-  total: number
-  bitswap: Record<string, string[]>
-  trustlessGateway: string[]
-
-  // this is limited to 5x entries to prevent new routing systems causing OOMs
-  other: any[]
-  otherCount: number
 }
 
 export interface FetchErrorPageProps {
@@ -199,24 +190,12 @@ export function FetchErrorPage ({ request, response, logs, providers }: FetchErr
       </>
     )
   } else {
-    const bitswapProviders: Array<{ PeerID: string, Multiaddrs: string[] }> = []
-    const trustlessGatewayProviders: string[] = providers.trustlessGateway
-    const unknownProviders: any[] = providers.other
-
-    Object.entries(providers.bitswap).forEach(([PeerID, Multiaddrs]) => {
-      bitswapProviders.push({
-        PeerID,
-        Multiaddrs
-      })
-    })
-
     providersMessage = (
       <>
         <Terminal>
           These providers were found but did not return the requested data:
-          {bitswapProviders.length > 0 ? '\n\nBitswap:\n\n' + JSON.stringify(bitswapProviders, null, 2) : ''}
-          {trustlessGatewayProviders.length > 0 ? '\n\nTrustless Gateways:\n\n' + JSON.stringify(trustlessGatewayProviders, null, 2) : ''}
-          {unknownProviders.length > 0 ? `\n\nUnknown Routing(s) (${providers.other.length}/${providers.otherCount}):\n\n` + JSON.stringify(unknownProviders, null, 2) : ''}
+
+          {'\n\n' + JSON.stringify(providers.providers, null, 2)}
         </Terminal>
       </>
     )


### PR DESCRIPTION
When an error occurs and providers were found, show the routing implementation that found the provider

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
