### PR TITLE
ci: purge Cloudflare cache after deploy

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -18,13 +18,36 @@ jobs:
       environment: production
     secrets:
       DEPLOYMENT_GITHUB_TOKEN: ${{ secrets.UCI_GITHUB_TOKEN || github.token }}
-  wait-for-deploy:
+  # Cloudflare caching setup (configured via Cache Rules in the dashboard):
+  # - Edge TTL and Browser TTL are set to 24h for faster cold cache hits
+  # - cache key uses resolved host (not request host) and ignores query params,
+  #   because every subdomain returns the same HTML+JS service worker
+  #   installer/bootstrapper, so a single cached response serves all of them
+  #
+  # Purge all cached assets after deploy so visitors get the new version
+  # without waiting for the 24h TTL to expire.
+  purge-cache-and-verify:
+    needs: deploy
     runs-on: ubuntu-latest
+    environment: production
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-      - name: Wait for deployment to complete
+      - name: Wait for Cloudflare Pages build to complete
         run: |
           # fetch the tag to ensure it's available
           git fetch origin tag ${{ inputs.tag }} --no-tags
+          # check Pages origin directly (bypasses CDN cache)
+          ./.github/scripts/wait-for-deploy.sh https://ipfs-service-worker-gateway.pages.dev ${{ inputs.tag }}
+      - name: Purge Cloudflare cache for inbrowser.link
+        run: |
+          curl --fail --request POST \
+            --url "https://api.cloudflare.com/client/v4/zones/3cf6893c26dde38efa39910a57798a59/purge_cache" \
+            -H 'Content-Type: application/json' \
+            -H "Authorization: Bearer $CF_TOKEN" \
+            --data '{"purge_everything": true}'
+        env:
+          CF_TOKEN: ${{ secrets.CF_CACHE_PURGE_TOKEN_PRODUCTION }}
+      - name: Wait for new version to be served via inbrowser.link
+        run: |
           ./.github/scripts/wait-for-deploy.sh https://inbrowser.link ${{ inputs.tag }}

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -18,11 +18,34 @@ jobs:
       environment: staging
     secrets:
       DEPLOYMENT_GITHUB_TOKEN: ${{ secrets.UCI_GITHUB_TOKEN || github.token }}
-  wait-for-deploy:
+  # Cloudflare caching setup (configured via Cache Rules in the dashboard):
+  # - Edge TTL and Browser TTL are set to 24h for faster cold cache hits
+  # - cache key uses resolved host (not request host) and ignores query params,
+  #   because every subdomain returns the same HTML+JS service worker
+  #   installer/bootstrapper, so a single cached response serves all of them
+  #
+  # Purge all cached assets after deploy so visitors get the new version
+  # without waiting for the 24h TTL to expire.
+  purge-cache-and-verify:
+    needs: deploy
     runs-on: ubuntu-latest
+    environment: staging
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-      - name: Wait for deployment to complete
+      - name: Wait for Cloudflare Pages build to complete
+        run: |
+          # check Pages origin directly (bypasses CDN cache)
+          ./.github/scripts/wait-for-deploy.sh https://staging.ipfs-service-worker-gateway.pages.dev ${{ inputs.tag }}
+      - name: Purge Cloudflare cache for inbrowser.dev
+        run: |
+          curl --fail --request POST \
+            --url "https://api.cloudflare.com/client/v4/zones/920073f8f22220ca3a3c514d81195e35/purge_cache" \
+            -H 'Content-Type: application/json' \
+            -H "Authorization: Bearer $CF_TOKEN" \
+            --data '{"purge_everything": true}'
+        env:
+          CF_TOKEN: ${{ secrets.CF_CACHE_PURGE_TOKEN_STAGING }}
+      - name: Wait for new version to be served via inbrowser.dev
         run: |
           ./.github/scripts/wait-for-deploy.sh https://inbrowser.dev ${{ inputs.tag }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,7 @@ jobs:
   deploy:
     name: Deploy ${{ inputs.tag }} to ${{ inputs.environment }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     environment: ${{ inputs.environment }}
     steps:
       - name: Checkout


### PR DESCRIPTION
as part of HTTP caching optimization in prod/staging,  the edge and browser TTLs wil be set to 24h for faster delivery of the service worker installer on cold cache hits. this means we need to manually purge all cached assets after each deploy so edge starts serving the new version without waiting for TTL expiry. kinda best of both worlds.

the deploy pipeline now checks the Cloudflare Pages origin directly (bypasses CDN cache) before purging, then verifies the public domain serves the new version after purge.

uses separate CF tokens per environment:
- `CF_CACHE_PURGE_TOKEN_PRODUCTION` for inbrowser.link
- `CF_CACHE_PURGE_TOKEN_STAGING` for inbrowser.dev

also adds 10m timeout to the deploy job.

cc @aschmahmann @achingbrain for visibility (i'll set secrets in respective environments and then merge and test)


### Token scopes to only cache purging

> <img width="1362" height="656" alt="image" src="https://github.com/user-attachments/assets/8f2af467-a7c8-4f0b-9751-a35a4e4f16ac" />

### Caching Rule 

For now set up in staging (`inbrowser.dev`) and not in production (`inbrowser.link`) so @aschmahmann  can compare performance –– lmk if looking good enough for me to apply to prod too.

> <img width="1293" height="6368" alt="image" src="https://github.com/user-attachments/assets/63270233-9269-4a1e-9e23-90c7bf95c5e4" />

