### PR TITLE
feat: enable webtransport on all supporting browsers

### DIFF
--- a/src/sw/lib/verified-fetch.ts
+++ b/src/sw/lib/verified-fetch.ts
@@ -39,8 +39,9 @@ async function libp2pDefaults (): Promise<Libp2pOptions> {
     webSockets()
   ]
 
-  // WebTransport only works reliably in Firefox at the time of writing
-  if (navigator?.userAgent?.toLowerCase().includes('firefox') === true) {
+  // Enable WebTransport when the browser exposes the API.
+  // Baseline as of 2026-03 (Safari 26.4); also Chrome 97+, Edge 98+, Firefox 114+.
+  if ('WebTransport' in globalThis) {
     transports.push(webTransport())
     filterAddrs.push('webtransport')
   }


### PR DESCRIPTION
## What was broken
A Firefox useragent sniff in `src/sw/lib/verified-fetch.ts` kept Chrome, Edge, and Safari users from dialing WebTransport peers, and stripped `webtransport` from the `filter-addrs` query sent to `delegated-ipfs.dev`.

## Fix
Feature-detect `globalThis.WebTransport`. WebTransport reached Baseline with Safari 26.4 (March 2026), so Chrome 97+, Edge 98+, Firefox 114+, and Safari 26.4+ now dial WebTransport peers and the routing query includes `webtransport`.

## Caveat: Chromium reliability
Chromium WebTransport throttles after enough sessions accumulate, blocking new dials until the page reloads (upstream: [chromium#40069954](https://issues.chromium.org/issues/40069954); IPFS impact: ipfs/in-web-browsers#211). 

We believe that shipping this despite that being wip is still net-positive: peers that are only reachable over WebTransport become dialable in Chrome/Edge, and libp2p falls back to other transports (WebSockets, HTTPS) or peers when WebTransport fails.

cc @achingbrain 