### PR TITLE
fix: include server-timing header on abort

### DIFF
--- a/src/sw/handlers/content-request-handler.ts
+++ b/src/sw/handlers/content-request-handler.ts
@@ -1,4 +1,4 @@
-import { MEDIA_TYPE_CAR, MEDIA_TYPE_CBOR, MEDIA_TYPE_DAG_CBOR, MEDIA_TYPE_DAG_JSON, MEDIA_TYPE_DAG_PB, MEDIA_TYPE_IPNS_RECORD, MEDIA_TYPE_JSON, MEDIA_TYPE_RAW, MEDIA_TYPE_TAR } from '@helia/verified-fetch'
+import { isAbortWithServerTimingError, MEDIA_TYPE_CAR, MEDIA_TYPE_CBOR, MEDIA_TYPE_DAG_CBOR, MEDIA_TYPE_DAG_JSON, MEDIA_TYPE_DAG_PB, MEDIA_TYPE_IPNS_RECORD, MEDIA_TYPE_JSON, MEDIA_TYPE_RAW, MEDIA_TYPE_TAR } from '@helia/verified-fetch'
 import { setMaxListeners, TimeoutError } from '@libp2p/interface'
 import { anySignal } from 'any-signal'
 import { config } from '../../config/index.ts'
@@ -360,28 +360,40 @@ async function fetchHandler ({ request, headers, renderHtml, event, logs, accept
       statusText: response.statusText
     })
   } catch (err: any) {
+    let response: Response
+    let responseBody: string
+
     if (abortController.signal.aborted) {
-      return fetchErrorPageResponse(request, init, new Response('', {
+      response = new Response('', {
         status: 504,
         statusText: 'Gateway Timeout',
         headers: {
           'content-type': 'application/json'
         }
-      }), JSON.stringify(errorToObject(abortController.signal.reason), null, 2), providers, firstInstallTime, logs)
+      })
+
+      responseBody = JSON.stringify(errorToObject(abortController.signal.reason), null, 2)
+    } else {
+      abortController.abort(err)
+      log.error('error during request - %e', err)
+
+      response = new Response('', {
+        status: 500,
+        statusText: 'Internal Server Error',
+        headers: {
+          'content-type': 'application/json',
+          'x-error-message': btoa(err.message)
+        }
+      })
+
+      responseBody = JSON.stringify(errorToObject(err), null, 2)
     }
 
-    abortController.abort(err)
+    if (isAbortWithServerTimingError(err)) {
+      response.headers.set('server-timing', err.serverTiming)
+    }
 
-    log.error('error during request - %e', err)
-
-    return fetchErrorPageResponse(request, init, new Response('', {
-      status: 500,
-      statusText: 'Internal Server Error',
-      headers: {
-        'content-type': 'application/json',
-        'x-error-message': btoa(err.message)
-      }
-    }), JSON.stringify(errorToObject(err), null, 2), providers, firstInstallTime, logs)
+    return fetchErrorPageResponse(request, init, response, responseBody, providers, firstInstallTime, logs)
   } finally {
     signal.clear()
     clearTimeout(timeout)

--- a/test-e2e/error-pages.test.ts
+++ b/test-e2e/error-pages.test.ts
@@ -1,6 +1,7 @@
 import { test, expect } from './fixtures/config-test-fixtures.ts'
 import { findIpAddress } from './fixtures/find-ip-address.ts'
 import { loadWithServiceWorker } from './fixtures/load-with-service-worker.ts'
+import { makeFetchRequest } from './fixtures/make-range-request.ts'
 
 test.describe('error pages', () => {
   test('it should show a message for unsupported hash algorithms', async ({ page, baseURL }) => {
@@ -30,5 +31,12 @@ test.describe('error pages', () => {
     })
 
     expect(await page.$('.e2e-no-service-worker-error')).toBeTruthy()
+  })
+
+  test('it should include Server-Timing header in error responses', async ({ page, baseURL }) => {
+    // uses un-configured dbl-sha2-256 algorithm
+    const response = await makeFetchRequest(page, `${baseURL}/ipfs/bahaacvrabdhd3fzrwaambazyivoiustl2bo2c3rgweo2ug4rogcoz2apaqaa`)
+    expect(response.status()).toBe(500)
+    expect(await response.headerValue('server-timing')).toBeTruthy()
   })
 })


### PR DESCRIPTION
When a request times out and throws an abort error, include the server-timing header so we can see how far the request got.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
