### PR TITLE
fix: resolve DNSLink records that point to IPNS names

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@helia/delegated-routing-v1-http-api-client": "^6.0.1",
     "@helia/routers": "^5.0.2",
     "@helia/utils": "^2.4.1",
-    "@helia/verified-fetch": "^7.0.0",
+    "@helia/verified-fetch": "^7.0.1",
     "@ipld/dag-cbor": "^9.2.5",
     "@ipld/dag-json": "^10.2.5",
     "@ipld/dag-pb": "^4.1.5",

--- a/test-conformance/fixtures/constants.ts
+++ b/test-conformance/fixtures/constants.ts
@@ -1,1 +1,1 @@
-export const GWC_IMAGE = process.env.GWC_IMAGE ?? 'ghcr.io/ipfs/gateway-conformance:v0.10.1'
+export const GWC_IMAGE = process.env.GWC_IMAGE ?? 'ghcr.io/ipfs/gateway-conformance:v0.11.0'

--- a/test-e2e/dnslink.test.ts
+++ b/test-e2e/dnslink.test.ts
@@ -1,0 +1,66 @@
+import { peerIdFromString } from '@libp2p/peer-id'
+import { CID } from 'multiformats'
+import { identity } from 'multiformats/hashes/identity'
+import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
+import { CODE_RAW } from '../src/ui/pages/multicodec-table.ts'
+import { test, expect } from './fixtures/config-test-fixtures.ts'
+import { loadWithServiceWorker } from './fixtures/load-with-service-worker.ts'
+import { publishDNSLink } from './fixtures/serve/dns-record-cache.ts'
+
+test.describe('DNSLink', () => {
+  test('should load a DNSLink record', async ({ page, baseURL }) => {
+    const domain = 'ipns-happy-path.com'
+    const cid = CID.createV1(CODE_RAW, identity.digest(uint8ArrayFromString('hello world')))
+
+    await publishDNSLink(domain, cid)
+
+    const response = await loadWithServiceWorker(page, `${baseURL}/ipns/${domain}`)
+
+    expect(response.status()).toBe(200)
+    expect(await response.text()).toContain('hello world')
+  })
+
+  test('should load a DNSLink record with a path', async ({ page, baseURL }) => {
+    const domain = 'ipns-with-path.com'
+    const cid = CID.parse('bafybeib3ffl2teiqdncv3mkz4r23b5ctrwkzrrhctdbne6iboayxuxk5ui')
+    const path = 'root2/root3/root4'
+
+    await publishDNSLink(domain, cid)
+
+    // TODO: use rootDomain
+    const response = await loadWithServiceWorker(page, `${baseURL}/ipns/${domain}/${path}`)
+
+    expect(response.status()).toBe(200)
+    expect(await response.text()).toContain('hello')
+  })
+
+  test('should load a DNSLink record that resolves to an IPNS name', async ({ page, baseURL }) => {
+    const name = 'k51qzi5uqu5dhjghbwdvbo6mi40htrq6e2z4pwgp15pgv3ho1azvidttzh8yy2'
+    const cid = 'baguqeeram5ujjqrwheyaty3w5gdsmoz6vittchvhk723jjqxk7hakxkd47xq'
+    const peerId = peerIdFromString(name)
+    const domain = 'recursive-dnslink.com'
+
+    await publishDNSLink(domain, peerId)
+
+    const response = await loadWithServiceWorker(page, `${baseURL}/ipns/${domain}`)
+    expect(response.status()).toBe(200)
+
+    const headers = await response.allHeaders()
+    expect(headers?.['content-type']).toContain('application/vnd.ipld.dag-json')
+    expect(headers?.['cache-control']).toBe('public, max-age=60')
+    expect(headers?.['etag']).toBe(`"${cid}.dag-json"`)
+    expect(headers?.['x-ipfs-path']).toBe(`/ipns/${domain}`)
+
+    expect(await response?.json()).toStrictEqual({
+      foo: {
+        link: {
+          '/': 'baguqeeraxpdqyfizawpb7zl5gnpg7jw3myuynb42ngzmeo7xn5kmm5pabt6q'
+        },
+        object: {
+          banana: 10,
+          monkey: false
+        }
+      }
+    })
+  })
+})

--- a/test-e2e/ipns.test.ts
+++ b/test-e2e/ipns.test.ts
@@ -1,18 +1,12 @@
-import { CID } from 'multiformats'
-import { identity } from 'multiformats/hashes/identity'
-import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
-import { CODE_RAW } from '../src/ui/pages/multicodec-table.ts'
 import { test, expect } from './fixtures/config-test-fixtures.ts'
 import { loadWithServiceWorker } from './fixtures/load-with-service-worker.ts'
-import { publishDNSLink } from './fixtures/serve/dns-record-cache.ts'
 
-test.describe('ipns', () => {
+test.describe('IPNS', () => {
   test('should resolve IPNS name and return as dag-json', async ({ page, baseURL }) => {
     const name = 'k51qzi5uqu5dhjghbwdvbo6mi40htrq6e2z4pwgp15pgv3ho1azvidttzh8yy2'
     const cid = 'baguqeeram5ujjqrwheyaty3w5gdsmoz6vittchvhk723jjqxk7hakxkd47xq'
 
     const response = await loadWithServiceWorker(page, `${baseURL}/ipns/${name}?format=dag-json`)
-
     expect(response.status()).toBe(200)
 
     const headers = await response.allHeaders()
@@ -42,31 +36,5 @@ test.describe('ipns', () => {
     // performed redirect to re-encoded IPNS name but we can't resolve record so
     // expect a 504
     expect(response.status()).toBe(504)
-  })
-
-  test('should load an IPNS domain', async ({ page, baseURL }) => {
-    const domain = 'ipns-happy-path.com'
-    const cid = CID.createV1(CODE_RAW, identity.digest(uint8ArrayFromString('hello world')))
-
-    await publishDNSLink(domain, cid)
-
-    const response = await loadWithServiceWorker(page, `${baseURL}/ipns/${domain}`)
-
-    expect(response.status()).toBe(200)
-    expect(await response.text()).toContain('hello world')
-  })
-
-  test('should load an IPNS domain with a path', async ({ page, baseURL }) => {
-    const domain = 'ipns-with-path.com'
-    const cid = CID.parse('bafybeib3ffl2teiqdncv3mkz4r23b5ctrwkzrrhctdbne6iboayxuxk5ui')
-    const path = 'root2/root3/root4'
-
-    await publishDNSLink(domain, cid)
-
-    // TODO: use rootDomain
-    const response = await loadWithServiceWorker(page, `${baseURL}/ipns/${domain}/${path}`)
-
-    expect(response.status()).toBe(200)
-    expect(await response.text()).toContain('hello')
   })
 })


### PR DESCRIPTION
Update `@helia/verified-fetch` to resolve DNSLink records correctly when the record resolves to an IPNS name.

Fixes #991

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
