### PR TITLE
fix: skip PWA manifest on CID subdomains

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -23,7 +23,6 @@
     <title>IPFS Service Worker Gateway | <%= GIT_VERSION %></title>
     <meta name="description" content="A static HTML page that initializes an instance of IPFS Service Worker Gateway" />
     <meta name="robots" content="noindex" />
-    <link rel="manifest" href="/ipfs-sw-manifest.json">
     <link rel="icon" href="/ipfs-sw-favicon.ico" type="image/ico"/>
     <link rel="shortcut icon" href="/ipfs-sw-favicon.ico" type="image/x-icon"/>
     <%= CSS_STYLES %>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -251,6 +251,15 @@ function tooManyRedirects (storageKey: string, maxRedirects = 5, period = 5_000)
   return recent.length > maxRedirects
 }
 
+// only register PWA manifest on root domain, not on CID subdomains
+// where it causes unnecessary background DNS lookups
+if (!location.hostname.includes('.ipfs.') && !location.hostname.includes('.ipns.')) {
+  const manifest = document.createElement('link')
+  manifest.rel = 'manifest'
+  manifest.href = '/ipfs-sw-manifest.json'
+  document.head.appendChild(manifest)
+}
+
 main()
   .catch((err) => {
     // eslint-disable-next-line no-console


### PR DESCRIPTION
remove static manifest link from index.html and inject it conditionally in JS only on the root domain, avoiding unnecessary background DNS lookups on ephemeral CID subdomains.

- part of https://github.com/ipfs/service-worker-gateway/issues/21

## Demo

On main page, manifest triggers Chromium to show  "Install" button for web app:

> <img width="1631" height="969" alt="2026-02-17_00-11" src="https://github.com/user-attachments/assets/0d5dd717-bde7-4ac7-bd4b-6e54f2fd382f" />

With this PR the button is gone from subdomains:

> <img width="1637" height="491" alt="2026-02-17_00-12" src="https://github.com/user-attachments/assets/9d9dbc45-94e2-47bf-a5ae-65cad622b18f" />

(Allowing web apps to provide own)