### PR TITLE
fix: share edge cache across SPA paths per subdomain

### DIFF
--- a/src/cloudflare/snippets/02_shared_sw_installer_cache.ts
+++ b/src/cloudflare/snippets/02_shared_sw_installer_cache.ts
@@ -1,26 +1,30 @@
 // Cloudflare Snippet: shared service worker installer cache
 //
-// Controls edge and browser caching for the service worker gateway.
-// All subdomains serve the same HTML+JS service worker installer, so
-// versioned SW assets can share a single cache entry across subdomains.
+// Controls edge caching for the service worker gateway. Every subdomain
+// serves the same installer HTML and the same versioned JS/CSS.
 //
-// /ipfs-sw-* paths (versioned SW assets):
-//   - normalized cache key (base domain) so subdomains share edge cache
-//   - 24h edge TTL (assets only change on deploy)
+// /ipfs-sw-* (versioned SW assets):
+//   Cache key normalized to base domain. Identical bytes across all
+//   subdomains share one edge entry.
 //
-// Everything else:
-//   - default cache key (per-subdomain, so badbits 410s are per-CID)
-//   - 5-minute edge TTL so badbits enforcement at the origin takes
-//     effect within 5 minutes of a CID being blocked
+// Everything else (SPA fallback to index.html at origin):
+//   Cache key normalized per subdomain. Origin returns the same installer
+//   HTML for any non-asset path, so the long tail of arbitrary URLs
+//   collapses to one entry per hostname. Badbits enforcement uses a manual
+//   purge of the whole subdomain, so edge TTL does not gate how fast a
+//   blocked CID stops being served.
+//
+// HTML and versioned JS/CSS share the same TTL on purpose: a stale HTML
+// entry referencing fresh JS (or vice versa) could mismatch and break
+// the installer.
+
+const EDGE_CACHE_TTL_S = 86400 // 24h
 
 export default {
   async fetch (request: Request): Promise<Response> {
     const url = new URL(request.url)
 
     if (url.pathname.startsWith('/ipfs-sw-')) {
-      // Versioned service worker assets are identical across all subdomains.
-      // Normalize cache key to base domain so they share a single edge cache
-      // entry, and cache for 24h (86400s) since they only change on deploy.
       const baseDomain = url.hostname.split('.').slice(-2).join('.')
       const cacheKey = `https://${baseDomain}${url.pathname}`
 
@@ -29,27 +33,25 @@ export default {
           cacheEverything: true,
           cacheKey,
           cacheTtlByStatus: {
-            '200-299': 86400,
-            // Do not cache errors for SW assets -- a transient failure
-            // should not be stuck in cache for 24h.
+            '200-299': EDGE_CACHE_TTL_S,
+            // Do not cache errors. A transient failure must not be stuck
+            // in cache for the full TTL.
             '300-599': 0
           }
         }
       })
     }
 
-    // Everything else: use default cache key (includes full hostname, so
-    // each subdomain caches independently). Use 5-minute TTL (300s) so
-    // badbits enforcement at the origin takes effect within 5 minutes
-    // of a CID being blocked. Caching 300s is fine here -- these are
-    // redirects from path_gateway_to_subdomain snippet or the origin.
+    const cacheKey = `https://${url.hostname}/__sw_installer_html`
+
     return fetch(request, {
       cf: {
         cacheEverything: true,
+        cacheKey,
         cacheTtlByStatus: {
-          '200-399': 300,
-          // Do not cache client/server errors -- a transient failure
-          // should not be stuck in cache.
+          '200-399': EDGE_CACHE_TTL_S,
+          // Do not cache errors. A transient failure must not be stuck
+          // in cache for the full TTL.
           '400-599': 0
         }
       }

--- a/test/cloudflare/snippets/02_shared_sw_installer_cache.spec.ts
+++ b/test/cloudflare/snippets/02_shared_sw_installer_cache.spec.ts
@@ -91,21 +91,33 @@ describe('02_shared_sw_installer_cache', () => {
     })
   })
 
