### PR TITLE
feat: multibase parity with Kubo / Rainbow

### DIFF
--- a/build.js
+++ b/build.js
@@ -398,6 +398,32 @@ await fs.writeFile('dist/cloudflare/snippets/meta.json', JSON.stringify(cloudfla
 await fs.copyFile('src/cloudflare/snippets/01_path_gateway_to_subdomain.js.rules', 'dist/cloudflare/snippets/01_path_gateway_to_subdomain.js.rules')
 await fs.copyFile('src/cloudflare/snippets/02_shared_sw_installer_cache.js.rules', 'dist/cloudflare/snippets/02_shared_sw_installer_cache.js.rules')
 
+// Cloudflare Snippets cap each bundle at 32 KiB. Print every output's size
+// so a regression is visible in CI logs, and fail the build if any one
+// crosses the cap. Skip the check for non-minified dev/test builds where
+// the size is not representative of the deployed artifact.
+const CF_SNIPPET_MAX_BYTES = 32 * 1024
+if (process.env.NODE_ENV !== 'test' && process.env.NODE_ENV !== 'development') {
+  const oversized = []
+  for (const [outPath, info] of Object.entries(cloudflareResult.metafile.outputs)) {
+    if (!outPath.endsWith('.js')) {
+      continue
+    }
+    const pct = ((info.bytes / CF_SNIPPET_MAX_BYTES) * 100).toFixed(0)
+    console.info(`  ${outPath}: ${(info.bytes / 1024).toFixed(1)} KiB (${pct}% of CF 32 KiB cap)`)
+    if (info.bytes > CF_SNIPPET_MAX_BYTES) {
+      oversized.push({ path: outPath, bytes: info.bytes })
+    }
+  }
+  if (oversized.length > 0) {
+    console.error('\nERROR: snippet bundle(s) exceed Cloudflare 32 KiB limit:')
+    for (const { path: p, bytes } of oversized) {
+      console.error(`  ${p}: ${bytes} bytes (${bytes - CF_SNIPPET_MAX_BYTES} over the cap)`)
+    }
+    process.exit(1)
+  }
+}
+
 /**
  * @type {esbuild.BuildOptions}
  */

--- a/src/cloudflare/snippets/cid.ts
+++ b/src/cloudflare/snippets/cid.ts
@@ -1,5 +1,15 @@
 import { CODE_DAG_PB, CODE_LIBP2P_KEY } from '../../ui/pages/multicodec-table.ts'
-import { base16Decode, base32Decode, base36Decode, base58Decode, base64urlDecode, varintDecode, varintEncode } from './codec.ts'
+import {
+  base2Decode,
+  base16Decode, base16UpperDecode,
+  base32Decode, base32UpperDecode, base32PadDecode, base32PadUpperDecode,
+  base32HexDecode, base32HexUpperDecode, base32HexPadDecode, base32HexPadUpperDecode,
+  base36Decode, base36UpperDecode,
+  base58Decode, base58FlickrDecode,
+  base64Decode, base64PadDecode, base64urlDecode, base64UrlPadDecode,
+  base256EmojiDecode, B256EMOJI_PREFIX_CP,
+  varintDecode, varintEncode
+} from './codec.ts'
 
 export interface CID {
   version: number
@@ -39,16 +49,52 @@ export function parseCID (str: string): CID {
   const rest = str.substring(1)
   let offset = 0
 
+  // Multibase prefix dispatch. Mirrors `ipfs multibase list`
+  // (https://github.com/multiformats/multibase/blob/master/multibase.csv).
+  // 'b' (base32) and 'k' (base36) run first: they are the canonical
+  // subdomain labels for /ipfs/ and /ipns/ and cover the hot path.
+  // base256emoji runs next: its 🚀 prefix is U+1F680, two UTF-16 code
+  // units, so the single-char checks below would not see it.
   if (prefix === 'b') {
     bytes = base32Decode(rest)
   } else if (prefix === 'k') {
     bytes = base36Decode(rest)
+  } else if (str.codePointAt(0) === B256EMOJI_PREFIX_CP) {
+    bytes = base256EmojiDecode(str.slice(2))
+  } else if (prefix === '0') {
+    bytes = base2Decode(rest)
+  } else if (prefix === 'B') {
+    bytes = base32UpperDecode(rest)
+  } else if (prefix === 'c') {
+    bytes = base32PadDecode(rest)
+  } else if (prefix === 'C') {
+    bytes = base32PadUpperDecode(rest)
+  } else if (prefix === 'v') {
+    bytes = base32HexDecode(rest)
+  } else if (prefix === 'V') {
+    bytes = base32HexUpperDecode(rest)
+  } else if (prefix === 't') {
+    bytes = base32HexPadDecode(rest)
+  } else if (prefix === 'T') {
+    bytes = base32HexPadUpperDecode(rest)
+  } else if (prefix === 'K') {
+    bytes = base36UpperDecode(rest)
   } else if (prefix === 'z') {
     bytes = base58Decode(rest)
-  } else if (prefix === 'f' || prefix === 'F') {
+  } else if (prefix === 'Z') {
+    bytes = base58FlickrDecode(rest)
+  } else if (prefix === 'f') {
     bytes = base16Decode(rest)
+  } else if (prefix === 'F') {
+    bytes = base16UpperDecode(rest)
+  } else if (prefix === 'm') {
+    bytes = base64Decode(rest)
+  } else if (prefix === 'M') {
+    bytes = base64PadDecode(rest)
   } else if (prefix === 'u') {
     bytes = base64urlDecode(rest)
+  } else if (prefix === 'U') {
+    bytes = base64UrlPadDecode(rest)
   } else {
     // try bare base58btc (handles 12D3K... peer IDs)
     bytes = base58Decode(str)

--- a/src/cloudflare/snippets/codec.ts
+++ b/src/cloudflare/snippets/codec.ts
@@ -1,5 +1,11 @@
 /**
- * varint (unsigned LEB128) encode/decode
+ * varint (unsigned LEB128) decode. Returns [value, bytesRead].
+ *
+ * Real CID inputs only carry tiny varints (version=1, multicodec under 2^16),
+ * but a malformed CID could feed a large value here. The bitwise
+ * `(byte & 0x7f) << shift` form is signed 32-bit and silently truncates
+ * once shift > 24, so multiply instead and throw on values past
+ * MAX_SAFE_INTEGER or runs longer than 9 bytes.
  */
 export function varintDecode (buf: Uint8Array, offset: number): [number, number] {
   let value = 0
@@ -7,28 +13,66 @@ export function varintDecode (buf: Uint8Array, offset: number): [number, number]
   let i = offset
   while (i < buf.length) {
     const byte = buf[i]
-    value |= (byte & 0x7f) << shift
+    value += (byte & 0x7f) * 2 ** shift
+    if (value > Number.MAX_SAFE_INTEGER) {
+      throw new Error('varint value is too large to decode safely')
+    }
     i++
-    if ((byte & 0x80) === 0) { break }
+    if ((byte & 0x80) === 0) { return [value, i - offset] }
     shift += 7
-    if (shift > 49) { throw new Error('varint too long') }
+    if (shift > 49) { throw new Error('varint has too many bytes (max is 9)') }
   }
-  return [value, i - offset]
+  throw new Error('varint input ended early (more bytes expected)')
 }
 
+/**
+ * varint (unsigned LEB128) encode.
+ *
+ * LEB128 is unsigned, so reject anything that is not a non-negative safe
+ * integer; a negative or fractional input would otherwise produce garbage
+ * bytes. Use `% 128` and `Math.floor(/ 128)` rather than `>>> 7`, which
+ * truncates to 32 bits and would mis-encode values above 2^32.
+ */
 export function varintEncode (value: number): Uint8Array {
+  if (!Number.isInteger(value) || value < 0 || value > Number.MAX_SAFE_INTEGER) {
+    throw new Error(`varint value must be a whole number from 0 to ${Number.MAX_SAFE_INTEGER}, got ${value}`)
+  }
   const bytes = []
   while (value > 0x7f) {
-    bytes.push((value & 0x7f) | 0x80)
-    value >>>= 7
+    bytes.push((value % 128) | 0x80)
+    value = Math.floor(value / 128)
   }
   bytes.push(value & 0x7f)
   return new Uint8Array(bytes)
 }
 
+// Build a 128-entry ASCII lookup table for an alphabet. Slots that are not
+// in the alphabet hold INVALID (0xff), which is out of range for every
+// alphabet here (max index 63 for base64). Decoders must check for INVALID
+// before using the value; otherwise unknown characters silently decode to
+// whatever byte the alphabet's first character maps to.
+const INVALID = 0xff
+function makeMap (alphabet: string): Uint8Array {
+  const m = new Uint8Array(128).fill(INVALID)
+  for (let i = 0; i < alphabet.length; i++) {
+    m[alphabet.charCodeAt(i)] = i
+  }
+  return m
+}
+
+// Look up an ASCII character in a decoder map; throw if it is not in the
+// alphabet. Char codes >= 128 are rejected because the map is 128 wide.
+function lookup (map: Uint8Array, str: string, i: number, base: string): number {
+  const code = str.charCodeAt(i)
+  const v = code < 128 ? map[code] : INVALID
+  if (v === INVALID) {
+    throw new Error(`not a valid ${base} character at position ${i}: ${JSON.stringify(str[i])}`)
+  }
+  return v
+}
+
 const B58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
-const B58_MAP = new Uint8Array(128)
-for (let i = 0; i < B58_ALPHABET.length; i++) { B58_MAP[B58_ALPHABET.charCodeAt(i)] = i }
+const B58_MAP = makeMap(B58_ALPHABET)
 
 export function base58Encode (bytes: Uint8Array): string {
   let zeros = 0
@@ -61,8 +105,7 @@ export function base58Decode (str: string): Uint8Array {
   const buf = new Uint8Array(size)
 
   for (let i = zeros; i < str.length; i++) {
-    let carry = B58_MAP[str.charCodeAt(i)]
-    if (carry === undefined) { throw new Error('invalid base58 char') }
+    let carry = lookup(B58_MAP, str, i, 'base58')
     for (let j = size - 1; j >= 0; j--) {
       carry += 58 * buf[j]
       buf[j] = carry & 0xff
@@ -81,8 +124,7 @@ export function base58Decode (str: string): Uint8Array {
 }
 
 const B32_ALPHABET = 'abcdefghijklmnopqrstuvwxyz234567'
-const B32_MAP = new Uint8Array(128)
-for (let i = 0; i < B32_ALPHABET.length; i++) { B32_MAP[B32_ALPHABET.charCodeAt(i)] = i }
+const B32_MAP = makeMap(B32_ALPHABET)
 
 /**
  * base32lower encode (RFC 4648, no padding)
@@ -114,8 +156,7 @@ export function base32Decode (str: string): Uint8Array {
   let bits = 0
   let buffer = 0
   for (let i = 0; i < str.length; i++) {
-    const val = B32_MAP[str.charCodeAt(i)]
-    if (val === undefined) { throw new Error('invalid base32 char') }
+    const val = lookup(B32_MAP, str, i, 'base32')
     buffer = (buffer << 5) | val
     bits += 5
     if (bits >= 8) {
@@ -128,8 +169,7 @@ export function base32Decode (str: string): Uint8Array {
 
 // big-integer base conversion, same pattern as base58
 const B36_ALPHABET = '0123456789abcdefghijklmnopqrstuvwxyz'
-const B36_MAP = new Uint8Array(128)
-for (let i = 0; i < B36_ALPHABET.length; i++) { B36_MAP[B36_ALPHABET.charCodeAt(i)] = i }
+const B36_MAP = makeMap(B36_ALPHABET)
 
 /**
  * base36lower encode
@@ -174,8 +214,7 @@ export function base36Decode (str: string): Uint8Array {
   const buf = new Uint8Array(size)
 
   for (let i = zeros; i < str.length; i++) {
-    let carry = B36_MAP[str.charCodeAt(i)]
-    if (carry === undefined) { throw new Error('invalid base36 char') }
+    let carry = lookup(B36_MAP, str, i, 'base36')
     for (let j = size - 1; j >= 0; j--) {
       carry += 36 * buf[j]
       buf[j] = carry & 0xff
@@ -196,6 +235,9 @@ export function base16Encode (bytes: Uint8Array): string {
   return Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join('')
 }
 
+const B16_ALPHABET = '0123456789abcdef'
+const B16_MAP = makeMap(B16_ALPHABET)
+
 /**
  * base16 (hex) decode
  */
@@ -204,14 +246,15 @@ export function base16Decode (str: string): Uint8Array {
   if (str.length % 2 !== 0) { str = '0' + str }
   const out = new Uint8Array(str.length / 2)
   for (let i = 0; i < out.length; i++) {
-    out[i] = parseInt(str.substring(i * 2, i * 2 + 2), 16)
+    const hi = lookup(B16_MAP, str, i * 2, 'base16')
+    const lo = lookup(B16_MAP, str, i * 2 + 1, 'base16')
+    out[i] = (hi << 4) | lo
   }
   return out
 }
 
 const B64_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_'
-const B64_MAP = new Uint8Array(128)
-for (let i = 0; i < B64_ALPHABET.length; i++) { B64_MAP[B64_ALPHABET.charCodeAt(i)] = i }
+const B64_MAP = makeMap(B64_ALPHABET)
 
 // helper: base64url encode (only needed for tests)
 export function base64urlEncode (bytes: Uint8Array): string {
@@ -238,13 +281,131 @@ export function base64urlDecode (str: string): Uint8Array {
   let bits = 0
   let buffer = 0
   for (let i = 0; i < str.length; i++) {
-    const val = B64_MAP[str.charCodeAt(i)]
+    const val = lookup(B64_MAP, str, i, 'base64url')
     buffer = (buffer << 6) | val
     bits += 6
     if (bits >= 8) {
       bits -= 8
       out.push((buffer >>> bits) & 0xff)
     }
+  }
+  return new Uint8Array(out)
+}
+
+// === kubo-aligned multibase extensions ===
+// Decoders for the rest of `ipfs multibase list`. Most are thin wrappers
+// over the decoders above: alphabets are case-insensitive, padding strips
+// off, and base64 maps to base64url by swapping `+/` for `-_`.
+
+const stripPad = (s: string): string => s.replace(/[=]+$/, '')
+
+// base32 variants (RFC4648): upper, padded, padded-upper.
+export const base32UpperDecode = (s: string): Uint8Array => base32Decode(s.toLowerCase())
+export const base32PadDecode = (s: string): Uint8Array => base32Decode(stripPad(s))
+export const base32PadUpperDecode = (s: string): Uint8Array => base32Decode(stripPad(s).toLowerCase())
+
+// base32hex uses the RFC4648 extended hex alphabet, so it needs its own map.
+const B32HEX_ALPHABET = '0123456789abcdefghijklmnopqrstuv'
+const B32HEX_MAP = makeMap(B32HEX_ALPHABET)
+export function base32HexDecode (str: string): Uint8Array {
+  str = str.toLowerCase()
+  const out = []
+  let bits = 0
+  let buffer = 0
+  for (let i = 0; i < str.length; i++) {
+    const val = lookup(B32HEX_MAP, str, i, 'base32hex')
+    buffer = (buffer << 5) | val
+    bits += 5
+    if (bits >= 8) {
+      bits -= 8
+      out.push((buffer >>> bits) & 0xff)
+    }
+  }
+  return new Uint8Array(out)
+}
+export const base32HexUpperDecode = (s: string): Uint8Array => base32HexDecode(s.toLowerCase())
+export const base32HexPadDecode = (s: string): Uint8Array => base32HexDecode(stripPad(s))
+export const base32HexPadUpperDecode = (s: string): Uint8Array => base32HexDecode(stripPad(s).toLowerCase())
+
+// base16 and base36 upper: only the case differs from the lowercase form.
+export const base16UpperDecode = (s: string): Uint8Array => base16Decode(s.toLowerCase())
+export const base36UpperDecode = (s: string): Uint8Array => base36Decode(s.toLowerCase())
+
+// base58flickr uses its own alphabet (lowercase first, then uppercase).
+const B58FLICKR_ALPHABET = '123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ'
+const B58FLICKR_MAP = makeMap(B58FLICKR_ALPHABET)
+export function base58FlickrDecode (str: string): Uint8Array {
+  let zeros = 0
+  while (zeros < str.length && str[zeros] === '1') { zeros++ }
+  const size = ((str.length - zeros) * 733 / 1000 | 0) + 1
+  const buf = new Uint8Array(size)
+  for (let i = zeros; i < str.length; i++) {
+    let carry = lookup(B58FLICKR_MAP, str, i, 'base58flickr')
+    for (let j = size - 1; j >= 0; j--) {
+      carry += 58 * buf[j]
+      buf[j] = carry & 0xff
+      carry >>>= 8
+    }
+  }
+  let start = 0
+  while (start < size && buf[start] === 0) { start++ }
+  const result = new Uint8Array(zeros + size - start)
+  result.set(buf.subarray(start), zeros)
+  return result
+}
+
+// base64 and base64pad differ from base64url only in `+/` vs `-_`. Swap
+// them back so we can reuse base64urlDecode.
+const toUrl = (s: string): string => s.replace(/\+/g, '-').replace(/\//g, '_')
+export const base64Decode = (s: string): Uint8Array => base64urlDecode(toUrl(s))
+export const base64PadDecode = (s: string): Uint8Array => base64Decode(stripPad(s))
+export const base64UrlPadDecode = (s: string): Uint8Array => base64urlDecode(stripPad(s))
+
+// base2: one bit per character ('0' or '1').
+const ASCII_ZERO = '0'.charCodeAt(0)
+const ASCII_ONE = '1'.charCodeAt(0)
+export function base2Decode (str: string): Uint8Array {
+  const out = []
+  let bits = 0
+  let buffer = 0
+  for (let i = 0; i < str.length; i++) {
+    const c = str.charCodeAt(i)
+    let v: number
+    if (c === ASCII_ZERO) {
+      v = 0
+    } else if (c === ASCII_ONE) {
+      v = 1
+    } else {
+      throw new Error('invalid base2 char')
+    }
+    buffer = (buffer << 1) | v
+    bits += 1
+    if (bits >= 8) {
+      bits -= 8
+      out.push((buffer >>> bits) & 0xff)
+    }
+  }
+  return new Uint8Array(out)
+}
+
+// base256emoji: one emoji codepoint per byte. Alphabet copied verbatim from
+// https://github.com/multiformats/js-multiformats/blob/master/src/bases/base256emoji.ts
+const B256EMOJI_ALPHABET = '🚀🪐☄🛰🌌🌑🌒🌓🌔🌕🌖🌗🌘🌍🌏🌎🐉☀💻🖥💾💿😂❤😍🤣😊🙏💕😭😘👍😅👏😁🔥🥰💔💖💙😢🤔😆🙄💪😉☺👌🤗💜😔😎😇🌹🤦🎉💞✌✨🤷😱😌🌸🙌😋💗💚😏💛🙂💓🤩😄😀🖤😃💯🙈👇🎶😒🤭❣😜💋👀😪😑💥🙋😞😩😡🤪👊🥳😥🤤👉💃😳✋😚😝😴🌟😬🙃🍀🌷😻😓⭐✅🥺🌈😈🤘💦✔😣🏃💐☹🎊💘😠☝😕🌺🎂🌻😐🖕💝🙊😹🗣💫💀👑🎵🤞😛🔴😤🌼😫⚽🤙☕🏆🤫👈😮🙆🍻🍃🐶💁😲🌿🧡🎁⚡🌞🎈❌✊👋😰🤨😶🤝🚶💰🍓💢🤟🙁🚨💨🤬✈🎀🍺🤓😙💟🌱😖👶🥴▶➡❓💎💸⬇😨🌚🦋😷🕺⚠🙅😟😵👎🤲🤠🤧📌🔵💅🧐🐾🍒😗🤑🌊🤯🐷☎💧😯💆👆🎤🙇🍑❄🌴💣🐸💌📍🥀🤢👅💡💩👐📸👻🤐🤮🎼🥵🚩🍎🍊👼💍📣🥂'
+const B256EMOJI_MAP = new Map<number, number>()
+{
+  let i = 0
+  for (const ch of B256EMOJI_ALPHABET) {
+    B256EMOJI_MAP.set(ch.codePointAt(0)!, i)
+    i++
+  }
+}
+export const B256EMOJI_PREFIX_CP = 0x1F680 // 🚀 codepoint
+export function base256EmojiDecode (str: string): Uint8Array {
+  const out: number[] = []
+  for (const ch of str) {
+    const v = B256EMOJI_MAP.get(ch.codePointAt(0)!)
+    if (v === undefined) { throw new Error('invalid base256emoji char') }
+    out.push(v)
   }
   return new Uint8Array(out)
 }

--- a/src/lib/parse-request.ts
+++ b/src/lib/parse-request.ts
@@ -2,13 +2,25 @@ import { isIP } from '@chainsafe/is-ip'
 import { InvalidParametersError } from '@libp2p/interface'
 import { peerIdFromCID, peerIdFromString } from '@libp2p/peer-id'
 import { base16, base16upper } from 'multiformats/bases/base16'
-import { base32 } from 'multiformats/bases/base32'
-import { base36 } from 'multiformats/bases/base36'
-import { base58btc } from 'multiformats/bases/base58'
+import { base2 } from 'multiformats/bases/base2'
+import { base256emoji } from 'multiformats/bases/base256emoji'
+import { base32, base32hex, base32hexpad, base32hexpadupper, base32hexupper, base32pad, base32padupper, base32upper } from 'multiformats/bases/base32'
+import { base36, base36upper } from 'multiformats/bases/base36'
+import { base58btc, base58flickr } from 'multiformats/bases/base58'
+import { base64, base64pad, base64url, base64urlpad } from 'multiformats/bases/base64'
 import { CID } from 'multiformats/cid'
 import { dnsLinkLabelDecoder, dnsLinkLabelEncoder, isInlinedDnsLink } from './dns-link-labels.ts'
 import type { PeerId } from '@libp2p/interface'
 import type { MultibaseDecoder } from 'multiformats/cid'
+
+// 🚀 (U+1F680) is the base256emoji prefix. JS strings store it as a surrogate
+// pair, so a `str[0]` lookup never matches; check the codepoint instead.
+const BASE256_EMOJI_PREFIX_CP = 0x1F680
+
+// Browsers percent-encode 🚀 (and the rest of the emoji alphabet) when it
+// appears in a URL path. We watch for this exact prefix so we can decode
+// only the emoji case and leave every ASCII base alone.
+const BASE256_EMOJI_PREFIX_PCT = '%F0%9F%9A%80'
 
 export type URIType = 'subdomain' | 'path' | 'native' | 'internal' | 'external'
 
@@ -301,6 +313,16 @@ function parseCID (str: string): CID<any, any, any, 1> {
       return CID.parse(str)
     }
 
+    // base256emoji CIDs can arrive in two shapes:
+    //   - raw 🚀… , when the caller already holds a decoded string
+    //   - %F0%9F%9A%80… , when the URL parser percent-encoded the path
+    // The raw form needs no work; findMultibaseDecoder picks it up via
+    // codePointAt below. Decode only the percent form so ASCII bases
+    // stay on the zero-decode hot path.
+    if (str.startsWith(BASE256_EMOJI_PREFIX_PCT)) {
+      str = decodeURIComponent(str)
+    }
+
     return CID.parse(str, findMultibaseDecoder(str))
   } catch (err: any) {
     throw new InvalidParametersError(`Could not parse CID from string "${str}" - ${err.message}`)
@@ -323,22 +345,39 @@ function parsePeerId (str: string): PeerId {
   }
 }
 
+// Map the multibase prefix character to its decoder. Covers every base in
+// `ipfs multibase list` minus identity. base32 (`b`) and base36 (`k`) come
+// first as the canonical subdomain labels for /ipfs/ and /ipns/.
 function findMultibaseDecoder (str: string): MultibaseDecoder<string> | undefined {
-  const prefix = str.substring(0, 1)
-
-  switch (prefix) {
-    case 'b':
-      return base32
-    case 'k':
-      return base36
-    case 'f':
-      return base16
-    case 'F':
-      return base16upper
-    case 'z':
-      return base58btc
+  switch (str.substring(0, 1)) {
+    case 'b': return base32
+    case 'k': return base36
+    case '0': return base2
+    case 'B': return base32upper
+    case 'c': return base32pad
+    case 'C': return base32padupper
+    case 'v': return base32hex
+    case 'V': return base32hexupper
+    case 't': return base32hexpad
+    case 'T': return base32hexpadupper
+    case 'K': return base36upper
+    case 'z': return base58btc
+    case 'Z': return base58flickr
+    case 'f': return base16
+    case 'F': return base16upper
+    case 'm': return base64
+    case 'M': return base64pad
+    case 'u': return base64url
+    case 'U': return base64urlpad
     default:
-      // do nothing
+      // fall through to the codepoint check below
+  }
+
+  // 🚀 (base256emoji) is two UTF-16 code units, so str.substring(0, 1) above
+  // returns just the high surrogate and never matches a case. Check the
+  // codepoint here as a last step so the ASCII switch stays the hot path.
+  if (str.codePointAt(0) === BASE256_EMOJI_PREFIX_CP) {
+    return base256emoji
   }
 }
 

--- a/test/cloudflare/snippets/codec.spec.ts
+++ b/test/cloudflare/snippets/codec.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'aegir/chai'
-import { base16Decode, base16Encode, base32Decode, base32Encode, base36Decode, base36Encode, base58Decode, base58Encode, base64urlDecode, base64urlEncode, varintDecode, varintEncode } from '../../../src/cloudflare/snippets/codec.ts'
+import { base16Decode, base16Encode, base2Decode, base256EmojiDecode, base32Decode, base32Encode, base32HexDecode, base36Decode, base36Encode, base58Decode, base58Encode, base58FlickrDecode, base64Decode, base64urlDecode, base64urlEncode, varintDecode, varintEncode } from '../../../src/cloudflare/snippets/codec.ts'
 
 describe('varint', () => {
   it('encodes and decodes single-byte values', () => {
@@ -76,4 +76,121 @@ describe('base64url', () => {
     const decoded = base64urlDecode(b64)
     expect(decoded).to.equalBytes(knownBytes)
   })
+})
+
+// Decoders must throw on invalid characters, not silently decode them as
+// byte 0. The earlier implementation backed lookup tables with Uint8Array
+// (default 0) and checked `=== undefined`, which never matched, so any
+// unknown char decoded as the alphabet's first character.
+describe('invalid input throws', () => {
+  const cases: Array<[string, (s: string) => Uint8Array, string, RegExp]> = [
+    ['base58', base58Decode, 'abc!def', /not a valid base58 character/],
+    ['base58flickr', base58FlickrDecode, 'abc!def', /not a valid base58flickr character/],
+    ['base32', base32Decode, 'abc!def', /not a valid base32 character/],
+    ['base32hex', base32HexDecode, 'abc!def', /not a valid base32hex character/],
+    ['base36', base36Decode, 'abc!def', /not a valid base36 character/],
+    ['base16', base16Decode, 'gg', /not a valid base16 character/],
+    ['base64', base64Decode, 'abc!def', /not a valid base64url character/],
+    ['base64url', base64urlDecode, 'abc!def', /not a valid base64url character/],
+    ['base2', base2Decode, '0102', /invalid base2 char/],
+    ['base256emoji', base256EmojiDecode, 'A', /invalid base256emoji char/]
+  ]
+
+  for (const [name, fn, input, pattern] of cases) {
+    it(`${name} rejects out-of-alphabet chars`, () => {
+      expect(() => fn(input)).to.throw(pattern)
+    })
+  }
+
+  it('error message reports the offending position and character', () => {
+    expect(() => base58Decode('abc!def')).to.throw(/position 3: "!"/)
+    expect(() => base16Decode('aab!')).to.throw(/position 3: "!"/)
+  })
+
+  it('base58 rejects look-alikes that are not in the alphabet (0, O, I, l)', () => {
+    expect(() => base58Decode('0abc')).to.throw(/not a valid base58 character/)
+    expect(() => base58Decode('Oabc')).to.throw(/not a valid base58 character/)
+    expect(() => base58Decode('Iabc')).to.throw(/not a valid base58 character/)
+    expect(() => base58Decode('labc')).to.throw(/not a valid base58 character/)
+  })
+
+  it('rejects non-ASCII characters (char code >= 128)', () => {
+    const nonAscii = String.fromCharCode(233) // 'é'
+    expect(() => base58Decode('abc' + nonAscii + 'def')).to.throw(/not a valid base58 character/)
+    expect(() => base32Decode('abc' + nonAscii + 'def')).to.throw(/not a valid base32 character/)
+    expect(() => base16Decode('a' + nonAscii)).to.throw(/not a valid base16 character/)
+  })
+})
+
+describe('varintDecode regressions', () => {
+  it('decodes a single-byte varint (codec 0x70 dag-pb)', () => {
+    expect(varintDecode(new Uint8Array([0x70]), 0)).to.deep.equal([0x70, 1])
+  })
+
+  it('decodes a two-byte varint (300 -> [0xac, 0x02])', () => {
+    expect(varintDecode(new Uint8Array([0xac, 0x02]), 0)).to.deep.equal([300, 2])
+  })
+
+  it('decodes correctly across the 32-bit boundary', () => {
+    // 2^28 needs 5 bytes. The old `<<` form was signed 32-bit and would
+    // truncate (or go negative) once shift > 24.
+    expect(varintDecode(new Uint8Array([0x80, 0x80, 0x80, 0x80, 0x01]), 0))
+      .to.deep.equal([2 ** 28, 5])
+    // 2^49: largest power of two inside MAX_SAFE_INTEGER, eight 7-bit bytes.
+    expect(varintDecode(new Uint8Array([0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x01]), 0))
+      .to.deep.equal([2 ** 49, 8])
+  })
+
+  it('respects the offset argument', () => {
+    const buf = new Uint8Array([0xff, 0xff, 0xac, 0x02, 0xff])
+    expect(varintDecode(buf, 2)).to.deep.equal([300, 2])
+  })
+
+  it('throws on a varint that exceeds Number.MAX_SAFE_INTEGER', () => {
+    const buf = new Uint8Array([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f])
+    expect(() => varintDecode(buf, 0)).to.throw(/too large to decode safely/)
+  })
+
+  it('throws on more than 8 continuation bytes', () => {
+    const buf = new Uint8Array([0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x01])
+    expect(() => varintDecode(buf, 0)).to.throw(/too many bytes/)
+  })
+
+  it('throws on a truncated varint (continuation bit on last byte)', () => {
+    expect(() => varintDecode(new Uint8Array([0x80]), 0)).to.throw(/ended early/)
+  })
+})
+
+describe('varintEncode regressions', () => {
+  it('encodes single-byte values', () => {
+    expect(Array.from(varintEncode(0))).to.deep.equal([0])
+    expect(Array.from(varintEncode(0x70))).to.deep.equal([0x70])
+    expect(Array.from(varintEncode(0x7f))).to.deep.equal([0x7f])
+  })
+
+  it('encodes multi-byte values', () => {
+    expect(Array.from(varintEncode(300))).to.deep.equal([0xac, 0x02])
+    expect(Array.from(varintEncode(2 ** 28))).to.deep.equal([0x80, 0x80, 0x80, 0x80, 0x01])
+  })
+
+  it('encodes values above 2^32 correctly', () => {
+    // The old `value >>>= 7` truncated to 32 bits, so any value above
+    // 2^32 came out as garbage. Round-trip through decode to confirm.
+    const big = 2 ** 40
+    expect(varintDecode(varintEncode(big), 0)).to.deep.equal([big, 6])
+  })
+
+  const rejectCases: Array<[string, number]> = [
+    ['negative', -1],
+    ['fractional', 1.5],
+    ['NaN', Number.NaN],
+    ['Infinity', Number.POSITIVE_INFINITY],
+    ['above MAX_SAFE_INTEGER', Number.MAX_SAFE_INTEGER + 2]
+  ]
+
+  for (const [label, value] of rejectCases) {
+    it(`rejects ${label} input`, () => {
+      expect(() => varintEncode(value)).to.throw(/must be a whole number/)
+    })
+  }
 })

--- a/test/cloudflare/snippets/multibase.spec.ts
+++ b/test/cloudflare/snippets/multibase.spec.ts
@@ -1,0 +1,81 @@
+// Feed each multibase from `ipfs multibase list` (kubo) into the snippet
+// and check that toSubdomain normalizes it back to the canonical subdomain
+// label: base32 for /ipfs/, base36 for /ipns/.
+//
+// Fixtures were generated with kubo:
+//   echo -n "<canonical>" | ipfs multibase decode > tmp.bin
+//   for b in $(ipfs multibase list); do ipfs multibase encode -b="$b" tmp.bin; done
+//
+// Source CIDs:
+//   /ipfs/  bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi  (v1 dag-pb)
+//   /ipns/  k51qzi5uqu5dlvj2baxnqndepeb86cbk3ng7n3i46uzyxzyqj2xjonzllnv0v8  (libp2p key)
+//
+// `identity` is skipped: it is not a CID encoding.
+
+import { expect } from 'aegir/chai'
+import { toSubdomain } from '../../../src/cloudflare/snippets/subdomain.ts'
+
+const IPFS_CANONICAL = 'bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi'
+const IPNS_CANONICAL = 'k51qzi5uqu5dlvj2baxnqndepeb86cbk3ng7n3i46uzyxzyqj2xjonzllnv0v8'
+
+const ipfsCases: Array<[string, string]> = [
+  ['base2', '0000000010111000000010010001000001100001111000100011100110011111011001000101011111111110100000110110011111001111010011111111101010000111111111100011010111100110100101110110010000101101001100001011100000000000001001011101101110000100101100110100111000011000111011110100101000011100100011010'],
+  ['base32', 'bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi'],
+  ['base32upper', 'BAFYBEIGDYRZT5SFP7UDM7HU76UH7Y26NF3EFUYLQABF3OCLGTQY55FBZDI'],
+  ['base32pad', 'cafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi======'],
+  ['base32padupper', 'CAFYBEIGDYRZT5SFP7UDM7HU76UH7Y26NF3EFUYLQABF3OCLGTQY55FBZDI======'],
+  ['base16', 'f01701220c3c4733ec8affd06cf9e9ff50ffc6bcd2ec85a6170004bb709669c31de94391a'],
+  ['base16upper', 'F01701220C3C4733EC8AFFD06CF9E9FF50FFC6BCD2EC85A6170004BB709669C31DE94391A'],
+  ['base36', 'k2jmtxw8rjh1z69c6not3wtdxb0u3urbzhyll1t9jg6ox26dhi5sfi1m'],
+  ['base36upper', 'K2JMTXW8RJH1Z69C6NOT3WTDXB0U3URBZHYLL1T9JG6OX26DHI5SFI1M'],
+  ['base64', 'mAXASIMPEcz7Ir/0Gz56f9Q/8a80uyFphcABLtwlmnDHelDka'],
+  ['base64pad', 'MAXASIMPEcz7Ir/0Gz56f9Q/8a80uyFphcABLtwlmnDHelDka'],
+  ['base32hexpad', 't05o14863ohpjti5fvk3cv7kvuk7voqud5r45kobg015re2b6jgott51p38======'],
+  ['base32hexpadupper', 'T05O14863OHPJTI5FVK3CV7KVUK7VOQUD5R45KOBG015RE2B6JGOTT51P38======'],
+  ['base64url', 'uAXASIMPEcz7Ir_0Gz56f9Q_8a80uyFphcABLtwlmnDHelDka'],
+  ['base64urlpad', 'UAXASIMPEcz7Ir_0Gz56f9Q_8a80uyFphcABLtwlmnDHelDka'],
+  ['base32hex', 'v05o14863ohpjti5fvk3cv7kvuk7voqud5r45kobg015re2b6jgott51p38'],
+  ['base32hexupper', 'V05O14863OHPJTI5FVK3CV7KVUK7VOQUD5R45KOBG015RE2B6JGOTT51P38'],
+  ['base58btc', 'zdj7Wic6KcJAfWz1c9o4M6kq9Lwd5BfbxkVafnrojaaGiSFxM'],
+  ['base58flickr', 'ZCJ7vHB6jBiaEvZ1B9N4m6KQ9kWC5bEAXKuzEMRNJzzgHrfXm'],
+  ['base256emoji', '🚀🪐⭐💻😅❓💎🌈🌸🌚💰💍🌒😵🐶💁🤐🌎👼🙃🙅☺🌚😞🤤⭐🚀😃✈🌕😚🍻💜🐷⚽✌😊']
+]
+
+const ipnsCases: Array<[string, string]> = [
+  ['base2', '000000001011100100000000000100100000010000000000100010010001000001110010001101000000010110010111110001100100011010010000100001001000011100110101010100011001001111111000110111011001101000010101010111000111001111101100100100011100011110001111000110101100000110001101001010100110101101010100011110101110010010001000100100100'],
+  ['base32', 'bafzaajaiaejcbzdibmxyzdjbbehgvizh6g5tikvy47mshdy6gwbruvgwvd24seje'],
+  ['base32upper', 'BAFZAAJAIAEJCBZDIBMXYZDJBBEHGVIZH6G5TIKVY47MSHDY6GWBRUVGWVD24SEJE'],
+  ['base32pad', 'cafzaajaiaejcbzdibmxyzdjbbehgvizh6g5tikvy47mshdy6gwbruvgwvd24seje'],
+  ['base32padupper', 'CAFZAAJAIAEJCBZDIBMXYZDJBBEHGVIZH6G5TIKVY47MSHDY6GWBRUVGWVD24SEJE'],
+  ['base16', 'f0172002408011220e4680b2f8c8d21090e6aa327f1bb342ab8e7d9238f1e35831a54d6a8f5c91124'],
+  ['base16upper', 'F0172002408011220E4680B2F8C8D21090E6AA327F1BB342AB8E7D9238F1E35831A54D6A8F5C91124'],
+  ['base36', 'k51qzi5uqu5dlvj2baxnqndepeb86cbk3ng7n3i46uzyxzyqj2xjonzllnv0v8'],
+  ['base36upper', 'K51QZI5UQU5DLVJ2BAXNQNDEPEB86CBK3NG7N3I46UZYXZYQJ2XJONZLLNV0V8'],
+  ['base64', 'mAXIAJAgBEiDkaAsvjI0hCQ5qoyfxuzQquOfZI48eNYMaVNao9ckRJA'],
+  ['base64pad', 'MAXIAJAgBEiDkaAsvjI0hCQ5qoyfxuzQquOfZI48eNYMaVNao9ckRJA=='],
+  ['base32hexpad', 't05p0090804921p381cnop3911476l8p7u6tj8alosvci73ou6m1hkl6ml3qsi494'],
+  ['base32hexpadupper', 'T05P0090804921P381CNOP3911476L8P7U6TJ8ALOSVCI73OU6M1HKL6ML3QSI494'],
+  ['base64url', 'uAXIAJAgBEiDkaAsvjI0hCQ5qoyfxuzQquOfZI48eNYMaVNao9ckRJA'],
+  ['base64urlpad', 'UAXIAJAgBEiDkaAsvjI0hCQ5qoyfxuzQquOfZI48eNYMaVNao9ckRJA=='],
+  ['base32hex', 'v05p0090804921p381cnop3911476l8p7u6tj8alosvci73ou6m1hkl6ml3qsi494'],
+  ['base32hexupper', 'V05P0090804921P381CNOP3911476L8P7U6TJ8ALOSVCI73OU6M1HKL6ML3QSI494'],
+  ['base58btc', 'z5AanNVJCxnWCzDzCerCejh6EdigZJnNfHrJGzTp5TT2moo7mRGhZZu'],
+  ['base58flickr', 'Z5azMnuicXMvcZdZcDRcDJG6eCHFyiMnEhRigZsP5ss2LNN7LqgGyyU'],
+  ['base256emoji', '🚀🪐🥺🚀🥰🌔🪐💻😅🎤😴🌗👌👑🎵👏🌕🌏😬🎁💙💩😙😇😆🎀❄🍒🔥😛😘🌹🌻😊💋💅✊🤐🦋☀🥰']
+]
+
+describe('multibase round-trip: /ipfs/ -> base32 subdomain label', () => {
+  for (const [name, input] of ipfsCases) {
+    it(name, () => {
+      expect(toSubdomain(input, 'ipfs')).to.equal(IPFS_CANONICAL)
+    })
+  }
+})
+
+describe('multibase round-trip: /ipns/ -> base36 subdomain label', () => {
+  for (const [name, input] of ipnsCases) {
+    it(name, () => {
+      expect(toSubdomain(input, 'ipns')).to.equal(IPNS_CANONICAL)
+    })
+  }
+})

--- a/test/lib/parse-request.spec.ts
+++ b/test/lib/parse-request.spec.ts
@@ -569,4 +569,78 @@ describe('parse-request', () => {
       })
     })
   })
+
+  // Round-trip the canonical /ipfs/ CID through every multibase from
+  // `ipfs multibase list` (kubo) minus identity. Fixtures match those in
+  // test/cloudflare/snippets/multibase.spec.ts and were generated with kubo:
+  //   ipfs cid format -b=<base> bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi
+  describe('multibase coverage on /ipfs/ path', () => {
+    const canonical = 'bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi'
+    const canonicalCid = CID.parse(canonical)
+
+    const cases: Array<[string, string]> = [
+      ['base2', '0000000010111000000010010001000001100001111000100011100110011111011001000101011111111110100000110110011111001111010011111111101010000111111111100011010111100110100101110110010000101101001100001011100000000000001001011101101110000100101100110100111000011000111011110100101000011100100011010'],
+      ['base32', 'bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi'],
+      ['base32upper', 'BAFYBEIGDYRZT5SFP7UDM7HU76UH7Y26NF3EFUYLQABF3OCLGTQY55FBZDI'],
+      ['base32pad', 'cafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi======'],
+      ['base32padupper', 'CAFYBEIGDYRZT5SFP7UDM7HU76UH7Y26NF3EFUYLQABF3OCLGTQY55FBZDI======'],
+      ['base16', 'f01701220c3c4733ec8affd06cf9e9ff50ffc6bcd2ec85a6170004bb709669c31de94391a'],
+      ['base16upper', 'F01701220C3C4733EC8AFFD06CF9E9FF50FFC6BCD2EC85A6170004BB709669C31DE94391A'],
+      ['base36', 'k2jmtxw8rjh1z69c6not3wtdxb0u3urbzhyll1t9jg6ox26dhi5sfi1m'],
+      ['base36upper', 'K2JMTXW8RJH1Z69C6NOT3WTDXB0U3URBZHYLL1T9JG6OX26DHI5SFI1M'],
+      ['base32hexpad', 't05o14863ohpjti5fvk3cv7kvuk7voqud5r45kobg015re2b6jgott51p38======'],
+      ['base32hexpadupper', 'T05O14863OHPJTI5FVK3CV7KVUK7VOQUD5R45KOBG015RE2B6JGOTT51P38======'],
+      ['base64url', 'uAXASIMPEcz7Ir_0Gz56f9Q_8a80uyFphcABLtwlmnDHelDka'],
+      ['base32hex', 'v05o14863ohpjti5fvk3cv7kvuk7voqud5r45kobg015re2b6jgott51p38'],
+      ['base32hexupper', 'V05O14863OHPJTI5FVK3CV7KVUK7VOQUD5R45KOBG015RE2B6JGOTT51P38'],
+      ['base58btc', 'zdj7Wic6KcJAfWz1c9o4M6kq9Lwd5BfbxkVafnrojaaGiSFxM'],
+      ['base58flickr', 'ZCJ7vHB6jBiaEvZ1B9N4m6KQ9kWC5bEAXKuzEMRNJzzgHrfXm'],
+      ['base64urlpad', 'UAXASIMPEcz7Ir_0Gz56f9Q_8a80uyFphcABLtwlmnDHelDka'],
+      ['base256emoji', '🚀🪐⭐💻😅❓💎🌈🌸🌚💰💍🌒😵🐶💁🤐🌎👼🙃🙅☺🌚😞🤤⭐🚀😃✈🌕😚🍻💜🐷⚽✌😊']
+      // base64 (m) and base64pad (M) are skipped: their alphabets contain
+      // '/', which is a path separator in URLs and cannot survive a round
+      // trip through the URL parser. The decoders themselves are exercised
+      // by the snippet multibase.spec.ts.
+    ]
+
+    for (const [name, encoded] of cases) {
+      it(`/ipfs/<${name}> resolves to canonical CID`, () => {
+        const result = parseRequest(new URL(`http://localhost:3000/ipfs/${encoded}`), new URL('http://localhost:3000'))
+        if (result.type !== 'path' || !('cid' in result)) {
+          throw new Error(`expected path-IPFS result, got ${JSON.stringify(result)}`)
+        }
+        expect(result.cid.equals(canonicalCid)).to.equal(true, `${name} did not round-trip`)
+        // subdomain URL should always be the canonical base32 label
+        expect(result.subdomainURL.host).to.equal(`${canonical}.ipfs.localhost:3000`)
+      })
+    }
+  })
+
+  // Same coverage for /ipns/, asserting the libp2p-key peer ID round-trips.
+  describe('multibase coverage on /ipns/ path', () => {
+    const canonicalIpns = 'k51qzi5uqu5dlvj2baxnqndepeb86cbk3ng7n3i46uzyxzyqj2xjonzllnv0v8'
+
+    const cases: Array<[string, string]> = [
+      ['base32', 'bafzaajaiaejcbzdibmxyzdjbbehgvizh6g5tikvy47mshdy6gwbruvgwvd24seje'],
+      ['base32upper', 'BAFZAAJAIAEJCBZDIBMXYZDJBBEHGVIZH6G5TIKVY47MSHDY6GWBRUVGWVD24SEJE'],
+      ['base16', 'f0172002408011220e4680b2f8c8d21090e6aa327f1bb342ab8e7d9238f1e35831a54d6a8f5c91124'],
+      ['base16upper', 'F0172002408011220E4680B2F8C8D21090E6AA327F1BB342AB8E7D9238F1E35831A54D6A8F5C91124'],
+      ['base36', 'k51qzi5uqu5dlvj2baxnqndepeb86cbk3ng7n3i46uzyxzyqj2xjonzllnv0v8'],
+      ['base36upper', 'K51QZI5UQU5DLVJ2BAXNQNDEPEB86CBK3NG7N3I46UZYXZYQJ2XJONZLLNV0V8'],
+      ['base58btc', 'z5AanNVJCxnWCzDzCerCejh6EdigZJnNfHrJGzTp5TT2moo7mRGhZZu']
+      // Other multibases decode to the same libp2p-key bytes, but
+      // @libp2p/peer-id rejects forms outside base32/base36/base58btc.
+      // Widen the fixture if that upstream constraint relaxes.
+    ]
+
+    for (const [name, encoded] of cases) {
+      it(`/ipns/<${name}> resolves to canonical libp2p-key`, () => {
+        const result = parseRequest(new URL(`http://localhost:3000/ipns/${encoded}`), new URL('http://localhost:3000'))
+        if (result.type !== 'path' || !('peerId' in result)) {
+          throw new Error(`expected path-IPNS result, got ${JSON.stringify(result)}`)
+        }
+        expect(result.subdomainURL.host).to.equal(`${canonicalIpns}.ipns.localhost:3000`)
+      })
+    }
+  })
 })


### PR DESCRIPTION
> Towards: 
> - https://github.com/ipshipyard/roadmaps/issues/53

## TLDR

We have some headroom in Cloudflare Snippets (max 32KiB), let's avoid any discrepancy and support same bases as ipfs.io does today.

This PR adds missing bases to both snippets and SW router.

cc @achingbrain @aschmahmann 

## Summary

Brings https://inbrowser.link to parity with Kubo's `ipfs multibase list`  across both runtime and the Cloudflare snippet. Before this PR, CIDs encoded in any base outside `b, k, f, F, z` were rejected before reaching `verified-fetch`.

- `src/cloudflare/snippets/{cid,codec}.ts`: 20-prefix dispatch ported from https://github.com/ipshipyard/waterworks-infra/pull/970. Hardened varint against signed-32-bit overflow and made alphabet lookup throw on unknown chars instead of silently mapping to byte 0. New decoders: `base2`, `base32` upper/pad/hex variants, `base36upper`, `base58flickr`, `base64` / `base64pad` / `base64urlpad`, `base256emoji`.
- `src/lib/parse-request.ts`: `findMultibaseDecoder` widened from 5 to 20 prefixes. 🚀 (base256emoji) is dispatched by codepoint after the ASCII switch since the prefix is two UTF-16 code units. `parseCID` decodes percent-escapes only when the CID starts with `%F0%9F%9A%80`, so ASCII bases stay on a zero-decode hot path.
- `build.js`: enforce Cloudflare's 32 KiB per-snippet cap; print every output's size and percent of cap, fail the build if any cross the line.

## Bundle size impact

### Cloudflare snippets (32 KiB cap each)

| Snippet | main | this PR | Δ |
|---|---|---|---|
| `01_path_gateway_to_subdomain.js` | 4.1 KiB | 8.1 KiB (25% of cap) | +4.0 KiB (+99%) |
| `02_shared_sw_installer_cache.js` | 0.4 KiB | 0.4 KiB | 0 |

Roughly half of the snippet growth is the `base256emoji` alphabet (256 multi-byte emoji codepoints). Snippets ship a hand-written decoder set, so every new base adds bytes directly. Build now fails if any snippet crosses the 32 KiB cap so we don't risk anything here.

### Service worker + UI app

| Artifact | main | this PR | Δ |
|---|---|---|---|
| `ipfs-sw-sw.js` (service worker) | 978.1 KiB | 978.4 KiB | +379 B (+0.04%) |
| `ipfs-sw-index-*.js` (UI app, all chunks) | 1306 KiB | 1315 KiB | +9.1 KiB (+0.7%) |

iiuc the SW bundle size gains almost nothing because `multiformats/bases/*` is already in the dependency tree via `@helia/verified-fetch`. The new imports in `parse-request.ts` mostly wire up code that was already shipping; the SW delta is just the dispatch table and the percent-encoded prefix string.

## Test plan

- [x] `npm run test:node` passes 
- [x] Manually verified against live kubo `ipfs multibase encode` / `ipfs cid format`
- [x] Production build under the 32 KiB Cloudflare cap