### PR TITLE
chore: detect service worker in benchmarks

### DIFF
--- a/benchmark/benchmark.test.ts
+++ b/benchmark/benchmark.test.ts
@@ -11,20 +11,16 @@ const CID = 'bafybeigocr7lc57bjw3b7jkv2y3mtggcvfiebs5wq5b7epfwtb5wgwgzm4'
 test.describe('@helia/service-worker-gateway - benchmark', () => {
   const tests = [{
     name: 'inbrowser.link (subdomain gateway)',
-    url: (cid: string): string => `https://${cid}.ipfs.inbrowser.link/`,
-    redirect: (cid: string): string => `https://${cid}.ipfs.inbrowser.link/`
+    url: (cid: string): string => `https://${cid}.ipfs.inbrowser.link/`
   }, {
     name: 'inbrowser.link (path gateway)',
-    url: (cid: string): string => `https://inbrowser.link/ipfs/${cid}/`,
-    redirect: (cid: string): string => `https://${cid}.ipfs.inbrowser.link/`
+    url: (cid: string): string => `https://inbrowser.link/ipfs/${cid}/`
   }, {
     name: 'inbrowser.dev (subdomain gateway)',
-    url: (cid: string): string => `https://${cid}.ipfs.inbrowser.dev/`,
-    redirect: (cid: string): string => `https://${cid}.ipfs.inbrowser.dev/`
+    url: (cid: string): string => `https://${cid}.ipfs.inbrowser.dev/`
   }, {
     name: 'inbrowser.dev (path gateway',
-    url: (cid: string): string => `https://inbrowser.dev/ipfs/${cid}/`,
-    redirect: (cid: string): string => `https://${cid}.ipfs.inbrowser.dev/`
+    url: (cid: string): string => `https://inbrowser.dev/ipfs/${cid}/`
   }]
 
   tests.forEach(t => {

--- a/benchmark/benchmark.test.ts
+++ b/benchmark/benchmark.test.ts
@@ -47,8 +47,7 @@ test.describe('@helia/service-worker-gateway - benchmark', () => {
         const response = await loadWithServiceWorker(page, t.url(CID), {
           // 'commit' means the response headers have been received and the page
           // is starting to load
-          waitUntil: 'commit',
-          redirect: t.redirect(CID)
+          waitUntil: 'commit'
         })
         time += (Date.now() - start)
         process.stdout.write('.')

--- a/benchmark/benchmark.test.ts
+++ b/benchmark/benchmark.test.ts
@@ -19,7 +19,7 @@ test.describe('@helia/service-worker-gateway - benchmark', () => {
     name: 'inbrowser.dev (subdomain gateway)',
     url: (cid: string): string => `https://${cid}.ipfs.inbrowser.dev/`
   }, {
-    name: 'inbrowser.dev (path gateway',
+    name: 'inbrowser.dev (path gateway)',
     url: (cid: string): string => `https://inbrowser.dev/ipfs/${cid}/`
   }]
 

--- a/test-e2e/ipns.test.ts
+++ b/test-e2e/ipns.test.ts
@@ -1,6 +1,4 @@
-import { peerIdFromString } from '@libp2p/peer-id'
 import { CID } from 'multiformats'
-import { base36 } from 'multiformats/bases/base36'
 import { identity } from 'multiformats/hashes/identity'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { CODE_RAW } from '../src/ui/pages/multicodec-table.ts'
@@ -39,12 +37,7 @@ test.describe('ipns', () => {
   test('should redirect b58 IPNS name in path gateway to CIDv1 b36 libp2p key', async ({ page, baseURL, protocol, host }) => {
     // @see TestRedirectCanonicalIPNS/GET_for_%2Fipns%2F%7Bb58-multihash-of-ed25519-key%7D_redirects_to_%2Fipns%2F%7Bcidv1-libp2p-key-base36%7D
     const name = '12D3KooWRBy97UB99e3J6hiPesre1MZeuNQvfan4gBziswrRJsNK'
-    const peerId = peerIdFromString(name)
-    const key = peerId.toCID().toString(base36)
-
-    const response = await loadWithServiceWorker(page, `${baseURL}/ipns/${name}/root2`, {
-      redirect: `${protocol}//${key}.ipns.${host}/root2`
-    })
+    const response = await loadWithServiceWorker(page, `${baseURL}/ipns/${name}/root2`)
 
     // performed redirect to re-encoded IPNS name but we can't resolve record so
     // expect a 504

--- a/test-e2e/smoke-test.test.ts
+++ b/test-e2e/smoke-test.test.ts
@@ -86,9 +86,7 @@ test.describe('smoke test', () => {
     const cid = 'bafkqablimvwgy3y'
     const asBase16 = CID.parse(cid).toString(base16)
 
-    const response = await loadWithServiceWorker(page, `${baseURL}/ipfs/${asBase16}`, {
-      redirect: `${protocol}//${cid}.ipfs.${host}/`
-    })
+    const response = await loadWithServiceWorker(page, `${baseURL}/ipfs/${asBase16}`)
     expect(response.status()).toBe(200)
     expect(await response.text()).toContain('hello')
   })
@@ -97,9 +95,7 @@ test.describe('smoke test', () => {
     const name = 'k51qzi5uqu5dk3v4rmjber23h16xnr23bsggmqqil9z2gduiis5se8dht36dam'
     const asBase16 = peerIdFromString(name).toCID().toString(base16)
 
-    const response = await loadWithServiceWorker(page, `${baseURL}/ipns/${asBase16}`, {
-      redirect: `${protocol}//${name}.ipns.${host}/`
-    })
+    const response = await loadWithServiceWorker(page, `${baseURL}/ipns/${asBase16}`)
     expect(response.status()).toBe(200)
     expect(await response.text()).toContain('hello')
   })
@@ -151,9 +147,7 @@ test.describe('smoke test', () => {
 
     const uri = new URL(`ipfs://${cid}`)
 
-    const response = await loadWithServiceWorker(page, `${baseURL}/ipfs/?uri=${encodeURIComponent(uri.toString())}`, {
-      redirect: `${protocol}//${cid}.ipfs.${host}/`
-    })
+    const response = await loadWithServiceWorker(page, `${baseURL}/ipfs/?uri=${encodeURIComponent(uri.toString())}`)
 
     expect(response?.status()).toBe(200)
     expect(await response?.headerValue('x-ipfs-path')).toBe(`/ipfs/${cid}`)
@@ -164,9 +158,7 @@ test.describe('smoke test', () => {
       format: 'raw'
     })
 
-    await loadWithServiceWorker(page, `${baseURL}/ipfs/${cid2}`, {
-      redirect: `${protocol}//${cid2}.ipfs.${host}/`
-    })
+    await loadWithServiceWorker(page, `${baseURL}/ipfs/${cid2}`)
 
     await page.locator('a').click()
 


### PR DESCRIPTION
Use `fromServiceWorker` to detect swg in benchmarks. Cannot use this in e2e tests as it is broken in Firefox.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
