### PR TITLE
fix: improve 502 error messaging

### DIFF
--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -7,3 +7,7 @@ export function isBitswapProvider (prov?: any): prov is BitswapProvider {
 export function isTrustlessGatewayProvider (prov?: any): prov is TrustlessGatewayProvider {
   return prov?.type === 'trustless-gateway'
 }
+
+export function isFallbackTrustlessGatewayProvider (prov?: any): prov is TrustlessGatewayProvider {
+  return prov?.routing === 'http-gateway-routing' && prov?.type === 'trustless-gateway'
+}

--- a/src/sw/handlers/content-request-handler.ts
+++ b/src/sw/handlers/content-request-handler.ts
@@ -6,7 +6,7 @@ import { CURRENT_CACHES } from '../../constants.ts'
 import { errorToObject } from '../../lib/error-to-object.ts'
 import { getSubdomainParts } from '../../lib/get-subdomain-parts.ts'
 import { getSwLogger } from '../../lib/logger.ts'
-import { isBitswapProvider, isTrustlessGatewayProvider } from '../../lib/providers.ts'
+import { isBitswapProvider, isFallbackTrustlessGatewayProvider, isTrustlessGatewayProvider } from '../../lib/providers.ts'
 import { getInstallTime } from '../lib/install-time.ts'
 import { sniffRawContentType } from '../lib/sniff-raw-content-type.ts'
 import { getVerifiedFetch } from '../lib/verified-fetch.ts'
@@ -216,7 +216,11 @@ async function fetchHandler ({ request, headers, renderHtml, event, logs, accept
     redirect: 'manual',
     onProgress: (evt) => {
       if (evt.type.endsWith(':found-provider')) {
-        providers.total++
+        if (isFallbackTrustlessGatewayProvider(evt.detail)) {
+          // do not include fallback trustless gateways in provider list since
+          // they aren't really providers in the IPFS sense
+          return
+        }
 
         log('got found-provider event %s %j', evt.type, evt.detail)
 

--- a/src/ui/pages/fetch-error.tsx
+++ b/src/ui/pages/fetch-error.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { parseRequest } from '../../lib/parse-request.ts'
+import { isTrustlessGatewayProvider } from '../../lib/providers.ts'
 import { removeRootHashIfPresent } from '../../lib/remove-root-hash.ts'
 import { toGatewayRoot } from '../../lib/to-gateway-root.ts'
 import { Button } from '../components/button.tsx'
@@ -214,6 +215,9 @@ export function FetchErrorPage ({ request, response, logs, providers }: FetchErr
     </>
   )
 
+  let showInspectBlock = false
+  let showRetry = false
+
   let message = (
     <>
       <p className='f5 ma3 fw4 db'>An error occurred in the service worker gateway.</p>
@@ -230,6 +234,7 @@ export function FetchErrorPage ({ request, response, logs, providers }: FetchErr
       </>
     )
   } else if (response.status === 501) {
+    showInspectBlock = true
     message = (
       <>
         <p className='f5 ma3 fw4 db'>This gateway encountered content it did not know how to handle.</p>
@@ -241,9 +246,14 @@ export function FetchErrorPage ({ request, response, logs, providers }: FetchErr
     message = (
       <>
         <p className='f5 ma3 fw4 db'>An error occurred while streaming the content.</p>
+        {providers.total === 0
+          ? (
+            <p className='f5 ma3 fw4 db'>This means that no providers with browser-compatible transports were found, and that proxy fallback at trustless-gateway.link failed to to find TCP or QUIC providers.</p>
+            )
+          : ''}
         {providers.total > 0
           ? (
-            <p className='f5 ma3 fw4 db'>This may mean that a recursive gateway claimed to have the content but then failed to actually fetch it on our behalf.</p>
+            <p className='f5 ma3 fw4 db'>This means that one or more providers claimed to have the content but then failed to send the data.</p>
             )
           : ''}
         <Terminal>{response.body}</Terminal>
@@ -252,6 +262,7 @@ export function FetchErrorPage ({ request, response, logs, providers }: FetchErr
       </>
     )
   } else if (response.status === 504) {
+    showRetry = true
     message = (
       <>
         <p className='db pt1 lh-copy ma3'>Fetching your content from the <Link href='https://docs.ipfs.tech/concepts/glossary/#mainnet'>public IPFS network</Link> failed.</p>
@@ -289,15 +300,15 @@ export function FetchErrorPage ({ request, response, logs, providers }: FetchErr
   if (showCheckAvailability && cid != null) {
     checkAvailabilityButton = (
       <>
-        <Button className='bg-navy-muted' onClick={() => checkAvailability(cid)}>Check CID availability</Button>
+        <Button className='bg-teal' onClick={() => checkAvailability(cid)}>Check CID availability</Button>
       </>
     )
   }
 
-  let viewRawBlockButton = <></>
+  let inspectBlockButton = <></>
 
-  if (viewRawBlockButton && cid != null) {
-    viewRawBlockButton = (
+  if (inspectBlockButton && cid != null && showInspectBlock) {
+    inspectBlockButton = (
       <>
         <Button
           className='bg-navy-muted' onClick={(evt: MouseEvent) => {
@@ -311,8 +322,18 @@ export function FetchErrorPage ({ request, response, logs, providers }: FetchErr
               }
             })
           }}
-        >View raw block
+        >Inspect block
         </Button>
+      </>
+    )
+  }
+
+  let retryButton = <></>
+
+  if (showRetry) {
+    retryButton = (
+      <>
+        <Button className='bg-navy-muted' onClick={retry}>Retry</Button>
       </>
     )
   }
@@ -323,11 +344,11 @@ export function FetchErrorPage ({ request, response, logs, providers }: FetchErr
         <>
           {message}
           <p className='ma3'>
-            <Button className='bg-teal' onClick={retry}>Retry</Button>
+            {checkAvailabilityButton}
+            {retryButton}
             <Button className='bg-navy-muted' onClick={goBack}>Go back</Button>
             <Button className='bg-navy-muted' onClick={toggleDebugInfo}>{showDebugInfo ? 'Hide' : 'Show'} debug info</Button>
-            {checkAvailabilityButton}
-            {viewRawBlockButton}
+            {inspectBlockButton}
           </p>
           {showDebugInfo && <DebugInfo request={request} response={response} logs={logs} />}
         </>

--- a/src/ui/pages/fetch-error.tsx
+++ b/src/ui/pages/fetch-error.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react'
 import { parseRequest } from '../../lib/parse-request.ts'
-import { isTrustlessGatewayProvider } from '../../lib/providers.ts'
 import { removeRootHashIfPresent } from '../../lib/remove-root-hash.ts'
 import { toGatewayRoot } from '../../lib/to-gateway-root.ts'
 import { Button } from '../components/button.tsx'


### PR DESCRIPTION
- Omit fallback providers from the provider list
- Mention browser-compatible transports vs TCP/QUIC transports used as fallback
- Do not show "retry" button when retrying won't change the outcome
- Make the "Check CID availability" button the obvious call to action

Fixes #1070

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
