### PR TITLE
fix: encode filename in url as uri component

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@helia/delegated-routing-v1-http-api-client": "^6.0.1",
     "@helia/routers": "^5.1.0",
     "@helia/utils": "^2.5.0",
-    "@helia/verified-fetch": "^7.2.7",
+    "@helia/verified-fetch": "^7.2.10",
     "@ipld/dag-cbor": "^9.2.5",
     "@ipld/dag-json": "^10.2.5",
     "@ipld/dag-pb": "^4.1.5",

--- a/src/sw/handlers/content-request-handler.ts
+++ b/src/sw/handlers/content-request-handler.ts
@@ -218,7 +218,7 @@ async function fetchHandler ({ request, headers, renderHtml, event, logs, accept
       if (evt.type.endsWith(':found-provider')) {
         providers.total++
 
-        log('got found-provider event %s %j %e', evt.type, evt.detail, new Error('where'))
+        log('got found-provider event %s %j', evt.type, evt.detail)
 
         if (isBitswapProvider(evt.detail)) {
           providers.providers.push({

--- a/src/ui/pages/render-entity.tsx
+++ b/src/ui/pages/render-entity.tsx
@@ -168,7 +168,7 @@ function UnixFSDirectory ({ cid, ipfsPath, directory }: UnixFSDirectoryProps): R
   function viewLink (name: string): void {
     const url = new URL(window.location.href)
 
-    window.location.href = `${url.protocol}//${url.host}${url.pathname}${encodeURI(name)}${url.search}${url.hash}`
+    window.location.href = `${url.protocol}//${url.host}${url.pathname}${encodeURIComponent(name)}${url.search}${url.hash}`
   }
 
   const linkParts = ipfsPath.split('/')

--- a/src/ui/pages/render-media.tsx
+++ b/src/ui/pages/render-media.tsx
@@ -69,9 +69,9 @@ export function RenderMediaPage (): ReactElement {
       <header className='flex items-center bg-navy white ph3 sans-serif f6' style={topBarStyle}>
         <a href={toGatewayRoot('/')} className='white no-underline b' title='IPFS Service Worker Gateway'>ipfs</a>
         <span className='mh2 white-50'>{'\u25b8'}</span>
-        <span className='truncate b' title={props.displayName}>{props.displayName}</span>
+        <span className='truncate b display-name' title={props.displayName}>{props.displayName}</span>
         <span className='mh2 white-50'>{'\u25b8'}</span>
-        <span className='white-70 truncate'>{props.contentType}</span>
+        <span className='white-70 truncate content-type'>{props.contentType}</span>
         {sizeLabel != null && (
           <>
             <span className='mh2 white-50'>{'\u2022'}</span>

--- a/test-e2e/directory-listing.spec.ts
+++ b/test-e2e/directory-listing.spec.ts
@@ -118,4 +118,25 @@ test.describe('directory-listing', () => {
 
     await expect(page.getByText('Raw Preview')).toBeVisible()
   })
+
+  test('should follow link for file with special characters in the name', async ({ page, baseURL }) => {
+    const fileName = 'h#e£l%l?o@-:w~o`rld.txt'
+
+    ;[file, directory] = await all(kubo.addAll([{
+      path: `/${fileName}`,
+      content: uint8ArrayFromString('hello world\n')
+    }], {
+      wrapWithDirectory: true,
+      rawLeaves: true
+    }))
+
+    const response = await loadWithServiceWorker(page, `${baseURL}/ipfs/${directory.cid}`)
+    expect(response.status()).toBe(200)
+
+    await expect(page.locator(`#row-${file.cid} .name-cell`)).toContainText(fileName)
+    await page.click(`#row-${file.cid} .name-cell`)
+
+    await expect(mediaViewerFrame(page).getByText('hello world')).toBeVisible()
+    await expect(page.locator('.display-name')).toContainText(fileName)
+  })
 })


### PR DESCRIPTION
Use `encodeURIComponent` to ensure we encode characters that can't be in URL segments

Fixes #1068

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
