### PR TITLE
feat: support routing prefetching and trustless gateways preconnects

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -23,6 +23,7 @@
     <title>IPFS Service Worker Gateway | <%= GIT_VERSION %></title>
     <meta name="description" content="A static HTML page that initializes an instance of IPFS Service Worker Gateway" />
     <meta name="robots" content="noindex" />
+    <%= CONNECTION_HINTS %>
     <link rel="icon" href="/ipfs-sw-favicon.ico" type="image/ico"/>
     <link rel="shortcut icon" href="/ipfs-sw-favicon.ico" type="image/x-icon"/>
     <%= CSS_STYLES %>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,6 +5,7 @@ import { config } from './config/index.ts'
 import { QUERY_PARAMS } from './lib/constants.ts'
 import { parseRequest } from './lib/parse-request.ts'
 import { isSafeOrigin } from './lib/path-or-subdomain.ts'
+import { prewarmContentRequest } from './lib/prewarm-content.ts'
 import { registerServiceWorker } from './lib/register-service-worker.ts'
 import type { ResolvableURI } from './lib/parse-request.ts'
 
@@ -159,6 +160,8 @@ async function main (): Promise<void> {
       const hasActiveWorker = registration?.active != null
 
       if (!hasActiveWorker) {
+        prewarmContentRequest(request, config)
+
         // install the service worker on the root path of this domain, either
         // path or subdomain gateway
         await registerServiceWorker()

--- a/src/lib/prewarm-content.ts
+++ b/src/lib/prewarm-content.ts
@@ -1,0 +1,79 @@
+import { base36 } from 'multiformats/bases/base36'
+import type { ResolvableURI } from './parse-request.ts'
+import type { Config } from '../config/index.ts'
+
+const FILTER_ADDRS = 'wss,tls,https'
+const FILTER_PROTOCOLS = 'unknown,transport-bitswap,transport-ipfs-gateway-http'
+
+function toArray (value: string | string[]): string[] {
+  return Array.isArray(value) ? value : [value]
+}
+
+function joinPath (basePathname: string, suffix: string): string {
+  const base = basePathname.endsWith('/') ? basePathname.slice(0, -1) : basePathname
+
+  if (base.length === 0) {
+    return suffix
+  }
+
+  return `${base}${suffix}`
+}
+
+function warmRequest (url: URL): void {
+  void fetch(url.toString(), {
+    method: 'GET',
+    mode: 'cors',
+    credentials: 'omit',
+    cache: 'force-cache',
+    keepalive: true
+  }).catch(() => {
+    // ignore prewarm errors, this is a best-effort optimization
+  })
+}
+
+export function buildPrewarmUrls (request: ResolvableURI, options: Pick<Config, 'routers' | 'dnsResolvers'>): URL[] {
+  const urls: URL[] = []
+  const routers = options.routers.map(router => new URL(router))
+  const resolvers = Object.values(options.dnsResolvers)
+    .flatMap(value => toArray(value))
+    .map(resolver => new URL(resolver))
+
+  if (request.type === 'internal' || request.type === 'external') {
+    return urls
+  }
+
+  if (request.protocol === 'ipfs') {
+    routers.forEach(router => {
+      const url = new URL(router.toString())
+      url.pathname = joinPath(url.pathname, `/routing/v1/providers/${request.cid.toString()}`)
+      url.searchParams.set('filter-addrs', FILTER_ADDRS)
+      url.searchParams.set('filter-protocols', FILTER_PROTOCOLS)
+      urls.push(url)
+    })
+  }
+
+  if (request.protocol === 'ipns') {
+    routers.forEach(router => {
+      const url = new URL(router.toString())
+      url.pathname = joinPath(url.pathname, `/routing/v1/ipns/${request.peerId.toCID().toString(base36)}`)
+      urls.push(url)
+    })
+  }
+
+  if (request.protocol === 'dnslink') {
+    resolvers.forEach(resolver => {
+      const url = new URL(resolver.toString())
+      url.searchParams.set('name', `_dnslink.${request.domain}`)
+      url.searchParams.set('type', 'TXT')
+      urls.push(url)
+    })
+  }
+
+  return urls
+}
+
+export function prewarmContentRequest (request: ResolvableURI, options: Pick<Config, 'routers' | 'dnsResolvers'>): void {
+  buildPrewarmUrls(request, options).forEach(url => {
+    warmRequest(url)
+  })
+}

--- a/test/lib/prewarm-content.spec.ts
+++ b/test/lib/prewarm-content.spec.ts
@@ -1,0 +1,39 @@
+import { expect } from 'aegir/chai'
+import { dnsLinkLabelEncoder } from '../../src/lib/dns-link-labels.ts'
+import { parseRequest } from '../../src/lib/parse-request.ts'
+import { buildPrewarmUrls } from '../../src/lib/prewarm-content.ts'
+
+const options = {
+  routers: ['https://delegated-ipfs.dev'],
+  dnsResolvers: {
+    '.': 'https://delegated-ipfs.dev/dns-query'
+  }
+}
+
+describe('prewarm-content', () => {
+  it('builds provider query for ipfs requests', () => {
+    const request = parseRequest(new URL('https://bafyaaaa.ipfs.localhost:3000/'), new URL('https://localhost:3000'))
+    const urls = buildPrewarmUrls(request, options)
+
+    expect(urls).to.have.lengthOf(1)
+    expect(urls[0].toString()).to.equal('https://delegated-ipfs.dev/routing/v1/providers/bafyaaaa?filter-addrs=wss%2Ctls%2Chttps&filter-protocols=unknown%2Ctransport-bitswap%2Ctransport-ipfs-gateway-http')
+  })
+
+  it('builds routing query for ipns requests', () => {
+    const ipnsName = 'k51qzi5uqu5djpzsgwway43y9oc6p6zf2mco05x7yo6njcs9n1u4s19416t69w'
+    const request = parseRequest(new URL(`https://${ipnsName}.ipns.localhost:3000/`), new URL('https://localhost:3000'))
+    const urls = buildPrewarmUrls(request, options)
+
+    expect(urls).to.have.lengthOf(1)
+    expect(urls[0].toString()).to.equal(`https://delegated-ipfs.dev/routing/v1/ipns/${ipnsName}`)
+  })
+
+  it('builds dns query for dnslink requests', () => {
+    const domain = 'docs.ipfs.tech'
+    const request = parseRequest(new URL(`https://${dnsLinkLabelEncoder(domain)}.ipns.localhost:3000/`), new URL('https://localhost:3000'))
+    const urls = buildPrewarmUrls(request, options)
+
+    expect(urls).to.have.lengthOf(1)
+    expect(urls[0].toString()).to.equal('https://delegated-ipfs.dev/dns-query?name=_dnslink.docs.ipfs.tech&type=TXT')
+  })
+})


### PR DESCRIPTION
## Support routing prefetching and trustless gateways preconnects

<!---
The title of the PR will be the commit message of the merge commit, so please make sure it is descriptive enough.
We utilize the Conventional Commits specification for our commit messages. See <https://www.conventionalcommits.org/en/v1.0.0/#specification> for more information.
The commit tag types can be of one of the following: feat, fix, deps, refactor, chore, docs. See <https://github.com/ipfs/helia/blob/main/.github/workflows/main.yml#L184-L192>
The title must also be fewer than 72 characters long or it will fail the Semantic PR check. See <https://github.com/ipfs/helia/blob/main/.github/workflows/semantic-pull-request.yml>
--->

## Description

Closes #979. The idea here is to parallelize requests the service worker is likely to make with the installation of the service worker itself.

<!--
Please write a summary of your changes and why you made them.
Please include any relevant issues in here, for example:
Related https://github.com/ipfs/helia/issues/ABCD.
Fixes https://github.com/ipfs/helia/issues/XYZ.
-->

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->
Some todo / outstanding items:
- [ ] The DNSLink prefetching assumes the configured resolvers cover all domains which is currently the case for all configured build options, we could add the logic to properly handle this
- [ ] None of these prefetches / preconnects are necessary if the page is just a simple identity multihash of a raw cid. Should we specially handle this case (even if not other cases like a tiny unixfs object inlined in an identity multihash)

Note: This was generated with LLM help, if there's a better way to solve #979 or if we want to start with something small like hard-coded preconnects instead of the complexity involved with the prefetches that's fine by me. There are some tests here, but idk if there are reasonable ways to do end-to-end testing here.

## Change checklist

- [x] I have performed a self-review of my own code
- ~[ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)~
- [x] I have added tests that prove my fix is effective or that my feature works
