### PR TITLE
fix: set up go before node

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -63,16 +63,16 @@ jobs:
         with:
           ref: ${{ steps.set_release_tag.outputs.release_tag }}
 
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.24'
+
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
           node-version: lts/*
       - uses: ipfs/aegir/actions/cache-node-modules@main # this will cache node_modules and run `npm run build`
-
-      - name: Setup Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: '1.24'
 
       - name: Build binary
         shell: bash # force bash even on windows-latest


### PR DESCRIPTION
The cache-node-modules step runs `npm run build` which requires go to be installed so set up go before caching node modules, otherwise building binaries on mac os fails - https://github.com/ipfs/service-worker-gateway/actions/runs/26014583651

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
