### PR TITLE
fix: remove preview link on downloading page

### DIFF
--- a/src/ui/pages/downloading-page.tsx
+++ b/src/ui/pages/downloading-page.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { parseRequest } from '../../lib/parse-request.ts'
 import { removeRootHashIfPresent } from '../../lib/remove-root-hash.ts'
 import { toGatewayRoot } from '../../lib/to-gateway-root.ts'
 import { Button } from '../components/button.tsx'
@@ -11,17 +10,6 @@ declare global {
   var downloadingPage: {
     request: ResolvableURI
   }
-}
-
-function findCid (): string | void {
-  try {
-    const url = new URL(globalThis.location.href)
-    const req = parseRequest(url, url)
-
-    if ((req.type === 'subdomain' || req.type === 'path' || req.type === 'native') && req.protocol === 'ipfs') {
-      return req.cid.toString()
-    }
-  } catch {}
 }
 
 export interface DownloadingPageProps {

--- a/src/ui/pages/downloading-page.tsx
+++ b/src/ui/pages/downloading-page.tsx
@@ -4,7 +4,6 @@ import { removeRootHashIfPresent } from '../../lib/remove-root-hash.ts'
 import { toGatewayRoot } from '../../lib/to-gateway-root.ts'
 import { Button } from '../components/button.tsx'
 import ContentBox from '../components/content-box.tsx'
-import { createLink } from '../utils/links.ts'
 import type { ResolvableURI } from '../../lib/parse-request-cheap.ts'
 import type { ReactElement } from 'react'
 
@@ -41,7 +40,6 @@ export function DownloadingPage ({ request }: DownloadingPageProps): ReactElemen
   }
 
   removeRootHashIfPresent()
-  const cid = findCid()
 
   function retry (): void {
     // remove any UI-added navigation info
@@ -51,28 +49,6 @@ export function DownloadingPage ({ request }: DownloadingPageProps): ReactElemen
     window.location.reload(true)
   }
 
-  let viewPreviewBlockButton = <></>
-
-  if (viewPreviewBlockButton && cid != null) {
-    viewPreviewBlockButton = (
-      <>
-        <Button
-          className='bg-navy-muted' onClick={(evt: MouseEvent) => {
-            evt.preventDefault()
-            evt.stopPropagation()
-
-            window.location.href = createLink({
-              params: {
-                download: 'false'
-              }
-            })
-          }}
-        >Preview block
-        </Button>
-      </>
-    )
-  }
-
   return (
     <>
       <ContentBox title='Download'>
@@ -80,7 +56,6 @@ export function DownloadingPage ({ request }: DownloadingPageProps): ReactElemen
           <p className='f5 ma3 fw4 db'>Your download should begin shortly. If it does not, please retry.</p>
           <p className='ma3'>
             <Button className='bg-teal' onClick={retry}>Retry</Button>
-            {viewPreviewBlockButton}
           </p>
         </>
       </ContentBox>

--- a/test-e2e/downloading.spec.ts
+++ b/test-e2e/downloading.spec.ts
@@ -29,22 +29,6 @@ test.describe('downloading page', () => {
     expect(text).toContain('Your download should begin shortly')
   })
 
-  test('should allow previewing a block', async ({ page }) => {
-    const downloadPromise = page.waitForEvent('download')
-
-    await page.fill('#inputContent', '/ipfs/bafkqaddimvwgy3zao5xxe3debi')
-    await page.click('#show-advanced')
-    await page.selectOption('#download', 'true')
-    await page.click('#load-directly')
-
-    download = await downloadPromise
-
-    await delay(2_000)
-
-    const text = await page.textContent('body')
-    expect(text).toContain('Preview block')
-  })
-
   test('should allow retrying', async ({ page }) => {
     const downloadPromise = page.waitForEvent('download')
 


### PR DESCRIPTION
If the download has already started and the service worker is still running this works instantly as the block is already local, otherwise it takes as long to find and download the first block as the download which makes it look to the user as if the button is broken.

Remove the link from the page, the user can still preview the block from the download form if they are interested.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
