### PR TITLE
feat: pre-connect to routers and resolve gateway dns

### DIFF
--- a/build.js
+++ b/build.js
@@ -3,8 +3,8 @@ import { execSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 import fs from 'node:fs/promises'
 import path from 'node:path'
-import esbuild from 'esbuild'
 import { isIP } from '@chainsafe/is-ip'
+import esbuild from 'esbuild'
 
 /**
  * @param {string | string[]} str
@@ -182,12 +182,12 @@ const injectHtmlPages = async (metafile, revision) => {
     console.log(`Added git revision (${revision}) to ${path.relative(process.cwd(), htmlFilePath)}.`)
 
     // preconnect to routers as we will probably need to use them to find provs
-    let preconnect = new Set([
+    const preconnect = new Set([
       ...config.routers.map(toUrl)
     ])
 
     // only resolve DNS for gateways and DNS resolvers as we may use them
-    let dnsPrefetch = new Set([
+    const dnsPrefetch = new Set([
       ...config.gateways.map(toUrl),
       ...Object.values(config.dnsResolvers).map(toArray).map(toUrl)
     ])

--- a/build.js
+++ b/build.js
@@ -7,18 +7,6 @@ import { isIP } from '@chainsafe/is-ip'
 import esbuild from 'esbuild'
 
 /**
- * @param {string | string[]} str
- * @returns {string[]}
- */
-function toArray (str) {
-  if (Array.isArray(str)) {
-    return str
-  }
-
-  return [str]
-}
-
-/**
  * @param {string} str
  * @returns {string}
  */
@@ -189,7 +177,7 @@ const injectHtmlPages = async (metafile, revision) => {
     // only resolve DNS for gateways and DNS resolvers as we may use them
     const dnsPrefetch = new Set([
       ...config.gateways.map(toUrl),
-      ...Object.values(config.dnsResolvers).map(toArray).map(toUrl)
+      ...Object.values(config.dnsResolvers).flat().map(toUrl)
     ])
 
     htmlContent = htmlContent.replace(/<%= PRECONNECT_HINTS %>/g, [...preconnect]

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "clean": "aegir clean dist dist-tsc test-e2e/fixtures/data/gateway-conformance-fixtures",
     "dep-check": "aegir dep-check",
     "lint": "aegir lint",
-    "build": "node build.js && go build -o service-worker-gateway main.go",
+    "build": "node --experimental-strip-types build.js && go build -o service-worker-gateway main.go",
     "build:test": "cross-env NODE_ENV=test npm run build",
     "start": "cross-env NODE_ENV=development node --experimental-strip-types ./serve.ts --load-fixtures --watch",
     "test": "cross-env NODE_ENV=test aegir test -f test/**/*.spec.ts -- --experimental-strip-types",

--- a/public/index.html
+++ b/public/index.html
@@ -25,6 +25,8 @@
     <meta name="robots" content="noindex" />
     <link rel="icon" href="/ipfs-sw-favicon.ico" type="image/ico"/>
     <link rel="shortcut icon" href="/ipfs-sw-favicon.ico" type="image/x-icon"/>
+    <%= PRECONNECT_HINTS %>
+    <%= DNS_PREFETCH_HINTS %>
     <%= CSS_STYLES %>
     <style>
       .loading-container {


### PR DESCRIPTION
Use [rel=preconnect](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/rel/preconnect) to premptively connect to configured routers, and use [rel=dns-prefetch](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/rel/dns-prefetch) to resolve DNS for fallback trustless gateways ahead of time.

Do this in the HTML and not JS so it begins before we have installed the service worker.

- cc #979

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
