### PR TITLE
refactor(ci): build in GitHub Actions, deploy to CF Pages via wrangler

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -1,3 +1,15 @@
+# Deploy to Production
+#
+# How it works:
+# 1. Calls the reusable deploy.yml workflow which builds the site
+#    in GitHub Actions and deploys pre-built dist/ to Cloudflare Pages
+#    via wrangler (--branch=production targets the production environment).
+# 2. Verifies the deployment is live on the CF Pages origin URL.
+# 3. Fetches any CF Pages deployment logs for debugging.
+# 4. Purges Cloudflare CDN cache for inbrowser.link and verifies
+#    the new version is served.
+# 5. Deploys Cloudflare Snippets to the production zone.
+
 name: Deploy to Production
 
 on:
@@ -25,7 +37,8 @@ jobs:
       tag: ${{ inputs.tag }}
       environment: production
     secrets:
-      DEPLOYMENT_GITHUB_TOKEN: ${{ secrets.UCI_GITHUB_TOKEN || github.token }}
+      CF_PAGES_TOKEN: ${{ secrets.CF_PAGES_TOKEN }}
+      CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
   # Cloudflare caching setup (configured via Cache Rules in the dashboard):
   # - Edge TTL and Browser TTL are set to 24h for faster cold cache hits
   # - cache key uses resolved host (not request host) and ignores query params,
@@ -41,14 +54,14 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-      - name: Wait for Cloudflare Pages build to complete
+      - name: Wait for deployment to be live on CF Pages origin
         timeout-minutes: 9
         run: |
           # fetch the tag to ensure it's available
           git fetch origin tag ${{ inputs.tag }} --no-tags
           # check Pages origin directly (bypasses CDN cache)
           ./.github/scripts/wait-for-deploy.sh https://ipfs-service-worker-gateway.pages.dev ${{ inputs.tag }}
-      - name: Fetch Cloudflare Pages build logs
+      - name: Fetch Cloudflare Pages deployment logs
         if: success() || failure()
         run: ./.github/scripts/fetch-cf-pages-logs.sh
         env:

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -1,3 +1,15 @@
+# Deploy to Staging
+#
+# How it works:
+# 1. Calls the reusable deploy.yml workflow which builds the site
+#    in GitHub Actions and deploys pre-built dist/ to Cloudflare Pages
+#    via wrangler (--branch=staging targets the staging environment).
+# 2. Verifies the deployment is live on the CF Pages origin URL.
+# 3. Fetches any CF Pages deployment logs for debugging.
+# 4. Purges Cloudflare CDN cache for inbrowser.dev and verifies
+#    the new version is served.
+# 5. Deploys Cloudflare Snippets to the staging zone.
+
 name: Deploy to Staging
 
 on:
@@ -25,7 +37,8 @@ jobs:
       tag: ${{ inputs.tag }}
       environment: staging
     secrets:
-      DEPLOYMENT_GITHUB_TOKEN: ${{ secrets.UCI_GITHUB_TOKEN || github.token }}
+      CF_PAGES_TOKEN: ${{ secrets.CF_PAGES_TOKEN }}
+      CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
   # Cloudflare caching setup (configured via Cache Rules in the dashboard):
   # - Edge TTL and Browser TTL are set to 24h for faster cold cache hits
   # - cache key uses resolved host (not request host) and ignores query params,
@@ -41,12 +54,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-      - name: Wait for Cloudflare Pages build to complete
+      - name: Wait for deployment to be live on CF Pages origin
         timeout-minutes: 9
         run: |
           # check Pages origin directly (bypasses CDN cache)
           ./.github/scripts/wait-for-deploy.sh https://staging.ipfs-service-worker-gateway.pages.dev ${{ inputs.tag }}
-      - name: Fetch Cloudflare Pages build logs
+      - name: Fetch Cloudflare Pages deployment logs
         if: success() || failure()
         run: ./.github/scripts/fetch-cf-pages-logs.sh
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,3 +1,10 @@
+# Reusable workflow: builds the site in GitHub Actions and deploys
+# the pre-built dist/ to Cloudflare Pages via wrangler.
+#
+# Called by deploy-to-staging.yml and deploy-to-production.yml.
+# The --branch flag passed to wrangler determines which CF Pages
+# environment (staging or production) receives the deployment.
+
 name: Deploy
 
 on:
@@ -8,15 +15,15 @@ on:
         required: true
         type: string
       environment:
-        description: 'Environment to deploy to'
+        description: 'Environment to deploy to (staging or production)'
         required: true
         type: string
     secrets:
-      DEPLOYMENT_GITHUB_TOKEN:
-        description: |
-          A GitHub token with the following permissions:
-          contents: write (required; to be able to push to the environment branch)
-          workflows: write (required; to be able to modify .github/workflows)
+      CF_PAGES_TOKEN:
+        description: 'Cloudflare API token with Pages:Edit permission'
+        required: true
+      CF_ACCOUNT_ID:
+        description: 'Cloudflare account ID'
         required: true
 
 permissions: {}
@@ -32,11 +39,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.DEPLOYMENT_GITHUB_TOKEN }}
-      - name: Set up git config
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - name: Verify tag
         env:
           TAG: ${{ inputs.tag }}
@@ -46,15 +48,32 @@ jobs:
             echo "Tag $TAG is not present in the history of main"
             exit 1
           fi
-      - name: Checkout environment branch
-        env:
-          ENVIRONMENT: ${{ inputs.environment }}
-        run: git checkout $ENVIRONMENT
-      - name: Reset environment branch to tag
+      - name: Resolve commit SHA
+        id: sha
         env:
           TAG: ${{ inputs.tag }}
-        run: git reset --hard $TAG
-      - name: Force push environment branch
+        run: |
+          SHA=$(git rev-parse "$TAG")
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+      - name: Checkout tag
         env:
-          ENVIRONMENT: ${{ inputs.environment }}
-        run: git push -f origin $ENVIRONMENT
+          TAG: ${{ inputs.tag }}
+        run: git checkout "$TAG"
+      - uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+      - uses: ipfs/aegir/actions/cache-node-modules@main
+      # always rebuild from the checked-out tag to ensure dist/ is correct
+      # (aegir cache action skips the build on cache hit)
+      - run: npm run build
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CF_PAGES_TOKEN }}
+          accountId: ${{ secrets.CF_ACCOUNT_ID }}
+          command: >-
+            pages deploy ./dist
+            --project-name=ipfs-service-worker-gateway
+            --branch=${{ inputs.environment }}
+            --commit-hash=${{ steps.sha.outputs.sha }}
+            --commit-dirty=true


### PR DESCRIPTION
This PR moves the site build from Cloudflare Pages to GitHub Actions so build logs are directly visible in the workflow run instead of fetched via the CF API after the fact.

`deploy.yml` now checks out the tag, runs `npm run build` via the aegir cache action, and uploads the pre-built dist/ to CF Pages using `wrangler pages deploy --branch=<environment>`. this replaces the previous approach of force-pushing the tag to staging/production branches to trigger a build on Cloudflare's side.

the staging and production git branches are no longer needed for deployments -- wrangler's `--branch` flag determines the target environment. the CF Pages GitHub integration should be disconnected (or its build command set to empty) after this lands.

secrets changed:
- added `CF_PAGES_TOKEN` to staging/production envs (Cloudflare API token with Pages:Edit permission)
- reuses existing `CF_ACCOUNT_ID`
- removed `DEPLOYMENT_GITHUB_TOKEN` from deploy workflows

cc @achingbrain for visibility -- I'm going to merge this and re-deploy latest staging to smoke-test, then comment below with result