### PR TITLE
chore: update reusable GitHub actions

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -248,7 +248,7 @@ jobs:
 
       - name: Upload release asset
         if: steps.set_release_tag.outputs.release_tag != ''   # safety check
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -290,7 +290,7 @@ jobs:
       contents: write # to create release
       pull-requests: write # to create release PR
     steps:
-      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           release-type: node
           # Use a token for creating the release-pr and git tags so that the `deploy` workflow can be triggered by them


### PR DESCRIPTION
## Description

Updates the SHA-pinned reusable GitHub Actions used by release and binary upload workflows while preserving the existing pin specificity.

## Notes & open questions

Validation passed with YAML parsing for all workflows and actionlint.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
