### PR TITLE
chore: add sinon types dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "@types/polka": "^0.5.8",
     "@types/react": "^19.1.6",
     "@types/react-dom": "^19.1.9",
+    "@types/sinon": "^21.0.1",
     "@types/wait-on": "^5.3.4",
     "aegir": "^47.0.24",
     "body-parser": "^2.2.2",


### PR DESCRIPTION
These were previously in the dep tree somewhere but now they are not so add a dev dep, which should have been there in the first place.

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
