### PR TITLE
fix(snippets): installer cache poisoning

### DIFF
--- a/src/cloudflare/snippets/02_shared_sw_installer_cache.ts
+++ b/src/cloudflare/snippets/02_shared_sw_installer_cache.ts
@@ -70,6 +70,8 @@ export default {
           cacheKey,
           cacheTtlByStatus: {
             '200-299': EDGE_CACHE_TTL_S,
+            // Do not cache errors. A transient failure must not be stuck
+            // in cache for the full TTL.
             '300-599': 0
           }
         }
@@ -103,6 +105,8 @@ export default {
         cacheKey: `https://${url.hostname}/__sw_installer_html`,
         cacheTtlByStatus: {
           '200-299': EDGE_CACHE_TTL_S,
+          // Do not cache errors. A transient failure must not be stuck
+          // in cache for the full TTL.
           '300-599': 0
         }
       }

--- a/src/cloudflare/snippets/02_shared_sw_installer_cache.ts
+++ b/src/cloudflare/snippets/02_shared_sw_installer_cache.ts
@@ -56,7 +56,15 @@ export default {
       const baseDomain = url.hostname.split('.').slice(-2).join('.')
       const cacheKey = `https://${baseDomain}${url.pathname}`
 
-      return fetch(request, {
+      // redirect: manual matches the installer branch. With the
+      // default redirect: follow, an origin 3xx on an asset path
+      // would be followed and the target's 2xx body would land in
+      // cache under the asset cacheKey, serving wrong content.
+      // cacheTtlByStatus 300-599: 0 only drops the 3xx itself,
+      // not the followed 2xx.
+      const assetReq = new Request(request, { redirect: 'manual' })
+
+      return fetch(assetReq, {
         cf: {
           cacheEverything: true,
           cacheKey,

--- a/src/cloudflare/snippets/02_shared_sw_installer_cache.ts
+++ b/src/cloudflare/snippets/02_shared_sw_installer_cache.ts
@@ -1,22 +1,50 @@
 // Cloudflare Snippet: shared service worker installer cache
 //
-// Controls edge caching for the service worker gateway. Every subdomain
-// serves the same installer HTML and the same versioned JS/CSS.
+// What this snippet does
 //
-// /ipfs-sw-* (versioned SW assets):
-//   Cache key normalized to base domain. Identical bytes across all
-//   subdomains share one edge entry.
+// The service worker gateway serves a small HTML installer on every
+// subdomain. The installer registers a service worker that handles
+// all subsequent navigation. The page is the same for every URL on
+// every subdomain. Versioned JS/CSS assets (paths starting with
+// /ipfs-sw-) are also the same on every subdomain.
 //
-// Everything else (SPA fallback to index.html at origin):
-//   Cache key normalized per subdomain. Origin returns the same installer
-//   HTML for any non-asset path, so the long tail of arbitrary URLs
-//   collapses to one entry per hostname. Badbits enforcement uses a manual
-//   purge of the whole subdomain, so edge TTL does not gate how fast a
-//   blocked CID stops being served.
+// Two cache branches, both with a 24h TTL:
 //
-// HTML and versioned JS/CSS share the same TTL on purpose: a stale HTML
-// entry referencing fresh JS (or vice versa) could mismatch and break
-// the installer.
+//   /ipfs-sw-* (versioned assets)
+//     cache key normalized to the base domain, so all subdomains
+//     share one edge entry.
+//
+//   everything else (the installer page)
+//     cache key normalized to one entry per subdomain.
+//
+// HTML and asset TTLs match on purpose: a stale HTML referencing
+// fresh JS (or vice versa) would mismatch and break the installer.
+// Badbits is enforced by purging the whole subdomain, so a long
+// TTL does not delay takedowns.
+//
+// Why we rewrite the upstream URL for the installer branch
+//
+// The cache key collapses every non-asset URL on a subdomain into
+// one entry. That only works if origin returns the same response
+// for every URL. Origin can also return path specific responses
+// (a _redirects file, a trailing slash redirect, a content
+// negotiated codec redirect, a 404 body). Any one of those would
+// then be served back under every URL on the subdomain.
+//
+// In production we saw a transient 308 from origin get pinned for
+// 24 hours at one Cloudflare PoP and put a whole subdomain into a
+// redirect loop. To keep the cache key honest we ignore the
+// requested URL and always fetch "/" with Accept: text/html and
+// redirect: manual. The browser keeps the originally requested URL
+// in window.location, so client side SPA routing still works once
+// the installer JS runs.
+//
+// Why we cache only 2xx
+//
+// cacheEverything: true overrides the origin Cache-Control header,
+// so this snippet owns the cache decision. We only cache 200-299.
+// 3xx, 4xx and 5xx are not cached so a transient origin response
+// cannot get pinned for the full 24 hour TTL.
 
 const EDGE_CACHE_TTL_S = 86400 // 24h
 
@@ -34,25 +62,40 @@ export default {
           cacheKey,
           cacheTtlByStatus: {
             '200-299': EDGE_CACHE_TTL_S,
-            // Do not cache errors. A transient failure must not be stuck
-            // in cache for the full TTL.
             '300-599': 0
           }
         }
       })
     }
 
-    const cacheKey = `https://${url.hostname}/__sw_installer_html`
+    // The installer branch handles GET and HEAD only. Other
+    // methods (POST, OPTIONS, etc.) pass through untouched: they
+    // must not be rewritten to "/" and must not share the
+    // installer cache entry.
+    if (request.method !== 'GET' && request.method !== 'HEAD') {
+      return fetch(request)
+    }
 
-    return fetch(request, {
+    // Ignore the requested path. Always fetch the canonical
+    // installer URL ("/") with Accept: text/html and
+    // redirect: manual. This guarantees the collapsed cache key
+    // can never be populated with a path specific origin response.
+    // HEAD is rewritten the same way as GET; Cloudflare serves
+    // HEAD responses from the matching GET cache entry.
+    const installerUrl = new URL('/', url).toString()
+    const installerReq = new Request(installerUrl, {
+      method: request.method,
+      headers: { Accept: 'text/html' },
+      redirect: 'manual'
+    })
+
+    return fetch(installerReq, {
       cf: {
         cacheEverything: true,
-        cacheKey,
+        cacheKey: `https://${url.hostname}/__sw_installer_html`,
         cacheTtlByStatus: {
-          '200-399': EDGE_CACHE_TTL_S,
-          // Do not cache errors. A transient failure must not be stuck
-          // in cache for the full TTL.
-          '400-599': 0
+          '200-299': EDGE_CACHE_TTL_S,
+          '300-599': 0
         }
       }
     })

--- a/test/cloudflare/snippets/02_shared_sw_installer_cache.spec.ts
+++ b/test/cloudflare/snippets/02_shared_sw_installer_cache.spec.ts
@@ -1,43 +1,55 @@
-// Tests for 02_shared_sw_installer_cache.js Cloudflare Snippet
+// Tests for src/cloudflare/snippets/02_shared_sw_installer_cache.ts
 //
-// Run: node cloudflare/snippets/02_shared_sw_installer_cache.test.js
+// These tests verify the cache strategy used by the snippet:
 //
-// These tests verify caching behavior: cache key normalization for SW assets,
-// TTL differentiation, and Cache-Control passthrough.
+//   /ipfs-sw-* (versioned SW assets)
+//     - cache key normalized to the base domain
+//     - 2xx cached for 24h, everything else not cached
+//     - the original request is forwarded unchanged
+//
+//   installer page (everything else)
+//     - cache key normalized to one entry per subdomain
+//     - the upstream fetch is rewritten to "/" with
+//       Accept: text/html and redirect: manual so a path specific
+//       origin response cannot poison the collapsed cache entry
+//     - 2xx cached for 24h, 3xx/4xx/5xx not cached so a single bad
+//       origin response cannot pin a 24h redirect loop
+//     - non-GET methods pass through untouched
 
 import { expect } from 'aegir/chai'
 import Sinon from 'sinon'
 import handler from '../../../src/cloudflare/snippets/02_shared_sw_installer_cache.ts'
 import type { SinonSandbox } from 'sinon'
 
-// Captured cf options from the last fetch() call made by the snippet.
-let lastCfOptions = null
-// Status code the stubbed origin response will return.
+const EDGE_CACHE_TTL_S = 86400
+
+// State captured from the stubbed fetch on the last call.
+let lastRequest: Request | null = null
+let lastCfOptions: any = null
 let stubStatus = 200
-// Headers on the stubbed origin response.
-let stubHeaders = {}
+let stubHeaders: Record<string, string> = {}
 
-// Helper: call the snippet handler and return { cf, response }.
-async function callHandler (inputUrl: string): Promise<{ cf: any, response: Response }> {
+async function callHandler (inputUrl: string, init: RequestInit = {}): Promise<{ cf: any, request: Request | null, response: Response }> {
+  lastRequest = null
   lastCfOptions = null
-  const response = await handler.fetch(new Request(inputUrl))
-
-  return { cf: lastCfOptions, response }
+  const response = await handler.fetch(new Request(inputUrl, init))
+  return { cf: lastCfOptions, request: lastRequest, response }
 }
 
 describe('02_shared_sw_installer_cache', () => {
   let sandbox: SinonSandbox
 
   beforeEach(() => {
+    lastRequest = null
     lastCfOptions = null
     stubStatus = 200
     stubHeaders = {}
 
     sandbox = Sinon.createSandbox()
-    sandbox.replace(globalThis, 'fetch', (requestOrUrl, init) => {
-      lastCfOptions = init?.cf ?? null
-      const headers = new Headers(stubHeaders)
-      return Promise.resolve(new Response(null, { status: stubStatus, headers }))
+    sandbox.replace(globalThis, 'fetch', (input, init) => {
+      lastRequest = input instanceof Request ? input : new Request(input as RequestInfo, init)
+      lastCfOptions = (init as any)?.cf ?? null
+      return Promise.resolve(new Response(null, { status: stubStatus, headers: new Headers(stubHeaders) }))
     })
   })
 
@@ -45,156 +57,120 @@ describe('02_shared_sw_installer_cache', () => {
     sandbox.restore()
   })
 
-  describe('/ipfs-sw-* paths (versioned SW assets)', () => {
-    it('uses normalized cache key with base domain on .dev', async () => {
+  describe('/ipfs-sw-* (versioned SW assets)', () => {
+    it('uses cache key on base domain (.dev)', async () => {
       const { cf } = await callHandler('https://inbrowser.dev/ipfs-sw-main.js')
       expect(cf.cacheKey).to.equal('https://inbrowser.dev/ipfs-sw-main.js')
       expect(cf.cacheEverything).to.equal(true)
     })
 
-    it('uses normalized cache key with base domain on .link', async () => {
+    it('uses cache key on base domain (.link)', async () => {
       const { cf } = await callHandler('https://inbrowser.link/ipfs-sw-main.js')
       expect(cf.cacheKey).to.equal('https://inbrowser.link/ipfs-sw-main.js')
     })
 
-    it('normalizes subdomain cache key to base domain', async () => {
+    it('collapses subdomain cache key to base domain', async () => {
       const { cf } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/ipfs-sw-main.js')
       expect(cf.cacheKey).to.equal('https://inbrowser.dev/ipfs-sw-main.js')
     })
 
-    it('normalizes subdomain cache key to base domain on .link', async () => {
-      const { cf } = await callHandler('https://bafyxxx.ipfs.inbrowser.link/ipfs-sw-main.js')
-      expect(cf.cacheKey).to.equal('https://inbrowser.link/ipfs-sw-main.js')
-    })
-
-    it('uses 24h edge TTL for 200s only', async () => {
+    it('caches 2xx for 24h', async () => {
       const { cf } = await callHandler('https://inbrowser.dev/ipfs-sw-main.js')
-      expect(cf.cacheTtlByStatus['200-299']).to.equal(86400)
+      expect(cf.cacheTtlByStatus['200-299']).to.equal(EDGE_CACHE_TTL_S)
     })
 
-    it('does not cache non-200 responses at edge', async () => {
+    it('does not cache 3xx, 4xx or 5xx', async () => {
       const { cf } = await callHandler('https://inbrowser.dev/ipfs-sw-main.js')
       expect(cf.cacheTtlByStatus['300-599']).to.equal(0)
     })
 
-    it('does not override Cache-Control header', async () => {
-      stubHeaders = { 'Cache-Control': 'original-value' }
-      const { response } = await callHandler('https://inbrowser.dev/ipfs-sw-main.js')
-      expect(response.headers.get('Cache-Control'), 'original-value')
-    })
-
-    it('matches /ipfs-sw- prefix exactly', async () => {
-      // /ipfs-sw-bundle-abc123.js should match
-      const { cf } = await callHandler('https://inbrowser.dev/ipfs-sw-bundle-abc123.js')
-      expect(cf.cacheKey, 'https://inbrowser.dev/ipfs-sw-bundle-abc123.js')
-      expect(cf.cacheTtlByStatus['200-299']).to.equal(86400)
+    it('forwards the original request unchanged', async () => {
+      const { request } = await callHandler('https://inbrowser.dev/ipfs-sw-main.js')
+      expect(request).to.not.equal(null)
+      expect(request!.url).to.equal('https://inbrowser.dev/ipfs-sw-main.js')
+      expect(request!.method).to.equal('GET')
     })
   })
 
-  describe('non-SW paths (per-subdomain installer cache key, 24h TTL)', () => {
-    it('collapses /wiki/ to per-subdomain installer cache key', async () => {
-      const { cf } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/wiki/')
-      expect(cf.cacheKey).to.equal('https://bafyxxx.ipfs.inbrowser.dev/__sw_installer_html')
-      expect(cf.cacheEverything).to.equal(true)
+  describe('installer page (every non /ipfs-sw-* path)', () => {
+    it('collapses every path on a subdomain to one cache key', async () => {
+      const { cf: cfRoot } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/')
+      const { cf: cfDeep } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/wiki/Anything?q=1')
+      expect(cfRoot.cacheKey).to.equal('https://bafyxxx.ipfs.inbrowser.dev/__sw_installer_html')
+      expect(cfDeep.cacheKey).to.equal(cfRoot.cacheKey)
     })
 
-    it('collapses root / to per-subdomain installer cache key', async () => {
-      const { cf } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/')
-      expect(cf.cacheKey).to.equal('https://bafyxxx.ipfs.inbrowser.dev/__sw_installer_html')
-    })
-
-    it('shares cache key across long-tail paths on the same subdomain', async () => {
-      const { cf: cf1 } = await callHandler('https://en-wikipedia--on--ipfs-org.ipns.inbrowser.link/wiki/Charles_Krum.html')
-      const { cf: cf2 } = await callHandler('https://en-wikipedia--on--ipfs-org.ipns.inbrowser.link/wiki/Tver_Carriage_Works')
-      expect(cf1.cacheKey).to.equal(cf2.cacheKey)
-    })
-
-    it('uses different cache key for different subdomains', async () => {
+    it('uses a different cache key per subdomain', async () => {
       const { cf: cfA } = await callHandler('https://aaa.ipfs.inbrowser.dev/page')
       const { cf: cfB } = await callHandler('https://bbb.ipfs.inbrowser.dev/page')
       expect(cfA.cacheKey).to.not.equal(cfB.cacheKey)
     })
 
-    it('uses 24h edge TTL for 200-399', async () => {
+    it('caches 2xx for 24h', async () => {
       const { cf } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/page')
-      expect(cf.cacheTtlByStatus['200-399']).to.equal(86400)
+      expect(cf.cacheTtlByStatus['200-299']).to.equal(EDGE_CACHE_TTL_S)
     })
 
-    it('does not cache 400+ responses at edge', async () => {
-      const { cf } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/')
-      expect(cf.cacheTtlByStatus['400-599']).to.equal(0)
+    it('does not cache 3xx, 4xx or 5xx (no 24h redirect loop is possible)', async () => {
+      const { cf } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/page')
+      expect(cf.cacheTtlByStatus['300-599']).to.equal(0)
     })
 
-    it('does not override Cache-Control for 200 responses', async () => {
-      stubStatus = 200
-      stubHeaders = { 'Cache-Control': 'original-value' }
-      const { response } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/page')
-      expect(response.headers.get('Cache-Control')).to.equal('original-value')
+    it('rewrites the upstream URL to "/" regardless of requested path', async () => {
+      const { request } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/wiki/Anything?q=1')
+      expect(request!.url).to.equal('https://bafyxxx.ipfs.inbrowser.dev/')
     })
 
-    it('does not override Cache-Control for 404 responses', async () => {
-      stubStatus = 404
-      stubHeaders = { 'Cache-Control': 'no-cache' }
-      const { response } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/missing')
-      expect(response.headers.get('Cache-Control')).to.equal('no-cache')
+    it('rewrites the upstream URL to "/" for root requests too', async () => {
+      const { request } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/')
+      expect(request!.url).to.equal('https://bafyxxx.ipfs.inbrowser.dev/')
     })
 
-    it('uses per-subdomain cache key on .ipns. subdomain', async () => {
-      const { cf } = await callHandler('https://en-wikipedia--on--ipfs-org.ipns.inbrowser.dev/wiki/')
-      expect(cf.cacheKey).to.equal('https://en-wikipedia--on--ipfs-org.ipns.inbrowser.dev/__sw_installer_html')
-      expect(cf.cacheTtlByStatus['200-399']).to.equal(86400)
+    it('sets Accept: text/html on the upstream fetch', async () => {
+      const { request } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/page')
+      expect(request!.headers.get('Accept')).to.equal('text/html')
     })
 
-    it('does not override Cache-Control for 301 responses', async () => {
-      stubStatus = 301
-      stubHeaders = { 'Cache-Control': 'max-age=60' }
-      const { response } = await callHandler('https://inbrowser.dev/some/path')
-      expect(response.headers.get('Cache-Control')).to.equal('max-age=60')
+    it('uses redirect: manual so origin redirects are visible to the snippet', async () => {
+      const { request } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/page')
+      expect(request!.redirect).to.equal('manual')
     })
 
-    it('does not override Cache-Control for 500 responses', async () => {
-      stubStatus = 500
-      stubHeaders = { 'Cache-Control': 'no-store' }
-      const { response } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/')
-      expect(response.headers.get('Cache-Control')).to.equal('no-store')
+    it('preserves :port when rewriting to "/"', async () => {
+      const { request } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev:8443/anything')
+      expect(request!.url).to.equal('https://bafyxxx.ipfs.inbrowser.dev:8443/')
+    })
+
+    it('rewrites HEAD to HEAD "/" and shares the GET cache key', async () => {
+      const { request: gReq, cf: gCf } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/page')
+      const { request: hReq, cf: hCf } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/page', { method: 'HEAD' })
+      expect(hReq!.method).to.equal('HEAD')
+      expect(hReq!.url).to.equal('https://bafyxxx.ipfs.inbrowser.dev/')
+      expect(hReq!.headers.get('Accept')).to.equal('text/html')
+      expect(hReq!.redirect).to.equal('manual')
+      expect(hCf.cacheKey).to.equal(gCf.cacheKey)
+    })
+
+    it('passes POST through untouched (no rewrite, no snippet cache options)', async () => {
+      const { request, cf } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/anything', { method: 'POST' })
+      expect(request!.method).to.equal('POST')
+      expect(request!.url).to.equal('https://bafyxxx.ipfs.inbrowser.dev/anything')
+      expect(cf).to.equal(null)
+    })
+
+    it('passes OPTIONS through untouched (CORS preflight survives)', async () => {
+      const { request, cf } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/api', { method: 'OPTIONS' })
+      expect(request!.method).to.equal('OPTIONS')
+      expect(request!.url).to.equal('https://bafyxxx.ipfs.inbrowser.dev/api')
+      expect(cf).to.equal(null)
     })
   })
 
-  describe('cacheTtlByStatus key guards', () => {
-    it('cacheTtlByStatus keys are defined (not undefined)', async () => {
-      const { cf } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/page')
-      expect(cf.cacheTtlByStatus['200-399']).to.not.equal(undefined, 'expected 200-399 key to be defined')
-      expect(cf.cacheTtlByStatus['400-599']).to.not.equal(undefined, 'expected 400-599 key to be defined')
-    })
-
-    it('HTML and versioned SW asset TTLs match (avoid HTML-JS skew)', async () => {
+  describe('HTML and SW asset TTLs match (no HTML/JS skew)', () => {
+    it('2xx TTL is the same on both branches', async () => {
       const { cf: cfHtml } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/page')
       const { cf: cfAsset } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/ipfs-sw-main.js')
-      expect(cfHtml.cacheTtlByStatus['200-399']).to.equal(cfAsset.cacheTtlByStatus['200-299'])
-    })
-  })
-
-  describe('TLD-agnostic behavior', () => {
-    it('works the same for .dev and .link on SW asset paths', async () => {
-      const { cf: cfDev } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/ipfs-sw-main.js')
-      const { cf: cfLink } = await callHandler('https://bafyxxx.ipfs.inbrowser.link/ipfs-sw-main.js')
-      expect(cfDev.cacheTtlByStatus['200-299']).to.equal(cfLink.cacheTtlByStatus['200-299'])
-      expect(cfDev.cacheKey).to.equal('https://inbrowser.dev/ipfs-sw-main.js')
-      expect(cfLink.cacheKey).to.equal('https://inbrowser.link/ipfs-sw-main.js')
-    })
-
-    it('works the same for .dev and .link on non-SW paths', async () => {
-      const { cf: cfDev } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/page')
-      const { cf: cfLink } = await callHandler('https://bafyxxx.ipfs.inbrowser.link/page')
-      expect(cfDev.cacheTtlByStatus['200-399']).to.equal(cfLink.cacheTtlByStatus['200-399'])
-      expect(cfDev.cacheKey).to.equal('https://bafyxxx.ipfs.inbrowser.dev/__sw_installer_html')
-      expect(cfLink.cacheKey).to.equal('https://bafyxxx.ipfs.inbrowser.link/__sw_installer_html')
-    })
-
-    it('base domain requests use 24h TTL and per-host installer key', async () => {
-      const { cf } = await callHandler('https://inbrowser.dev/')
-      expect(cf.cacheTtlByStatus['200-399']).to.equal(86400)
-      expect(cf.cacheKey).to.equal('https://inbrowser.dev/__sw_installer_html')
+      expect(cfHtml.cacheTtlByStatus['200-299']).to.equal(cfAsset.cacheTtlByStatus['200-299'])
     })
   })
 })

--- a/test/cloudflare/snippets/02_shared_sw_installer_cache.spec.ts
+++ b/test/cloudflare/snippets/02_shared_sw_installer_cache.spec.ts
@@ -1,38 +1,31 @@
-// Tests for src/cloudflare/snippets/02_shared_sw_installer_cache.ts
+// Tests for 02_shared_sw_installer_cache.ts Cloudflare Snippet
 //
-// These tests verify the cache strategy used by the snippet:
-//
-//   /ipfs-sw-* (versioned SW assets)
-//     - cache key normalized to the base domain
-//     - 2xx cached for 24h, everything else not cached
-//     - the original request is forwarded unchanged
-//
-//   installer page (everything else)
-//     - cache key normalized to one entry per subdomain
-//     - the upstream fetch is rewritten to "/" with
-//       Accept: text/html and redirect: manual so a path specific
-//       origin response cannot poison the collapsed cache entry
-//     - 2xx cached for 24h, 3xx/4xx/5xx not cached so a single bad
-//       origin response cannot pin a 24h redirect loop
-//     - non-GET methods pass through untouched
+// These tests verify caching behavior: cache key normalization for SW assets,
+// TTL differentiation, Cache-Control passthrough, and the installer branch
+// upstream rewrite (path → "/", Accept: text/html, redirect: manual,
+// GET/HEAD only) that prevents path-specific origin responses from poisoning
+// the collapsed per-subdomain cache entry.
 
 import { expect } from 'aegir/chai'
 import Sinon from 'sinon'
 import handler from '../../../src/cloudflare/snippets/02_shared_sw_installer_cache.ts'
 import type { SinonSandbox } from 'sinon'
 
-const EDGE_CACHE_TTL_S = 86400
-
-// State captured from the stubbed fetch on the last call.
+// Captured cf options from the last fetch() call made by the snippet.
+let lastCfOptions = null
+// Captured Request from the last fetch() call (to assert URL/method/headers/redirect).
 let lastRequest: Request | null = null
-let lastCfOptions: any = null
+// Status code the stubbed origin response will return.
 let stubStatus = 200
-let stubHeaders: Record<string, string> = {}
+// Headers on the stubbed origin response.
+let stubHeaders = {}
 
+// Helper: call the snippet handler and return { cf, request, response }.
 async function callHandler (inputUrl: string, init: RequestInit = {}): Promise<{ cf: any, request: Request | null, response: Response }> {
-  lastRequest = null
   lastCfOptions = null
+  lastRequest = null
   const response = await handler.fetch(new Request(inputUrl, init))
+
   return { cf: lastCfOptions, request: lastRequest, response }
 }
 
@@ -40,16 +33,17 @@ describe('02_shared_sw_installer_cache', () => {
   let sandbox: SinonSandbox
 
   beforeEach(() => {
-    lastRequest = null
     lastCfOptions = null
+    lastRequest = null
     stubStatus = 200
     stubHeaders = {}
 
     sandbox = Sinon.createSandbox()
-    sandbox.replace(globalThis, 'fetch', (input, init) => {
-      lastRequest = input instanceof Request ? input : new Request(input as RequestInfo, init)
-      lastCfOptions = (init as any)?.cf ?? null
-      return Promise.resolve(new Response(null, { status: stubStatus, headers: new Headers(stubHeaders) }))
+    sandbox.replace(globalThis, 'fetch', (requestOrUrl, init) => {
+      lastRequest = requestOrUrl instanceof Request ? requestOrUrl : new Request(requestOrUrl as RequestInfo, init)
+      lastCfOptions = init?.cf ?? null
+      const headers = new Headers(stubHeaders)
+      return Promise.resolve(new Response(null, { status: stubStatus, headers }))
     })
   })
 
@@ -57,38 +51,49 @@ describe('02_shared_sw_installer_cache', () => {
     sandbox.restore()
   })
 
-  describe('/ipfs-sw-* (versioned SW assets)', () => {
-    it('uses cache key on base domain (.dev)', async () => {
+  describe('/ipfs-sw-* paths (versioned SW assets)', () => {
+    it('uses normalized cache key with base domain on .dev', async () => {
       const { cf } = await callHandler('https://inbrowser.dev/ipfs-sw-main.js')
       expect(cf.cacheKey).to.equal('https://inbrowser.dev/ipfs-sw-main.js')
       expect(cf.cacheEverything).to.equal(true)
     })
 
-    it('uses cache key on base domain (.link)', async () => {
+    it('uses normalized cache key with base domain on .link', async () => {
       const { cf } = await callHandler('https://inbrowser.link/ipfs-sw-main.js')
       expect(cf.cacheKey).to.equal('https://inbrowser.link/ipfs-sw-main.js')
     })
 
-    it('collapses subdomain cache key to base domain', async () => {
+    it('normalizes subdomain cache key to base domain', async () => {
       const { cf } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/ipfs-sw-main.js')
       expect(cf.cacheKey).to.equal('https://inbrowser.dev/ipfs-sw-main.js')
     })
 
-    it('caches 2xx for 24h', async () => {
-      const { cf } = await callHandler('https://inbrowser.dev/ipfs-sw-main.js')
-      expect(cf.cacheTtlByStatus['200-299']).to.equal(EDGE_CACHE_TTL_S)
+    it('normalizes subdomain cache key to base domain on .link', async () => {
+      const { cf } = await callHandler('https://bafyxxx.ipfs.inbrowser.link/ipfs-sw-main.js')
+      expect(cf.cacheKey).to.equal('https://inbrowser.link/ipfs-sw-main.js')
     })
 
-    it('does not cache 3xx, 4xx or 5xx', async () => {
+    it('uses 24h edge TTL for 200s only', async () => {
+      const { cf } = await callHandler('https://inbrowser.dev/ipfs-sw-main.js')
+      expect(cf.cacheTtlByStatus['200-299']).to.equal(86400)
+    })
+
+    it('does not cache non-200 responses at edge', async () => {
       const { cf } = await callHandler('https://inbrowser.dev/ipfs-sw-main.js')
       expect(cf.cacheTtlByStatus['300-599']).to.equal(0)
     })
 
-    it('forwards URL and method unchanged', async () => {
-      const { request } = await callHandler('https://inbrowser.dev/ipfs-sw-main.js')
-      expect(request).to.not.equal(null)
-      expect(request!.url).to.equal('https://inbrowser.dev/ipfs-sw-main.js')
-      expect(request!.method).to.equal('GET')
+    it('does not override Cache-Control header', async () => {
+      stubHeaders = { 'Cache-Control': 'original-value' }
+      const { response } = await callHandler('https://inbrowser.dev/ipfs-sw-main.js')
+      expect(response.headers.get('Cache-Control'), 'original-value')
+    })
+
+    it('matches /ipfs-sw- prefix exactly', async () => {
+      // /ipfs-sw-bundle-abc123.js should match
+      const { cf } = await callHandler('https://inbrowser.dev/ipfs-sw-bundle-abc123.js')
+      expect(cf.cacheKey, 'https://inbrowser.dev/ipfs-sw-bundle-abc123.js')
+      expect(cf.cacheTtlByStatus['200-299']).to.equal(86400)
     })
 
     it('uses redirect: manual so an origin 3xx cannot poison the asset cache key', async () => {
@@ -97,37 +102,80 @@ describe('02_shared_sw_installer_cache', () => {
     })
   })
 
-  describe('installer page (every non /ipfs-sw-* path)', () => {
-    it('collapses every path on a subdomain to one cache key', async () => {
-      const { cf: cfRoot } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/')
-      const { cf: cfDeep } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/wiki/Anything?q=1')
-      expect(cfRoot.cacheKey).to.equal('https://bafyxxx.ipfs.inbrowser.dev/__sw_installer_html')
-      expect(cfDeep.cacheKey).to.equal(cfRoot.cacheKey)
+  describe('non-SW paths (per-subdomain installer cache key, 24h TTL)', () => {
+    it('collapses /wiki/ to per-subdomain installer cache key', async () => {
+      const { cf } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/wiki/')
+      expect(cf.cacheKey).to.equal('https://bafyxxx.ipfs.inbrowser.dev/__sw_installer_html')
+      expect(cf.cacheEverything).to.equal(true)
     })
 
-    it('uses a different cache key per subdomain', async () => {
+    it('collapses root / to per-subdomain installer cache key', async () => {
+      const { cf } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/')
+      expect(cf.cacheKey).to.equal('https://bafyxxx.ipfs.inbrowser.dev/__sw_installer_html')
+    })
+
+    it('shares cache key across long-tail paths on the same subdomain', async () => {
+      const { cf: cf1 } = await callHandler('https://en-wikipedia--on--ipfs-org.ipns.inbrowser.link/wiki/Charles_Krum.html')
+      const { cf: cf2 } = await callHandler('https://en-wikipedia--on--ipfs-org.ipns.inbrowser.link/wiki/Tver_Carriage_Works')
+      expect(cf1.cacheKey).to.equal(cf2.cacheKey)
+    })
+
+    it('uses different cache key for different subdomains', async () => {
       const { cf: cfA } = await callHandler('https://aaa.ipfs.inbrowser.dev/page')
       const { cf: cfB } = await callHandler('https://bbb.ipfs.inbrowser.dev/page')
       expect(cfA.cacheKey).to.not.equal(cfB.cacheKey)
     })
 
-    it('caches 2xx for 24h', async () => {
+    it('uses 24h edge TTL for 2xx only', async () => {
       const { cf } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/page')
-      expect(cf.cacheTtlByStatus['200-299']).to.equal(EDGE_CACHE_TTL_S)
+      expect(cf.cacheTtlByStatus['200-299']).to.equal(86400)
     })
 
-    it('does not cache 3xx, 4xx or 5xx (no 24h redirect loop is possible)', async () => {
-      const { cf } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/page')
+    it('does not cache 3xx, 4xx or 5xx responses at edge', async () => {
+      const { cf } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/')
       expect(cf.cacheTtlByStatus['300-599']).to.equal(0)
     })
 
-    it('rewrites the upstream URL to "/" regardless of requested path', async () => {
-      const { request } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/wiki/Anything?q=1')
-      expect(request!.url).to.equal('https://bafyxxx.ipfs.inbrowser.dev/')
+    it('does not override Cache-Control for 200 responses', async () => {
+      stubStatus = 200
+      stubHeaders = { 'Cache-Control': 'original-value' }
+      const { response } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/page')
+      expect(response.headers.get('Cache-Control')).to.equal('original-value')
     })
 
-    it('rewrites the upstream URL to "/" for root requests too', async () => {
-      const { request } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/')
+    it('does not override Cache-Control for 404 responses', async () => {
+      stubStatus = 404
+      stubHeaders = { 'Cache-Control': 'no-cache' }
+      const { response } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/missing')
+      expect(response.headers.get('Cache-Control')).to.equal('no-cache')
+    })
+
+    it('uses per-subdomain cache key on .ipns. subdomain', async () => {
+      const { cf } = await callHandler('https://en-wikipedia--on--ipfs-org.ipns.inbrowser.dev/wiki/')
+      expect(cf.cacheKey).to.equal('https://en-wikipedia--on--ipfs-org.ipns.inbrowser.dev/__sw_installer_html')
+      expect(cf.cacheTtlByStatus['200-299']).to.equal(86400)
+    })
+
+    it('does not override Cache-Control for 301 responses', async () => {
+      stubStatus = 301
+      stubHeaders = { 'Cache-Control': 'max-age=60' }
+      const { response } = await callHandler('https://inbrowser.dev/some/path')
+      expect(response.headers.get('Cache-Control')).to.equal('max-age=60')
+    })
+
+    it('does not override Cache-Control for 500 responses', async () => {
+      stubStatus = 500
+      stubHeaders = { 'Cache-Control': 'no-store' }
+      const { response } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/')
+      expect(response.headers.get('Cache-Control')).to.equal('no-store')
+    })
+
+    // The next block covers the cache-poisoning fix: the upstream fetch
+    // must be rewritten so a path-specific origin response (e.g. a 308
+    // redirect) cannot be pinned under the per-subdomain cache key.
+
+    it('rewrites the upstream URL to "/" regardless of requested path', async () => {
+      const { request } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/wiki/Anything?q=1')
       expect(request!.url).to.equal('https://bafyxxx.ipfs.inbrowser.dev/')
     })
 
@@ -136,7 +184,7 @@ describe('02_shared_sw_installer_cache', () => {
       expect(request!.headers.get('Accept')).to.equal('text/html')
     })
 
-    it('uses redirect: manual so origin redirects are visible to the snippet', async () => {
+    it('uses redirect: manual so an origin 3xx cannot poison the installer cache key', async () => {
       const { request } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/page')
       expect(request!.redirect).to.equal('manual')
     })
@@ -151,8 +199,6 @@ describe('02_shared_sw_installer_cache', () => {
       const { request: hReq, cf: hCf } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/page', { method: 'HEAD' })
       expect(hReq!.method).to.equal('HEAD')
       expect(hReq!.url).to.equal('https://bafyxxx.ipfs.inbrowser.dev/')
-      expect(hReq!.headers.get('Accept')).to.equal('text/html')
-      expect(hReq!.redirect).to.equal('manual')
       expect(hCf.cacheKey).to.equal(gCf.cacheKey)
     })
 
@@ -171,11 +217,41 @@ describe('02_shared_sw_installer_cache', () => {
     })
   })
 
-  describe('HTML and SW asset TTLs match (no HTML/JS skew)', () => {
-    it('2xx TTL is the same on both branches', async () => {
+  describe('cacheTtlByStatus key guards', () => {
+    it('cacheTtlByStatus keys are defined (not undefined)', async () => {
+      const { cf } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/page')
+      expect(cf.cacheTtlByStatus['200-299']).to.not.equal(undefined, 'expected 200-299 key to be defined')
+      expect(cf.cacheTtlByStatus['300-599']).to.not.equal(undefined, 'expected 300-599 key to be defined')
+    })
+
+    it('HTML and versioned SW asset TTLs match (avoid HTML-JS skew)', async () => {
       const { cf: cfHtml } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/page')
       const { cf: cfAsset } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/ipfs-sw-main.js')
       expect(cfHtml.cacheTtlByStatus['200-299']).to.equal(cfAsset.cacheTtlByStatus['200-299'])
+    })
+  })
+
+  describe('TLD-agnostic behavior', () => {
+    it('works the same for .dev and .link on SW asset paths', async () => {
+      const { cf: cfDev } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/ipfs-sw-main.js')
+      const { cf: cfLink } = await callHandler('https://bafyxxx.ipfs.inbrowser.link/ipfs-sw-main.js')
+      expect(cfDev.cacheTtlByStatus['200-299']).to.equal(cfLink.cacheTtlByStatus['200-299'])
+      expect(cfDev.cacheKey).to.equal('https://inbrowser.dev/ipfs-sw-main.js')
+      expect(cfLink.cacheKey).to.equal('https://inbrowser.link/ipfs-sw-main.js')
+    })
+
+    it('works the same for .dev and .link on non-SW paths', async () => {
+      const { cf: cfDev } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/page')
+      const { cf: cfLink } = await callHandler('https://bafyxxx.ipfs.inbrowser.link/page')
+      expect(cfDev.cacheTtlByStatus['200-299']).to.equal(cfLink.cacheTtlByStatus['200-299'])
+      expect(cfDev.cacheKey).to.equal('https://bafyxxx.ipfs.inbrowser.dev/__sw_installer_html')
+      expect(cfLink.cacheKey).to.equal('https://bafyxxx.ipfs.inbrowser.link/__sw_installer_html')
+    })
+
+    it('base domain requests use 24h TTL and per-host installer key', async () => {
+      const { cf } = await callHandler('https://inbrowser.dev/')
+      expect(cf.cacheTtlByStatus['200-299']).to.equal(86400)
+      expect(cf.cacheKey).to.equal('https://inbrowser.dev/__sw_installer_html')
     })
   })
 })

--- a/test/cloudflare/snippets/02_shared_sw_installer_cache.spec.ts
+++ b/test/cloudflare/snippets/02_shared_sw_installer_cache.spec.ts
@@ -147,7 +147,7 @@ describe('02_shared_sw_installer_cache', () => {
     })
 
     it('rewrites HEAD to HEAD "/" and shares the GET cache key', async () => {
-      const { request: gReq, cf: gCf } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/page')
+      const { cf: gCf } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/page')
       const { request: hReq, cf: hCf } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/page', { method: 'HEAD' })
       expect(hReq!.method).to.equal('HEAD')
       expect(hReq!.url).to.equal('https://bafyxxx.ipfs.inbrowser.dev/')

--- a/test/cloudflare/snippets/02_shared_sw_installer_cache.spec.ts
+++ b/test/cloudflare/snippets/02_shared_sw_installer_cache.spec.ts
@@ -84,11 +84,16 @@ describe('02_shared_sw_installer_cache', () => {
       expect(cf.cacheTtlByStatus['300-599']).to.equal(0)
     })
 
-    it('forwards the original request unchanged', async () => {
+    it('forwards URL and method unchanged', async () => {
       const { request } = await callHandler('https://inbrowser.dev/ipfs-sw-main.js')
       expect(request).to.not.equal(null)
       expect(request!.url).to.equal('https://inbrowser.dev/ipfs-sw-main.js')
       expect(request!.method).to.equal('GET')
+    })
+
+    it('uses redirect: manual so an origin 3xx cannot poison the asset cache key', async () => {
+      const { request } = await callHandler('https://inbrowser.dev/ipfs-sw-main.js')
+      expect(request!.redirect).to.equal('manual')
     })
   })
 


### PR DESCRIPTION
> [!NOTE]
> This needs to be smoke-tested on `inbrowser.dev`, but should be safer than the current status quo 

A transient 3xx from origin gets pinned for 24h under the per-subdomain installer cache key, putting every URL on the subdomain into a redirect loop at one PoP. Seen today ([thread](https://ipshipyard.slack.com/archives/C06CY2RQ50V/p1779107069973919?thread_ts=1779095175.181589&cid=C06CY2RQ50V)) after #1061: rainbow returned `308 Location: /` for `bafy...ipfs.inbrowser.link` and the BOS PoP cached it (`cf-cache-status: HIT`, age 5640s).

Make the cache key honest:

* installer branch: GET and HEAD fetch `/` with `Accept: text/html` and `redirect: manual`, ignoring the requested path. `cacheTtlByStatus` restricted to 2xx (`200-299`).
* `/ipfs-sw-*` branch: `redirect: manual` added so a followed 3xx cannot land 2xx content under the asset cacheKey.

Zone purge on `inbrowser.link` after deploy to flush existing poisoned entries (~22h remaining on TTL otherwise).