### PR TITLE
fix: escape download form input and block download/preview links

### DIFF
--- a/src/lib/encode-path-components.ts
+++ b/src/lib/encode-path-components.ts
@@ -1,0 +1,14 @@
+/**
+ * IPFS path segments can include non-URL safe characters like # and ? so escape
+ * them so IPFS paths be appended to URLs
+ */
+export function encodePathComponents (str: string | string[]): string {
+  if (!Array.isArray(str)) {
+    str = str.split('/')
+  }
+
+  return str
+    .filter(segment => segment.trim() !== '')
+    .map(segment => encodeURIComponent(segment))
+    .join('/')
+}

--- a/src/lib/parse-request.ts
+++ b/src/lib/parse-request.ts
@@ -10,6 +10,7 @@ import { base58btc, base58flickr } from 'multiformats/bases/base58'
 import { base64, base64pad, base64url, base64urlpad } from 'multiformats/bases/base64'
 import { CID } from 'multiformats/cid'
 import { dnsLinkLabelDecoder, dnsLinkLabelEncoder, isInlinedDnsLink } from './dns-link-labels.ts'
+import { encodePathComponents } from './encode-path-components.ts'
 import type { PeerId } from '@libp2p/interface'
 import type { MultibaseDecoder } from 'multiformats/cid'
 
@@ -379,12 +380,6 @@ function findMultibaseDecoder (str: string): MultibaseDecoder<string> | undefine
   if (str.codePointAt(0) === BASE256_EMOJI_PREFIX_CP) {
     return base256emoji
   }
-}
-
-function encodePathComponents (str: string): string {
-  return str.split('/')
-    .map(component => encodeURIComponent(component))
-    .join('/')
 }
 
 export function parseRequest (url: URL | string, root: URL): ResolvableURI {

--- a/src/lib/parse-request.ts
+++ b/src/lib/parse-request.ts
@@ -381,12 +381,18 @@ function findMultibaseDecoder (str: string): MultibaseDecoder<string> | undefine
   }
 }
 
