### PR TITLE
feat: show ui after download

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "concurrently": "^9.1.2",
     "cors": "^2.8.5",
     "cross-env": "^10.1.0",
+    "delay": "^7.0.0",
     "esbuild": "^0.28.0",
     "fast-glob": "^3.3.3",
     "glob": "^13.0.0",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -103,9 +103,10 @@ async function main (): Promise<void> {
   }
 
   try {
-    if (request?.type === 'path' || request?.type === 'native') {
+    if (request.type === 'path' || request.type === 'native') {
       // redirect to subdomain
       window.location.href = request.subdomainURL.href
+      showUIAfterDelay(request)
       return
     }
 
@@ -129,6 +130,7 @@ async function main (): Promise<void> {
 
           if (request.type === 'subdomain' || request.type === 'path' || request.type === 'native') {
             window.location.href = request.subdomainURL.href
+            showUIAfterDelay(request)
             return
           }
           return
@@ -164,6 +166,7 @@ async function main (): Promise<void> {
 
       // reload so the subdomain request is handled by the service worker
       window.location.href = url.toString()
+      showUIAfterDelay(request)
       return
     }
   } catch (err: any) {
@@ -243,6 +246,21 @@ function tooManyRedirects (storageKey: string, maxRedirects = 5, period = 5_000)
   localStorage.setItem(storageKey, JSON.stringify(recent))
 
   return recent.length > maxRedirects
+}
+
+/**
+ * If the requested URL triggers a download, the currently displayed page will
+ * not change so show the user something, otherwise it looks like they are stuck
+ * on a loading page
+ */
+function showUIAfterDelay (request: ResolvableURI): void {
+  setTimeout(() => {
+    globalThis.downloadingPage = {
+      request
+    }
+
+    renderUi()
+  }, 500)
 }
 
 main()

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -1,12 +1,13 @@
 import React from 'react'
 import ReactDOMClient from 'react-dom/client'
 import './index.css'
-import { FaInfoCircle, FaGithub, FaExclamationTriangle, FaExclamationCircle, FaHome, FaListAlt } from 'react-icons/fa'
+import { FaInfoCircle, FaGithub, FaExclamationTriangle, FaExclamationCircle, FaHome, FaListAlt, FaFileDownload } from 'react-icons/fa'
 import { HashRouter, Route, Routes, NavLink } from 'react-router-dom'
 import { HASH_FRAGMENTS } from '../lib/constants.ts'
 import { ErrorBoundary } from './components/error-boundary.tsx'
 import ipfsLogo from './ipfs-logo.svg'
 import AboutPage from './pages/about.tsx'
+import { DownloadingPage } from './pages/downloading-page.tsx'
 import { FetchErrorPage } from './pages/fetch-error.tsx'
 import HomePage from './pages/home.tsx'
 import NoServiceWorkerErrorPage from './pages/no-service-worker.tsx'
@@ -74,6 +75,14 @@ function Header (): React.ReactElement {
     )
   }
 
+  if (globalThis.downloadingPage != null) {
+    errorPageLink = (
+      <NavLink to='/' className={({ isActive }) => (isActive || globalThis.location.hash === '') ? 'white' : 'aqua'} onClickCapture={doNothingIfClickedOnRoot}>
+        <FaFileDownload className='ml2 f3' />
+      </NavLink>
+    )
+  }
+
   return (
     <header className='e2e-header flex items-center pa2 bg-navy bb bw3 b--aqua tc justify-between'>
       <div>
@@ -124,6 +133,12 @@ function getIndexRoute (): React.ReactElement {
   if (globalThis.renderEntity != null && globalThis.location.hash === '') {
     return (
       <Route element={<RenderEntityPage />} index />
+    )
+  }
+
+  if (globalThis.downloadingPage != null) {
+    return (
+      <Route element={<DownloadingPage />} index />
     )
   }
 

--- a/src/ui/pages/downloading-page.tsx
+++ b/src/ui/pages/downloading-page.tsx
@@ -1,0 +1,89 @@
+import React from 'react'
+import { parseRequest } from '../../lib/parse-request.ts'
+import { removeRootHashIfPresent } from '../../lib/remove-root-hash.ts'
+import { toGatewayRoot } from '../../lib/to-gateway-root.ts'
+import { Button } from '../components/button.tsx'
+import ContentBox from '../components/content-box.tsx'
+import { createLink } from '../utils/links.ts'
+import type { ResolvableURI } from '../../lib/parse-request-cheap.ts'
+import type { ReactElement } from 'react'
+
+declare global {
+  var downloadingPage: {
+    request: ResolvableURI
+  }
+}
+
+function findCid (): string | void {
+  try {
+    const url = new URL(globalThis.location.href)
+    const req = parseRequest(url, url)
+
+    if ((req.type === 'subdomain' || req.type === 'path' || req.type === 'native') && req.protocol === 'ipfs') {
+      return req.cid.toString()
+    }
+  } catch {}
+}
+
+export interface DownloadingPageProps {
+  request?: ResolvableURI
+}
+
+export function DownloadingPage ({ request }: DownloadingPageProps): ReactElement {
+  request = request ?? globalThis.downloadingPage?.request
+
+  if (request == null) {
+    globalThis.location.href = toGatewayRoot('/')
+
+    return (
+      <></>
+    )
+  }
+
+  removeRootHashIfPresent()
+  const cid = findCid()
+
+  function retry (): void {
+    // remove any UI-added navigation info
+    history.pushState('', document.title, window.location.pathname + window.location.search)
+
+    // @ts-expect-error boolean `forceGet` argument is firefox-only
+    window.location.reload(true)
+  }
+
+  let viewPreviewBlockButton = <></>
+
+  if (viewPreviewBlockButton && cid != null) {
+    viewPreviewBlockButton = (
+      <>
+        <Button
+          className='bg-navy-muted' onClick={(evt: MouseEvent) => {
+            evt.preventDefault()
+            evt.stopPropagation()
+
+            window.location.href = createLink({
+              params: {
+                download: 'false'
+              }
+            })
+          }}
+        >Preview block
+        </Button>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <ContentBox title='Download'>
+        <>
+          <p className='f5 ma3 fw4 db'>Your download should begin shortly. If it does not, please retry.</p>
+          <p className='ma3'>
+            <Button className='bg-teal' onClick={retry}>Retry</Button>
+            {viewPreviewBlockButton}
+          </p>
+        </>
+      </ContentBox>
+    </>
+  )
+}

--- a/src/ui/utils/links.ts
+++ b/src/ui/utils/links.ts
@@ -1,5 +1,6 @@
 import { CID } from 'multiformats/cid'
 import { dnsLinkLabelEncoder } from '../../lib/dns-link-labels.ts'
+import { parseRequest } from '../../lib/parse-request-cheap.ts'
 import { createSearch } from '../../lib/query-helpers.ts'
 
 interface CreateLinkOptions {
@@ -13,28 +14,36 @@ interface CreateLinkOptions {
  * any existing params or fragment
  */
 export function createLink ({ ipfsPath, params, hash }: CreateLinkOptions): string {
-  const url = new URL(window.location.href)
-  const search = createSearch(url.searchParams, {
+  const currentPage = new URL(window.location.href)
+  const request = parseRequest(currentPage, currentPage)
+
+  if (request.type === 'external' || request.type === 'internal') {
+    throw new Error(`Could not parse subdomain from ${request.type ?? 'unknown'} url`)
+  }
+
+  const subdomainURL = request.subdomainURL
+
+  const search = createSearch(subdomainURL.searchParams, {
     params
   })
 
   // if no pathname passed, detect from the current URL
   if (ipfsPath == null) {
-    if (url.hostname.includes('.ipns.')) {
-      ipfsPath = `/ipns/${url.hostname.split('.ipns.')[0]}${url.pathname === '/' ? '' : url.pathname}`
+    if (subdomainURL.hostname.includes('.ipns.')) {
+      ipfsPath = `/ipns/${subdomainURL.hostname.split('.ipns.')[0]}${subdomainURL.pathname === '/' ? '' : subdomainURL.pathname}`
     } else {
-      ipfsPath = `/ipfs/${url.hostname.split('.ipfs.')[0]}${url.pathname === '/' ? '' : url.pathname}`
+      ipfsPath = `/ipfs/${subdomainURL.hostname.split('.ipfs.')[0]}${subdomainURL.pathname === '/' ? '' : subdomainURL.pathname}`
     }
   }
 
   const [,, cid, ...rest] = ipfsPath.split('/')
   const path = '/' + rest.filter(segment => segment.trim() !== '').join('/')
 
-  const host = (url.host.includes('.ipfs.') ? url.host.split('.ipfs.') : url.host.split('.ipns.'))[1]
+  const host = (subdomainURL.host.includes('.ipfs.') ? subdomainURL.host.split('.ipfs.') : subdomainURL.host.split('.ipns.'))[1]
 
   try {
-    return `${url.protocol}//${CID.parse(cid).toV1()}.ipfs.${host}${path === '/' ? '' : path}${search}${hash ?? url.hash}`
+    return `${subdomainURL.protocol}//${CID.parse(cid).toV1()}.ipfs.${host}${path === '/' ? '' : path}${search}${hash ?? subdomainURL.hash}`
   } catch {
-    return `${url.protocol}//${dnsLinkLabelEncoder(cid)}.ipns.${host}${path === '/' ? '' : path}${search}${hash ?? url.hash}`
+    return `${subdomainURL.protocol}//${dnsLinkLabelEncoder(cid)}.ipns.${host}${path === '/' ? '' : path}${search}${hash ?? subdomainURL.hash}`
   }
 }

--- a/test-e2e/download-form.test.ts
+++ b/test-e2e/download-form.test.ts
@@ -13,7 +13,7 @@ import * as tar from 'tar'
 import { test, expect } from './fixtures/config-test-fixtures.ts'
 import type { Download, Page, Response } from 'playwright'
 
-function captureDownloadResponse (page: Page, cid: string, host: string): Promise<Response> {
+export function captureDownloadResponse (page: Page, cid: string, host: string): Promise<Response> {
   const responsePromise = Promise.withResolvers<Response>()
 
   page.on('response', (response) => {

--- a/test-e2e/downloading.spec.ts
+++ b/test-e2e/downloading.spec.ts
@@ -1,0 +1,63 @@
+import delay from 'delay'
+import { test, expect } from './fixtures/config-test-fixtures.ts'
+import type { Download } from 'playwright'
+
+test.describe('downloading page', () => {
+  let download: Download
+
+  test.afterEach(async () => {
+    try {
+      await download?.delete()
+    } catch {
+      // this can throw if the page has already closed
+    }
+  })
+
+  test('should show a message after download', async ({ page }) => {
+    const downloadPromise = page.waitForEvent('download')
+
+    await page.fill('#inputContent', '/ipfs/bafkqaddimvwgy3zao5xxe3debi')
+    await page.click('#show-advanced')
+    await page.selectOption('#download', 'true')
+    await page.click('#load-directly')
+
+    download = await downloadPromise
+
+    await delay(2_000)
+
+    const text = await page.textContent('body')
+    expect(text).toContain('Your download should begin shortly')
+  })
+
+  test('should allow previewing a block', async ({ page }) => {
+    const downloadPromise = page.waitForEvent('download')
+
+    await page.fill('#inputContent', '/ipfs/bafkqaddimvwgy3zao5xxe3debi')
+    await page.click('#show-advanced')
+    await page.selectOption('#download', 'true')
+    await page.click('#load-directly')
+
+    download = await downloadPromise
+
+    await delay(2_000)
+
+    const text = await page.textContent('body')
+    expect(text).toContain('Preview block')
+  })
+
+  test('should allow retrying', async ({ page }) => {
+    const downloadPromise = page.waitForEvent('download')
+
+    await page.fill('#inputContent', '/ipfs/bafkqaddimvwgy3zao5xxe3debi')
+    await page.click('#show-advanced')
+    await page.selectOption('#download', 'true')
+    await page.click('#load-directly')
+
+    download = await downloadPromise
+
+    await delay(2_000)
+
+    const text = await page.textContent('body')
+    expect(text).toContain('Retry')
+  })
+})


### PR DESCRIPTION
After reloading the page to download content, show a screen that lets the user retry and/or inspect the block and lets them know that they aren't stuck in some weird loading state.

Fixes #1025

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
