### PR TITLE
fix: show "Check CID Availability" button on downloading page

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -255,8 +255,19 @@ function tooManyRedirects (storageKey: string, maxRedirects = 5, period = 5_000)
  */
 function showUIAfterDelay (request: ResolvableURI): void {
   setTimeout(() => {
+    let cid: string | undefined
+
+    if (request.type === 'native' && request.protocol === 'ipfs') {
+      cid = request.nativeURL.hostname
+    } else if (request.type === 'path' && request.protocol === 'ipfs') {
+      cid = request.pathURL.pathname.split('/')[2]
+    } else if (request.type === 'subdomain' && request.protocol === 'ipfs') {
+      cid = request.subdomainURL.hostname.split('.ipfs.')[0]
+    }
+
     globalThis.downloadingPage = {
-      request
+      request,
+      cid
     }
 
     renderUi()

--- a/src/ui/pages/downloading-page.tsx
+++ b/src/ui/pages/downloading-page.tsx
@@ -9,21 +9,38 @@ import type { ReactElement } from 'react'
 declare global {
   var downloadingPage: {
     request: ResolvableURI
+    cid?: string
   }
+}
+
+function checkAvailability (cid: string): void {
+  window.open(`https://check.ipfs.network/?cid=${cid}`)
 }
 
 export interface DownloadingPageProps {
   request?: ResolvableURI
+  cid?: string
 }
 
-export function DownloadingPage ({ request }: DownloadingPageProps): ReactElement {
+export function DownloadingPage ({ request, cid }: DownloadingPageProps): ReactElement {
   request = request ?? globalThis.downloadingPage?.request
+  cid = cid ?? globalThis.downloadingPage?.cid
 
   if (request == null) {
     globalThis.location.href = toGatewayRoot('/')
 
     return (
       <></>
+    )
+  }
+
+  let checkAvailabilityButton = <></>
+
+  if (cid != null) {
+    checkAvailabilityButton = (
+      <>
+        <Button className='bg-teal' onClick={() => checkAvailability(cid)}>Check CID availability</Button>
+      </>
     )
   }
 
@@ -43,7 +60,8 @@ export function DownloadingPage ({ request }: DownloadingPageProps): ReactElemen
         <>
           <p className='f5 ma3 fw4 db'>Your download should begin shortly. If it does not, please retry.</p>
           <p className='ma3'>
-            <Button className='bg-teal' onClick={retry}>Retry</Button>
+            {checkAvailabilityButton}
+            <Button className={cid == null ? 'bg-teal' : 'bg-navy-muted'} onClick={retry}>Retry</Button>
           </p>
         </>
       </ContentBox>

--- a/test-e2e/downloading.spec.ts
+++ b/test-e2e/downloading.spec.ts
@@ -1,5 +1,7 @@
 import delay from 'delay'
+import { CID } from 'multiformats/cid'
 import { test, expect } from './fixtures/config-test-fixtures.ts'
+import { publishDNSLink } from './fixtures/serve/dns-record-cache.ts'
 import type { Download } from 'playwright'
 
 test.describe('downloading page', () => {
@@ -43,5 +45,43 @@ test.describe('downloading page', () => {
 
     const text = await page.textContent('body')
     expect(text).toContain('Retry')
+  })
+
+  test('should allow checking availability', async ({ page }) => {
+    const downloadPromise = page.waitForEvent('download')
+
+    await page.fill('#inputContent', '/ipfs/bafkqaddimvwgy3zao5xxe3debi')
+    await page.click('#show-advanced')
+    await page.selectOption('#download', 'true')
+    await page.click('#load-directly')
+
+    download = await downloadPromise
+
+    await delay(2_000)
+
+    const text = await page.textContent('body')
+    expect(text).toContain('Check CID availability')
+  })
+
+  test('should not allow checking availability for IPNS', async ({ page }) => {
+    const domain = 'ipns-download-form.com'
+    const cid = CID.parse('bafkqaddimvwgy3zao5xxe3debi')
+
+    await publishDNSLink(domain, cid)
+
+    const downloadPromise = page.waitForEvent('download')
+
+    await page.fill('#inputContent', `/ipns/${domain}`)
+    await page.click('#show-advanced')
+    await page.selectOption('#download', 'true')
+    await page.click('#load-directly')
+
+    download = await downloadPromise
+
+    await delay(2_000)
+
+    const text = await page.textContent('body')
+    expect(text).toContain('Retry')
+    expect(text).not.toContain('Check CID availability')
   })
 })


### PR DESCRIPTION
To let the user self-diagnose where requests are taking a long time (e.g. provider search is slow or timing out), show the "Check CID Availability" button alongside the retry button.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