+function encodePathComponents (str: string): string {
+  return str.split('/')
+    .map(component => encodeURIComponent(component))
+    .join('/')
+}
+
 export function parseRequest (url: URL | string, root: URL): ResolvableURI {
   if (url instanceof String || typeof url === 'string') {
     if (url.startsWith('/ipfs/')) {
-      url = new URL(`ipfs://${url.substring('/ipfs/'.length)}`)
+      url = new URL(`ipfs://${encodePathComponents(url.substring('/ipfs/'.length))}`)
     } else if (url.startsWith('/ipns/')) {
-      url = new URL(`ipns://${url.substring('/ipns/'.length)}`)
+      url = new URL(`ipns://${encodePathComponents(url.substring('/ipns/'.length))}`)
     } else {
       url = new URL(url)
     }

--- a/src/sw/lib/safe-decode-uri.ts
+++ b/src/sw/lib/safe-decode-uri.ts
@@ -1,0 +1,12 @@
+/**
+ * `decodeURI` raises `URIError` on malformed `%`-sequences. Without this
+ * guard a stray `%` in a navigation URL turns into a 500 error page; we'd
+ * rather render the viewer with the raw header value than blow up.
+ */
+export function safeDecodeURI (s: string): string {
+  try {
+    return decodeURI(s)
+  } catch {
+    return s
+  }
+}

--- a/src/sw/pages/render-entity.ts
+++ b/src/sw/pages/render-entity.ts
@@ -3,6 +3,7 @@ import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
 import { GENERATED_HTML_CACHE_CONTROL } from '../../constants.ts'
 import { headersToObject } from '../../lib/headers-to-object.ts'
 import { APP_NAME, APP_VERSION, GIT_REVISION } from '../../version.ts'
+import { safeDecodeURI } from '../lib/safe-decode-uri.ts'
 import { htmlPage } from './page.ts'
 import type { ContentURI } from '../../lib/parse-request.ts'
 
@@ -20,7 +21,7 @@ export function renderEntityPageResponse (request: ContentURI, headers: Headers,
 
   const props = {
     cid: mergedHeaders.get('x-ipfs-roots')?.split(',').pop() ?? '',
-    ipfsPath: mergedHeaders.get('x-ipfs-path') ?? '',
+    ipfsPath: safeDecodeURI(mergedHeaders.get('x-ipfs-path') ?? ''),
     entity: uint8ArrayToString(new Uint8Array(entity, 0, entity.byteLength), 'base64'),
     contentType,
     request: {

--- a/src/sw/pages/render-entity.ts
+++ b/src/sw/pages/render-entity.ts
@@ -20,7 +20,7 @@ export function renderEntityPageResponse (request: ContentURI, headers: Headers,
 
   const props = {
     cid: mergedHeaders.get('x-ipfs-roots')?.split(',').pop() ?? '',
-    ipfsPath: decodeURI(mergedHeaders.get('x-ipfs-path') ?? ''),
+    ipfsPath: mergedHeaders.get('x-ipfs-path') ?? '',
     entity: uint8ArrayToString(new Uint8Array(entity, 0, entity.byteLength), 'base64'),
     contentType,
     request: {

--- a/src/sw/pages/render-media.ts
+++ b/src/sw/pages/render-media.ts
@@ -1,22 +1,10 @@
 import { GENERATED_HTML_CACHE_CONTROL } from '../../constants.ts'
 import { APP_NAME, APP_VERSION, GIT_REVISION } from '../../version.ts'
 import { deriveViewerNames, getMediaTypeInfo } from '../lib/media-viewer-types.ts'
+import { safeDecodeURI } from '../lib/safe-decode-uri.ts'
 import { htmlPage } from './page.ts'
 import type { ContentURI } from '../../lib/parse-request.ts'
 import type { MediaTypeInfo } from '../lib/media-viewer-types.ts'
-
-/**
- * `decodeURI` raises `URIError` on malformed `%`-sequences. Without this
- * guard a stray `%` in a navigation URL turns into a 500 error page; we'd
- * rather render the viewer with the raw header value than blow up.
- */
-function safeDecodeURI (s: string): string {
-  try {
-    return decodeURI(s)
-  } catch {
-    return s
-  }
-}
 
 /**
  * Build the HTML "media viewer" wrapper for top-level navigations to

--- a/src/ui/components/download-form.tsx
+++ b/src/ui/components/download-form.tsx
@@ -8,7 +8,7 @@ import { InputSelect } from './input-select.tsx'
 import type { ReactElement, MouseEvent } from 'react'
 
 export interface DownloadFormProps {
-  handleSubmit(e: React.FormEvent): void
+  handleSubmit(e: React.SyntheticEvent): void
   input: string
   setInput(download: string): void
   setSubdomainURL(url: URL): void

--- a/src/ui/utils/links.ts
+++ b/src/ui/utils/links.ts
@@ -37,7 +37,10 @@ export function createLink ({ ipfsPath, params, hash }: CreateLinkOptions): stri
   }
 
   const [,, cid, ...rest] = ipfsPath.split('/')
-  const path = '/' + rest.filter(segment => segment.trim() !== '').join('/')
+  const path = '/' + rest
+    .filter(segment => segment.trim() !== '')
+    .map(segment => encodeURIComponent(segment))
+    .join('/')
 
   const host = (subdomainURL.host.includes('.ipfs.') ? subdomainURL.host.split('.ipfs.') : subdomainURL.host.split('.ipns.'))[1]
 

--- a/src/ui/utils/links.ts
+++ b/src/ui/utils/links.ts
@@ -1,5 +1,6 @@
 import { CID } from 'multiformats/cid'
 import { dnsLinkLabelEncoder } from '../../lib/dns-link-labels.ts'
+import { encodePathComponents } from '../../lib/encode-path-components.ts'
 import { parseRequest } from '../../lib/parse-request-cheap.ts'
 import { createSearch } from '../../lib/query-helpers.ts'
 
@@ -37,10 +38,7 @@ export function createLink ({ ipfsPath, params, hash }: CreateLinkOptions): stri
   }
 
   const [,, cid, ...rest] = ipfsPath.split('/')
-  const path = '/' + rest
-    .filter(segment => segment.trim() !== '')
-    .map(segment => encodeURIComponent(segment))
-    .join('/')
+  const path = '/' + encodePathComponents(rest)
 
   const host = (subdomainURL.host.includes('.ipfs.') ? subdomainURL.host.split('.ipfs.') : subdomainURL.host.split('.ipns.'))[1]
 

--- a/test-e2e/directory-listing.spec.ts
+++ b/test-e2e/directory-listing.spec.ts
@@ -133,10 +133,53 @@ test.describe('directory-listing', () => {
     const response = await loadWithServiceWorker(page, `${baseURL}/ipfs/${directory.cid}`)
     expect(response.status()).toBe(200)
 
-    await expect(page.locator(`#row-${file.cid} .name-cell`)).toContainText(fileName)
-    await page.click(`#row-${file.cid} .name-cell`)
+    await expect(page.locator(`#row-${file.cid.toV1()} .name-cell`)).toContainText(fileName)
+    await page.click(`#row-${file.cid.toV1()} .name-cell`)
 
     await expect(mediaViewerFrame(page).getByText('hello world')).toBeVisible()
     await expect(page.locator('.display-name')).toContainText(fileName)
+  })
+
+  test('should download block for file with special characters in the name', async ({ page, baseURL }) => {
+    const fileName = 'h#e£l%l?o@-:w~o`rld.txt'
+
+    ;[file, directory] = await all(kubo.addAll([{
+      path: `/${fileName}`,
+      content: uint8ArrayFromString('hello world\n')
+    }], {
+      wrapWithDirectory: true,
+      rawLeaves: true
+    }))
+
+    const response = await loadWithServiceWorker(page, `${baseURL}/ipfs/${directory.cid}`)
+    expect(response.status()).toBe(200)
+
+    const downloadPromise = page.waitForEvent('download')
+    await page.click(`#row-${file.cid.toV1()} .download-block-button`)
+    const download = await downloadPromise
+
+    const downloadPath = path.join(os.tmpdir(), download.suggestedFilename())
+    await download.saveAs(downloadPath)
+
+    expect(uint8ArrayEquals(fs.readFileSync(downloadPath), await kubo.block.get(file.cid))).toBeTruthy()
+  })
+
+  test('should preview block for file with special characters in the name', async ({ page, baseURL }) => {
+    const fileName = 'h#e£l%l?o@-:w~o`rld.txt'
+
+    ;[file, directory] = await all(kubo.addAll([{
+      path: `/${fileName}`,
+      content: uint8ArrayFromString('hello world\n')
+    }], {
+      wrapWithDirectory: true,
+      rawLeaves: true
+    }))
+
+    const response = await loadWithServiceWorker(page, `${baseURL}/ipfs/${directory.cid}`)
+    expect(response.status()).toBe(200)
+
+    await page.click(`#row-${file.cid.toV1()} .view-block-button`)
+
+    await expect(page.getByText('Raw Preview')).toBeVisible()
   })
 })

--- a/test-e2e/download-form.test.ts
+++ b/test-e2e/download-form.test.ts
@@ -4,9 +4,12 @@ import { CarReader } from '@ipld/car'
 import { unmarshalIPNSRecord } from 'ipns'
 import all from 'it-all'
 import toBuffer from 'it-to-buffer'
+import { createKuboRPCClient } from 'kubo-rpc-client'
 import { CID } from 'multiformats/cid'
 import * as tar from 'tar'
+import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { test, expect } from './fixtures/config-test-fixtures.ts'
+import type { KuboRPCClient } from 'kubo-rpc-client'
 import type { Download, Page, Response } from 'playwright'
 
 export function captureDownloadResponse (page: Page, cid: string, host: string): Promise<Response> {
@@ -35,6 +38,15 @@ export function captureDownloadResponse (page: Page, cid: string, host: string):
 
 test.describe('download form', () => {
   let download: Download
+  let kubo: KuboRPCClient
+
+  test.beforeEach(async () => {
+    if (process.env.KUBO_GATEWAY == null || process.env.KUBO_GATEWAY === '') {
+      throw new Error('KUBO_GATEWAY not set')
+    }
+
+    kubo = createKuboRPCClient(process.env.KUBO_RPC)
+  })
 
   test.afterEach(async () => {
     try {
@@ -603,6 +615,32 @@ test.describe('download form', () => {
     await page.fill('#inputContent', '/ipfs/bafkqaddimvwgy3zao5xxe3debi')
     await page.reload()
 
+    await page.click('#show-advanced')
+    await page.selectOption('#download', 'true')
+    await page.click('#load-directly')
+
+    download = await downloadPromise
+
+    const file = await fsp.readFile(await download.path(), {
+      encoding: 'utf-8'
+    })
+
+    expect(file).toBe('hello world\n')
+  })
+
+  test('should download file with special characters in the name', async ({ page }) => {
+    const fileName = 'h#e£l%l?o@-:w~o`rld.txt'
+    const [, directory] = await all(kubo.addAll([{
+      path: `/${fileName}`,
+      content: uint8ArrayFromString('hello world\n')
+    }], {
+      wrapWithDirectory: true,
+      rawLeaves: true
+    }))
+
+    const downloadPromise = page.waitForEvent('download')
+
+    await page.fill('#inputContent', `/ipfs/${directory.cid}/${fileName}`)
     await page.click('#show-advanced')
     await page.selectOption('#download', 'true')
     await page.click('#load-directly')


### PR DESCRIPTION
Ensure special characters in URLs do not break download form input or block download/preview buttons

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
