### PR TITLE
fix: remove invalid conversions

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@helia/delegated-routing-v1-http-api-client": "^6.0.1",
     "@helia/routers": "^5.1.0",
     "@helia/utils": "^2.5.0",
-    "@helia/verified-fetch": "^7.2.1",
+    "@helia/verified-fetch": "^7.2.7",
     "@ipld/dag-cbor": "^9.2.5",
     "@ipld/dag-json": "^10.2.5",
     "@ipld/dag-pb": "^4.1.5",

--- a/src/ui/components/download-form.tsx
+++ b/src/ui/components/download-form.tsx
@@ -169,10 +169,6 @@ export default function DownloadForm ({
           <option value='raw'>Raw</option>
           <option value='car'>CAR</option>
           <option value='tar'>TAR</option>
-          <option value='dag-json'>DAG-JSON</option>
-          <option value='dag-cbor'>DAG-CBOR</option>
-          <option value='json'>JSON</option>
-          <option value='cbor'>CBOR</option>
           <option value='ipns-record'>IPNS Record</option>
         </InputSelect>
 

--- a/test-e2e/cbor.test.ts
+++ b/test-e2e/cbor.test.ts
@@ -2,7 +2,6 @@ import { stop } from '@libp2p/interface'
 import * as cbor from 'cborg'
 import { createKuboRPCClient } from 'kubo-rpc-client'
 import { test, expect } from './fixtures/config-test-fixtures.ts'
-import { IPLD_CONVERSIONS } from './fixtures/ipld-conversions.ts'
 import { loadWithServiceWorker } from './fixtures/load-with-service-worker.ts'
 import type { KuboRPCClient } from 'kubo-rpc-client'
 import type { CID } from 'multiformats/cid'
@@ -52,20 +51,4 @@ test.describe('cbor', () => {
 
     expect(cbor.decode(await response?.body())).toStrictEqual(object)
   })
-
-  for (const conversion of IPLD_CONVERSIONS) {
-    // eslint-disable-next-line no-loop-func
-    test(`should return cbor block as ${conversion.format}`, async ({ page, baseURL }) => {
-      const response = await loadWithServiceWorker(page, `${baseURL}/ipfs/${cid}?format=${conversion.format}&download=true`)
-      expect(response.status()).toBe(200)
-
-      const headers = await response.allHeaders()
-      expect(headers['content-type']).toContain(conversion.mediaType)
-      expect(headers['cache-control']).toBe('public, max-age=29030400, immutable')
-      expect(headers['content-disposition']).toContain(conversion.disposition)
-      expect(headers['content-disposition']).toContain(conversion.filename(cid))
-
-      expect(await conversion.decode(response)).toStrictEqual(object)
-    })
-  }
 })

--- a/test-e2e/dag-cbor.test.ts
+++ b/test-e2e/dag-cbor.test.ts
@@ -1,8 +1,8 @@
 import * as dagCbor from '@ipld/dag-cbor'
+import * as cbor from 'cborg'
 import { createKuboRPCClient } from 'kubo-rpc-client'
 import { CID } from 'multiformats/cid'
 import { test, expect } from './fixtures/config-test-fixtures.ts'
-import { IPLD_CONVERSIONS } from './fixtures/ipld-conversions.ts'
 import { loadWithServiceWorker } from './fixtures/load-with-service-worker.ts'
 import type { KuboRPCClient } from 'kubo-rpc-client'
 
@@ -50,20 +50,16 @@ test.describe('dag-cbor', () => {
     expect(dagCbor.decode(await response?.body())).toStrictEqual(object)
   })
 
-  for (const conversion of IPLD_CONVERSIONS) {
-    // eslint-disable-next-line no-loop-func
-    test(`should return dag-cbor block as ${conversion.format}`, async ({ page, baseURL }) => {
-      const response = await loadWithServiceWorker(page, `${baseURL}/ipfs/${cid}?format=${conversion.format}&download=true`)
+  test(`should return dag-cbor block as cbor`, async ({ page, baseURL }) => {
+    const response = await loadWithServiceWorker(page, `${baseURL}/ipfs/${cid}?format=cbor&download=true`)
+    expect(response.status()).toBe(200)
 
-      expect(response.status()).toBe(200)
+    const headers = await response.allHeaders()
+    expect(headers['content-type']).toContain('application/cbor')
+    expect(headers['cache-control']).toBe('public, max-age=29030400, immutable')
+    expect(headers['content-disposition']).toContain('attachment')
+    expect(headers['content-disposition']).toContain(`${cid}.cbor`)
 
-      const headers = await response.allHeaders()
-      expect(headers['content-type']).toContain(conversion.mediaType)
-      expect(headers['cache-control']).toBe('public, max-age=29030400, immutable')
-      expect(headers['content-disposition']).toContain(conversion.disposition)
-      expect(headers['content-disposition']).toContain(conversion.filename(cid))
-
-      expect(await conversion.decode(response)).toStrictEqual(object)
-    })
-  }
+    expect(await cbor.decode(await response.body())).toStrictEqual(object)
+  })
 })