-  describe('non-SW paths (default cache key, 5min TTL)', () => {
-    it('does not set custom cache key for /wiki/', async () => {
+  describe('non-SW paths (per-subdomain installer cache key, 24h TTL)', () => {
+    it('collapses /wiki/ to per-subdomain installer cache key', async () => {
       const { cf } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/wiki/')
-      expect(cf.cacheKey).to.equal(undefined)
+      expect(cf.cacheKey).to.equal('https://bafyxxx.ipfs.inbrowser.dev/__sw_installer_html')
       expect(cf.cacheEverything).to.equal(true)
     })
 
-    it('does not set custom cache key for root /', async () => {
+    it('collapses root / to per-subdomain installer cache key', async () => {
       const { cf } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/')
-      expect(cf.cacheKey).to.equal(undefined)
+      expect(cf.cacheKey).to.equal('https://bafyxxx.ipfs.inbrowser.dev/__sw_installer_html')
     })
 
-    it('uses 5-minute edge TTL for 200-399', async () => {
+    it('shares cache key across long-tail paths on the same subdomain', async () => {
+      const { cf: cf1 } = await callHandler('https://en-wikipedia--on--ipfs-org.ipns.inbrowser.link/wiki/Charles_Krum.html')
+      const { cf: cf2 } = await callHandler('https://en-wikipedia--on--ipfs-org.ipns.inbrowser.link/wiki/Tver_Carriage_Works')
+      expect(cf1.cacheKey).to.equal(cf2.cacheKey)
+    })
+
+    it('uses different cache key for different subdomains', async () => {
+      const { cf: cfA } = await callHandler('https://aaa.ipfs.inbrowser.dev/page')
+      const { cf: cfB } = await callHandler('https://bbb.ipfs.inbrowser.dev/page')
+      expect(cfA.cacheKey).to.not.equal(cfB.cacheKey)
+    })
+
+    it('uses 24h edge TTL for 200-399', async () => {
       const { cf } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/page')
-      expect(cf.cacheTtlByStatus['200-399']).to.equal(300)
+      expect(cf.cacheTtlByStatus['200-399']).to.equal(86400)
     })
 
     it('does not cache 400+ responses at edge', async () => {
@@ -127,10 +139,10 @@ describe('02_shared_sw_installer_cache', () => {
       expect(response.headers.get('Cache-Control')).to.equal('no-cache')
     })
 
-    it('does not set custom cache key for .ipns. subdomain', async () => {
+    it('uses per-subdomain cache key on .ipns. subdomain', async () => {
       const { cf } = await callHandler('https://en-wikipedia--on--ipfs-org.ipns.inbrowser.dev/wiki/')
-      expect(cf.cacheKey, undefined)
-      expect(cf.cacheTtlByStatus['200-399']).to.equal(300)
+      expect(cf.cacheKey).to.equal('https://en-wikipedia--on--ipfs-org.ipns.inbrowser.dev/__sw_installer_html')
+      expect(cf.cacheTtlByStatus['200-399']).to.equal(86400)
     })
 
     it('does not override Cache-Control for 301 responses', async () => {
@@ -154,6 +166,12 @@ describe('02_shared_sw_installer_cache', () => {
       expect(cf.cacheTtlByStatus['200-399']).to.not.equal(undefined, 'expected 200-399 key to be defined')
       expect(cf.cacheTtlByStatus['400-599']).to.not.equal(undefined, 'expected 400-599 key to be defined')
     })
+
+    it('HTML and versioned SW asset TTLs match (avoid HTML-JS skew)', async () => {
+      const { cf: cfHtml } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/page')
+      const { cf: cfAsset } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/ipfs-sw-main.js')
+      expect(cfHtml.cacheTtlByStatus['200-399']).to.equal(cfAsset.cacheTtlByStatus['200-299'])
+    })
   })
 
   describe('TLD-agnostic behavior', () => {
@@ -169,14 +187,14 @@ describe('02_shared_sw_installer_cache', () => {
       const { cf: cfDev } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/page')
       const { cf: cfLink } = await callHandler('https://bafyxxx.ipfs.inbrowser.link/page')
       expect(cfDev.cacheTtlByStatus['200-399']).to.equal(cfLink.cacheTtlByStatus['200-399'])
-      expect(cfDev.cacheKey).to.equal(undefined)
-      expect(cfLink.cacheKey).to.equal(undefined)
+      expect(cfDev.cacheKey).to.equal('https://bafyxxx.ipfs.inbrowser.dev/__sw_installer_html')
+      expect(cfLink.cacheKey).to.equal('https://bafyxxx.ipfs.inbrowser.link/__sw_installer_html')
     })
 
-    it('base domain requests use 5min TTL', async () => {
+    it('base domain requests use 24h TTL and per-host installer key', async () => {
       const { cf } = await callHandler('https://inbrowser.dev/')
-      expect(cf.cacheTtlByStatus['200-399']).to.equal(300)
-      expect(cf.cacheKey).to.equal(undefined)
+      expect(cf.cacheTtlByStatus['200-399']).to.equal(86400)
+      expect(cf.cacheKey).to.equal('https://inbrowser.dev/__sw_installer_html')
     })
   })
 })


### PR DESCRIPTION
## Problem

`/ipfs-sw-*` assets cache fine, but everything else on subdomains like `en-wikipedia--on--ipfs-org.ipns.inbrowser.link` misses constantly. Origin returns the same installer HTML for any non-asset path, but Cloudflare keys by URL, so each `/wiki/<article>` fills its own entry that nobody else ever hits.

## Fix

Normalize the cache key for non-asset paths to one entry per subdomain. The long tail collapses to a single slot per host.

HTML TTL bumped to 24h to match `/ipfs-sw-*` via a shared const, so the installer HTML and the bundle it references stay on the same version boundary. Badbits takedowns purge the subdomain manually, so TTL does not gate enforcement.

## Testing 

- i guess wee merge this and then deploy to staging (`.dev`) and look at CF cache hits, if all good, do the same for `.link` 


cc @achingbrain @aschmahmann 


