### PR TITLE
fix: handle hard refresh

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -162,12 +162,11 @@ async function main (): Promise<void> {
         // install the service worker on the root path of this domain, either
         // path or subdomain gateway
         await registerServiceWorker()
-
-        // service worker is now installed so redirect to path or subdomain for
-        // data so it can intercept the request
-        window.location.href = url.toString()
-        return
       }
+
+      // reload so the subdomain request is handled by the service worker
+      window.location.href = url.toString()
+      return
     }
   } catch (err: any) {
     // error during initialization, show an error message


### PR DESCRIPTION
Pressing shift while reloading the page bypasses the service worker on a subdomain so reload the page if this occurs.

Testing this with playwright seems difficult - https://github.com/microsoft/playwright/issues/39319 may need to be resolved first.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
