### PR TITLE
fix: set subdomain url from stored form input

### DIFF
--- a/src/ui/components/cid-input.tsx
+++ b/src/ui/components/cid-input.tsx
@@ -60,6 +60,23 @@ export interface CIDInputProps {
   setInvalid(invalid: boolean): void
 }
 
+export function parseSubdomain (val: string): URL | undefined {
+  // it may be just a CID
+  try {
+    CID.parse(val)
+
+    val = `/ipfs/${val}`
+  } catch {
+    // ignore
+  }
+
+  const request = parseRequest(val, new URL(globalThis.location.href))
+
+  if (request.type === 'subdomain' || request.type === 'path' || request.type === 'native') {
+    return request.subdomainURL
+  }
+}
+
 export function CIDInput ({ input, setInput, setSubdomainURL, setInvalid }: CIDInputProps): ReactElement {
   let initialErrorElement: ReactElement | undefined
 
@@ -68,32 +85,13 @@ export function CIDInput ({ input, setInput, setSubdomainURL, setInvalid }: CIDI
   function validate (val: string): void {
     setInput(val)
 
-    // it may be just a CID
     try {
-      CID.parse(val)
+      const subdomainURL = parseSubdomain(val)
 
-      val = `/ipfs/${val}`
-    } catch {
-      // ignore
-    }
-
-    try {
-      const request = parseRequest(val, new URL(globalThis.location.href))
-
-      if (request.type === 'subdomain' || request.type === 'path' || request.type === 'native') {
-        if (request.protocol === 'ipfs') {
-          setSubdomainURL(request.subdomainURL)
-          setInvalid(false)
-          return
-        } else if (request.protocol === 'ipns') {
-          setSubdomainURL(request.subdomainURL)
-          setInvalid(false)
-          return
-        } else if (request.protocol === 'dnslink') {
-          setSubdomainURL(request.subdomainURL)
-          setInvalid(false)
-          return
-        }
+      if (subdomainURL != null) {
+        setSubdomainURL(subdomainURL)
+        setInvalid(false)
+        return
       }
     } catch (err) {
       setErrorElement(<FormatHelp />)

--- a/src/ui/pages/home.tsx
+++ b/src/ui/pages/home.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react'
 import { LOCAL_STORAGE_KEYS } from '../../lib/local-storage.ts'
 import { removeRootHashIfPresent } from '../../lib/remove-root-hash.ts'
+import { parseSubdomain } from '../components/cid-input.tsx'
 import DownloadForm from '../components/download-form.tsx'
 import './default-page-styles.css'
 import type { ReactElement } from 'react'
@@ -8,10 +9,23 @@ import type { ReactElement } from 'react'
 function LoadContent (): ReactElement {
   removeRootHashIfPresent()
 
-  const initialInput = localStorage.getItem(LOCAL_STORAGE_KEYS.forms.requestPath) ?? ''
+  let initialInput = localStorage.getItem(LOCAL_STORAGE_KEYS.forms.requestPath) ?? ''
+  let initialSubdomainUrl
+
+  if (initialInput !== '') {
+    try {
+      initialSubdomainUrl = parseSubdomain(initialInput)
+
+      if (initialSubdomainUrl == null) {
+        initialInput = ''
+      }
+    } catch (err) {
+      initialInput = ''
+    }
+  }
 
   const [input, setInput] = useState(initialInput)
-  const [subdomainURL, setSubdomainURL] = useState<URL | undefined>()
+  const [subdomainURL, setSubdomainURL] = useState<URL | undefined>(initialSubdomainUrl)
   const [download, setDownload] = useState('')
   const [format, setFormat] = useState('')
   const [filename, setFilename] = useState('')
@@ -26,7 +40,7 @@ function LoadContent (): ReactElement {
     localStorage.setItem(LOCAL_STORAGE_KEYS.forms.requestPath, input)
   }, [input])
 
-  const handleSubmit = async (e: React.FormEvent): Promise<void> => {
+  const handleSubmit = async (e: React.SubmitEvent): Promise<void> => {
     e.stopPropagation()
     e.preventDefault()
 

--- a/test-e2e/download-form.test.ts
+++ b/test-e2e/download-form.test.ts
@@ -678,4 +678,23 @@ test.describe('download form', () => {
     expect(decoded.validityType).toEqual('EOL')
     expect(decoded.validity).toEqual('2123-04-12T13:44:59.801728Z')
   })
+
+  test('should reload the page and submit the form', async ({ page }) => {
+    const downloadPromise = page.waitForEvent('download')
+
+    await page.fill('#inputContent', '/ipfs/bafkqaddimvwgy3zao5xxe3debi')
+    await page.reload()
+
+    await page.click('#show-advanced')
+    await page.selectOption('#download', 'true')
+    await page.click('#load-directly')
+
+    download = await downloadPromise
+
+    const file = await fsp.readFile(await download.path(), {
+      encoding: 'utf-8'
+    })
+
+    expect(file).toBe('hello world\n')
+  })
 })


### PR DESCRIPTION
Without updating the expected subdomain url, the form is not submittable even though valid input has been pre-filled into the input field.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