--- a/test-e2e/dag-cbor.test.ts
+++ b/test-e2e/dag-cbor.test.ts
@@ -50,7 +50,7 @@ test.describe('dag-cbor', () => {
     expect(dagCbor.decode(await response?.body())).toStrictEqual(object)
   })
 
-  test(`should return dag-cbor block as cbor`, async ({ page, baseURL }) => {
+  test('should return dag-cbor block as cbor', async ({ page, baseURL }) => {
     const response = await loadWithServiceWorker(page, `${baseURL}/ipfs/${cid}?format=cbor&download=true`)
     expect(response.status()).toBe(200)
 

--- a/test-e2e/dag-json.test.ts
+++ b/test-e2e/dag-json.test.ts
@@ -3,7 +3,6 @@ import { stop } from '@libp2p/interface'
 import { createKuboRPCClient } from 'kubo-rpc-client'
 import { CID } from 'multiformats/cid'
 import { test, expect } from './fixtures/config-test-fixtures.ts'
-import { IPLD_CONVERSIONS } from './fixtures/ipld-conversions.ts'
 import { loadWithServiceWorker } from './fixtures/load-with-service-worker.ts'
 import type { KuboRPCClient } from 'kubo-rpc-client'
 
@@ -55,24 +54,16 @@ test.describe('dag-json', () => {
     expect(dagJson.decode(await response?.body())).toStrictEqual(object)
   })
 
-  for (const conversion of IPLD_CONVERSIONS) {
-    // eslint-disable-next-line no-loop-func
-    test(`should return dag-json block as ${conversion.format}`, async ({ page, baseURL }) => {
-      const response = await loadWithServiceWorker(page, `${baseURL}/ipfs/${cid}?format=${conversion.format}&download=true`)
+  test(`should return dag-json block as json`, async ({ page, baseURL }) => {
+    const response = await loadWithServiceWorker(page, `${baseURL}/ipfs/${cid}?format=json&download=true`)
+    expect(response.status()).toBe(200)
 
-      expect(response.status()).toBe(200)
+    const headers = await response.allHeaders()
+    expect(headers['content-type']).toContain('application/json')
+    expect(headers['cache-control']).toBe('public, max-age=29030400, immutable')
+    expect(headers['content-disposition']).toContain('attachment')
+    expect(headers['content-disposition']).toContain(`${cid}.json`)
 
-      const headers = await response.allHeaders()
-      expect(headers['content-type']).toContain(conversion.mediaType)
-      expect(headers['cache-control']).toBe('public, max-age=29030400, immutable')
-      expect(headers['content-disposition']).toContain(conversion.disposition)
-      expect(headers['content-disposition']).toContain(conversion.filename(cid))
-
-      if (headers['content-type'].includes('application/json') || headers['content-type'].includes('application/cbor')) {
-        expect(new Uint8Array(await response.body())).toStrictEqual(block)
-      } else {
-        expect(await conversion.decode(response)).toStrictEqual(object)
-      }
-    })
-  }
+    expect(new Uint8Array(await response.body())).toStrictEqual(block)
+  })
 })

--- a/test-e2e/dag-json.test.ts
+++ b/test-e2e/dag-json.test.ts
@@ -54,7 +54,7 @@ test.describe('dag-json', () => {
     expect(dagJson.decode(await response?.body())).toStrictEqual(object)
   })
 
-  test(`should return dag-json block as json`, async ({ page, baseURL }) => {
+  test('should return dag-json block as json', async ({ page, baseURL }) => {
     const response = await loadWithServiceWorker(page, `${baseURL}/ipfs/${cid}?format=json&download=true`)
     expect(response.status()).toBe(200)
 

--- a/test-e2e/download-form.test.ts
+++ b/test-e2e/download-form.test.ts
@@ -1,14 +1,10 @@
 import fs from 'node:fs'
 import fsp from 'node:fs/promises'
 import { CarReader } from '@ipld/car'
-import * as dagCbor from '@ipld/dag-cbor'
-import * as dagJson from '@ipld/dag-json'
-import * as cbor from 'cborg'
 import { unmarshalIPNSRecord } from 'ipns'
 import all from 'it-all'
 import toBuffer from 'it-to-buffer'
 import { CID } from 'multiformats/cid'
-import * as json from 'multiformats/codecs/json'
 import * as tar from 'tar'
 import { test, expect } from './fixtures/config-test-fixtures.ts'
 import type { Download, Page, Response } from 'playwright'
@@ -582,84 +578,6 @@ test.describe('download form', () => {
 
     expect(files['bafkqaddimvwgy3zao5xxe3debi']).toBeTruthy()
     expect(new TextDecoder().decode(files['bafkqaddimvwgy3zao5xxe3debi'])).toBe('hello world\n')
-  })
-
-  test('should download a block and specify DAG-JSON format', async ({ page }) => {
-    const obj = {
-      hello: CID.parse('bafkqaddimvwgy3zao5xxe3debi')
-    }
-
-    const downloadPromise = page.waitForEvent('download')
-    await page.fill('#inputContent', '/ipfs/baguqeerasfd64cjvzypw23uldj56sxclylkk264h2t76cks4vl7g5ilca3aq')
-    await page.click('#show-advanced')
-    await page.selectOption('#download', 'true')
-    await page.selectOption('#format', 'dag-json')
-    await page.click('#load-directly')
-
-    download = await downloadPromise
-
-    const file = await fsp.readFile(await download.path())
-    const decoded = dagJson.decode(file)
-    expect(decoded).toStrictEqual(obj)
-  })
-
-  test('should download a block and specify DAG-CBOR format', async ({ page }) => {
-    const obj = {
-      hello: CID.parse('bafkqaddimvwgy3zao5xxe3debi')
-    }
-
-    const downloadPromise = page.waitForEvent('download')
-    await page.fill('#inputContent', '/ipfs/bafyreicqloxaaoq4f5ykqits4iktnmvab62i7nqanv4uce55ep4f6omnvm')
-    await page.click('#show-advanced')
-    await page.selectOption('#download', 'true')
-    await page.selectOption('#format', 'dag-cbor')
-    await page.click('#load-directly')
-
-    download = await downloadPromise
-
-    const file = await fsp.readFile(await download.path())
-    const decoded = dagCbor.decode(file)
-    expect(decoded).toStrictEqual(obj)
-  })
-
-  test('should download a block and specify JSON format', async ({ page }) => {
-    const obj = {
-      hello: {
-        '/': 'bafkqaddimvwgy3zao5xxe3debi'
-      }
-    }
-
-    const downloadPromise = page.waitForEvent('download')
-    await page.fill('#inputContent', '/ipfs/baguqeerasfd64cjvzypw23uldj56sxclylkk264h2t76cks4vl7g5ilca3aq')
-    await page.click('#show-advanced')
-    await page.selectOption('#download', 'true')
-    await page.selectOption('#format', 'json')
-    await page.click('#load-directly')
-
-    download = await downloadPromise
-
-    const file = await fsp.readFile(await download.path())
-    const decoded = json.decode(file)
-    expect(decoded).toStrictEqual(obj)
-  })
-
-  test('should download a block and specify CBOR format', async ({ page }) => {
-    const obj = {
-      hello: 'world'
-    }
-
-    const downloadPromise = page.waitForEvent('download')
-    await page.fill('#inputContent', '/ipfs/bafireidykglsfhoixmivffc5uwhcgshx4j465xwqntbmu43nb2dzqwfvae')
-    await page.click('#show-advanced')
-    await page.selectOption('#download', 'true')
-    await page.selectOption('#format', 'cbor')
-    await page.click('#load-directly')
-
-    download = await downloadPromise
-
-    const file = await fsp.readFile(await download.path())
-    const decoded = cbor.decode(file)
-    expect(decoded).toStrictEqual(obj)
   })
 
   test('should download a block and specify IPNS Record format', async ({ page }) => {

--- a/test-e2e/json.test.ts
+++ b/test-e2e/json.test.ts
@@ -3,7 +3,6 @@ import { createKuboRPCClient } from 'kubo-rpc-client'
 import * as json from 'multiformats/codecs/json'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { test, expect } from './fixtures/config-test-fixtures.ts'
-import { IPLD_CONVERSIONS } from './fixtures/ipld-conversions.ts'
 import { loadWithServiceWorker } from './fixtures/load-with-service-worker.ts'
 import { makeFetchRequest } from './fixtures/make-range-request.ts'
 import type { KuboRPCClient } from 'kubo-rpc-client'
@@ -55,27 +54,6 @@ test.describe('json', () => {
 
     expect(await response.json()).toStrictEqual(object)
   })
-
-  for (const conversion of IPLD_CONVERSIONS) {
-    // eslint-disable-next-line no-loop-func
-    test(`should return json block as ${conversion.format}`, async ({ page, baseURL }) => {
-      const response = await loadWithServiceWorker(page, `${baseURL}/ipfs/${cid}?format=${conversion.format}&download=true`)
-
-      expect(response.status()).toBe(200)
-
-      const headers = await response.allHeaders()
-      expect(headers['content-type']).toContain(conversion.mediaType)
-      expect(headers['cache-control']).toBe('public, max-age=29030400, immutable')
-      expect(headers['content-disposition']).toContain(conversion.disposition)
-      expect(headers['content-disposition']).toContain(conversion.filename(cid))
-
-      if (headers['content-type'].includes('application/json') || headers['content-type'].includes('application/cbor')) {
-        expect(new Uint8Array(await response.body())).toStrictEqual(block)
-      } else {
-        expect(await conversion.decode(response)).toStrictEqual(object)
-      }
-    })
-  }
 
   test('should load json file with raw codec as application/json without headers', async ({ page, baseURL }) => {
     const body = '{ "test": "i am a plain json file" }\n'


### PR DESCRIPTION
In line with [IPIP-0524](https://github.com/ipfs/specs/pull/524), remove unsupported conversions (e.g. json -> dag-json, cbor -> dag-cbor) as these are not possbile due to the constraints the dag-* version codecs place on field types and ordering.

Refs: https://github.com/ipfs/helia-verified-fetch/pull/342

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
