### PR TITLE
fix: make url hash available to loaded HTML page

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -164,8 +164,15 @@ async function main (): Promise<void> {
         await registerServiceWorker()
       }
 
+      // remove service worker nav to prevent endless redirects
+      if (window.location.hash.startsWith('#/ipfs-sw')) {
+        window.location.hash = ''
+      }
+
       // reload so the subdomain request is handled by the service worker
-      window.location.href = url.toString()
+      // (including the hash)
+      window.location.reload()
+
       showUIAfterDelay(request)
       return
     }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -164,14 +164,56 @@ async function main (): Promise<void> {
         await registerServiceWorker()
       }
 
-      // remove service worker nav to prevent endless redirects
+      // Clear SW-UI hashes before navigating: otherwise the post-reload
+      // React app would match a `/ipfs-sw-…` route from the HashRouter
+      // and show a SW UI page instead of the requested CID content,
+      // causing endless redirects between the two.
       if (window.location.hash.startsWith('#/ipfs-sw')) {
+        url.hash = ''
         window.location.hash = ''
       }
 
-      // reload so the subdomain request is handled by the service worker
-      // (including the hash)
-      window.location.reload()
+      // Trigger a navigation so the just-installed service worker can
+      // intercept the subdomain request. Pick the cheapest primitive
+      // that still works in the presence of a URL fragment.
+      //
+      // Same-URL navigation behavior (HTML spec, verified in Chromium
+      // and Firefox):
+      //
+      //   Method                          No fragment   With fragment
+      //   ------------------------------- ------------- -------------
+      //   location.href = sameURL         reloads       no-op
+      //   location.replace(sameURL)       reloads       no-op
+      //   location.reload()               reloads       reloads
+      //
+      // For URLs that differ only in fragment (or match byte-for-byte
+      // with a fragment), the spec treats the navigation as a
+      // same-document fragment update, which collapses to a no-op when
+      // the URLs are byte-equal. Only `reload()` bypasses that and
+      // actually navigates. Without it the bootstrap would silently sit
+      // on URLs like `…/file.pdf#page=6` because the SW would never
+      // get a chance to intercept.
+      //
+      // Cache cost is the reason we do not unconditionally use
+      // `reload()`: per spec, `location.reload()` sends
+      // `Cache-Control: max-age=0` and forces a revalidation request
+      // even when the browser has a fresh local copy. Behind a CDN
+      // that meters requests (Cloudflare in production), every
+      // SW-bypassed reload turns into a billable edge request. The
+      // `href = url.toString()` path lets the browser serve the
+      // bootstrap HTML from its own cache when possible, costing zero
+      // edge requests.
+      //
+      // Caveat: `reload()` reloads the *current* URL, not `url`. If a
+      // future change here mutates `url` after this point, switch the
+      // fragment branch back to `location.href = url.toString()` and
+      // strip the fragment before the assignment so the navigation
+      // actually fires.
+      if (url.hash === '') {
+        window.location.href = url.toString()
+      } else {
+        window.location.reload()
+      }
 
       showUIAfterDelay(request)
       return

--- a/src/sw/index.ts
+++ b/src/sw/index.ts
@@ -93,6 +93,15 @@ self.addEventListener('activate', (event) => {
 self.addEventListener('fetch', (event) => {
   const log = getSwLogger('fetch')
   const url = new URL(event.request.url)
+  // Fragments are client-side only, but Chromium leaks the navigation
+  // hash through to `event.request.url` for `location.reload()` (and
+  // any top-level navigation targeting a fragment URL). Letting it
+  // through here pollutes cache keys, threads stale state into wrapper
+  // props (causing `URL#frag#frag` iframe srcs when the client appends
+  // `globalThis.location.hash`), and complicates `parseRequest`. The
+  // wrapper UI reads `globalThis.location.hash` directly when it needs
+  // the user fragment for embedded viewers (e.g. PDF `#page=N`).
+  url.hash = ''
   const request = parseRequest(url, new URL(self.location.href))
 
   // collect logs from Helia/libp2p during the fetch operation

--- a/src/sw/pages/render-media.ts
+++ b/src/sw/pages/render-media.ts
@@ -41,9 +41,12 @@ export function renderMediaViewerPageResponse (request: ContentURI, response: Re
     kind: info.kind,
     displayName,
     filename,
-    // Same URL the page was served from. Subresource re-fetches arrive with
-    // `request.destination` set to `image`/`video`/`audio`/`iframe`/... —
-    // never `document` — so they skip the wrapper.
+    // Same URL the page was served from. Subresource re-fetches arrive
+    // with `request.destination` set to `image`/`video`/`audio`/`iframe`/...,
+    // never `document`, so they skip the wrapper. This is hash-free
+    // because the SW's fetch handler strips `event.request.url`'s
+    // fragment at the boundary; the client appends
+    // `globalThis.location.hash` when it hands the iframe its src.
     url: request.subdomainURL.toString()
   }
 

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -113,38 +113,38 @@ function Header (): React.ReactElement {
  * the landing page, otherwise show the "Enter a CID" UI page
  */
 function getIndexRoute (): React.ReactElement {
-  if (globalThis.fetchError != null && globalThis.location.hash === '') {
+  if (globalThis.fetchError != null) {
     return (
-      <Route element={<FetchErrorPage />} index />
+      <Route element={<FetchErrorPage />} path='*' index />
     )
   }
 
-  if (globalThis.serverError != null && globalThis.location.hash === '') {
+  if (globalThis.serverError != null) {
     return (
-      <Route element={<ServerErrorPage />} index />
+      <Route element={<ServerErrorPage />} path='*' index />
     )
   }
 
-  if (globalThis.originIsolationWarning != null && globalThis.location.hash === '') {
+  if (globalThis.originIsolationWarning != null) {
     return (
-      <Route element={<OriginIsolationWarningPage />} index />
+      <Route element={<OriginIsolationWarningPage />} path='*' index />
     )
   }
 
-  if (globalThis.renderEntity != null && globalThis.location.hash === '') {
+  if (globalThis.renderEntity != null) {
     return (
-      <Route element={<RenderEntityPage />} index />
+      <Route element={<RenderEntityPage />} path='*' index />
     )
   }
 
   if (globalThis.downloadingPage != null) {
     return (
-      <Route element={<DownloadingPage />} index />
+      <Route element={<DownloadingPage />} path='*' index />
     )
   }
 
   return (
-    <Route element={<HomePage />} index />
+    <Route element={<HomePage />} path='*' index />
   )
 }
 
@@ -169,12 +169,12 @@ function App (): React.ReactElement {
       <Header />
       <ErrorBoundary>
         <Routes>
-          {getIndexRoute()}
           <Route path={`/${HASH_FRAGMENTS.IPFS_SW_LOAD_UI}`} element={<HomePage />} />,
           <Route path={`/${HASH_FRAGMENTS.IPFS_SW_ABOUT_UI}`} element={<AboutPage />} />,
           <Route path={`/${HASH_FRAGMENTS.IPFS_SW_FETCH_ERROR_UI}`} element={<FetchErrorPage />} />
           <Route path={`/${HASH_FRAGMENTS.IPFS_SW_SERVER_ERROR_UI}`} element={<ServerErrorPage />} />
           <Route path={`/${HASH_FRAGMENTS.IPFS_SW_ORIGIN_ISOLATION_WARNING}`} element={<OriginIsolationWarningPage />} />
+          {getIndexRoute()}
         </Routes>
       </ErrorBoundary>
     </HashRouter>

--- a/src/ui/pages/render-media.tsx
+++ b/src/ui/pages/render-media.tsx
@@ -106,6 +106,14 @@ export function RenderMediaPage (): ReactElement {
 }
 
 function MediaBody ({ kind, url, filename, contentType }: NonNullable<typeof globalThis.renderMedia>): ReactElement {
+  // Pass the parent's URL fragment through to the iframe verbatim so the
+  // embedded viewer honors whatever the user typed (e.g. `#page=6` for
+  // PDFs, anchors inside text content). The SW request itself never
+  // sees the fragment (the SW's fetch handler strips it before
+  // dispatching), so only the embedded viewer in the iframe acts on it.
+  // The wrapper does not inject a fragment of its own.
+  const iframeSrc = `${url}${globalThis.location.hash}`
+
   switch (kind) {
     case 'image':
       return <img src={url} alt={filename} style={mediaStyle} />
@@ -114,16 +122,14 @@ function MediaBody ({ kind, url, filename, contentType }: NonNullable<typeof glo
     case 'audio':
       return <audio src={url} controls style={{ width: '80%' }} />
     case 'pdf':
-      // `#toolbar=0` hides the embedded PDF.js toolbar in Chromium, nudging
-      // users toward our explicit Download button.
-      return <iframe src={`${url}#toolbar=0`} title={filename} style={iframeStyle} />
+      return <iframe src={iframeSrc} title={filename} style={iframeStyle} />
     case 'text':
     case 'json':
       // Reuse the browser's built-in text/JSON renderer via an iframe. The
       // subresource fetch arrives with `destination === 'iframe'`, skipping
       // the wrapper. Cheap, and avoids fetching the body in JS just to drop
       // it into a `<pre>`.
-      return <iframe src={url} title={filename} style={iframeStyle} />
+      return <iframe src={iframeSrc} title={filename} style={iframeStyle} />
     default:
       return <div className='white pa4'>Unsupported media type: {contentType}</div>
   }

--- a/test-e2e/first-hit.test.ts
+++ b/test-e2e/first-hit.test.ts
@@ -61,6 +61,33 @@ test.describe('first-hit ipfs-hosted', () => {
 
       expect(page?.url()).toBe(`${protocol}//bafkqablimvwgy3y.ipfs.${host}/?foo=bar`)
     })
+
+    test('subdomain with unknown #fragment still loads content', async ({ page, baseURL, protocol, host }) => {
+      // Regression for #1088 / `#x-ipfs-companion-no-redirect`: when a
+      // user navigates to a CID subdomain with a hash that the gateway's
+      // HashRouter does not recognize (an ipfs-companion sentinel, a
+      // hosted SPA route like `#/mail/Inbox`, a PDF `#page=N`, etc.),
+      // the bootstrap must still hand off to the SW and the user's
+      // fragment must survive the reload.
+      const cid = 'bafkqablimvwgy3y'
+      const response = await page.goto(`${protocol}//${cid}.ipfs.${host}/#x-ipfs-companion-no-redirect`, {
+        waitUntil: 'networkidle'
+      })
+
+      expect(response?.status()).toBe(200)
+
+      await mediaViewerFrame(page).getByText('hello').waitFor({
+        timeout: 25_000
+      })
+
+      // fragment must survive so extensions watching the hash still see it
+      expect(page.url()).toBe(`${protocol}//${cid}.ipfs.${host}/#x-ipfs-companion-no-redirect`)
+
+      // and the wrapper propagates it to the iframe so embedded viewers
+      // (PDF, anchors, etc.) can act on it
+      const iframeSrc = await page.locator('iframe').getAttribute('src')
+      expect(iframeSrc).toContain('x-ipfs-companion-no-redirect')
+    })
   })
 })
 

--- a/test-e2e/media-viewer.test.ts
+++ b/test-e2e/media-viewer.test.ts
@@ -95,10 +95,9 @@ test.describe('media-viewer wrapper', () => {
       expect(props?.displayName).toBe('tiny.pdf')
       expect(props?.filename).toBe('tiny.pdf')
 
-      // `#toolbar=0` hides Chromium's built-in PDF toolbar so users reach
-      // for our top-bar Download button instead.
+      // wrapper does not inject any fragment of its own
       const iframeSrc = await page.locator('iframe').getAttribute('src')
-      expect(iframeSrc).toContain('#toolbar=0')
+      expect(iframeSrc).not.toContain('#')
 
       await assertDownloadButton(page, 'tiny.pdf')
     })
@@ -198,7 +197,7 @@ test.describe('media-viewer wrapper', () => {
       expect(props?.filename).toBe(`${pdfFile}.pdf`)
 
       const iframeSrc = await page.locator('iframe').getAttribute('src')
-      expect(iframeSrc).toContain('#toolbar=0')
+      expect(iframeSrc).not.toContain('#')
 
       await assertDownloadButton(page, `${pdfFile}.pdf`)
     })
@@ -215,6 +214,69 @@ test.describe('media-viewer wrapper', () => {
 
     const href = await page.locator('a:has-text("Download")').getAttribute('href')
     expect(href).toBe(`?download=true&filename=${encodeURIComponent('readme.txt')}`)
+  })
+
+  test.describe('user URL fragment passthrough', () => {
+    test('PDF iframe receives the user fragment exactly once', async ({ page, baseURL }) => {
+      await loadWithMediaViewer(page, `${baseURL}/ipfs/${pdfDir}/tiny.pdf#page=6`)
+
+      const iframeSrc = await page.locator('iframe').getAttribute('src')
+      // Regression: Chromium leaks the navigation hash into the SW's
+      // `event.request.url`, so the SW must strip it before handing the
+      // URL to the wrapper. Otherwise the client appends the user's
+      // hash again and the iframe loads `URL#frag#frag`, which routes
+      // the iframe back through the wrapper and stacks viewers.
+      expect(iframeSrc?.split('#').length).toBe(2)
+      expect(iframeSrc).toMatch(/#page=6$/)
+    })
+
+    test('text iframe receives the user fragment exactly once', async ({ page, baseURL }) => {
+      await loadWithMediaViewer(page, `${baseURL}/ipfs/${txtDir}/readme.txt#section-1`)
+
+      const iframeSrc = await page.locator('iframe').getAttribute('src')
+      expect(iframeSrc?.split('#').length).toBe(2)
+      expect(iframeSrc).toMatch(/#section-1$/)
+    })
+
+    test('PDF iframe has no fragment when no user fragment', async ({ page, baseURL }) => {
+      await loadWithMediaViewer(page, `${baseURL}/ipfs/${pdfDir}/tiny.pdf`)
+
+      const iframeSrc = await page.locator('iframe').getAttribute('src')
+      expect(iframeSrc).not.toContain('#')
+    })
+
+    test('text iframe has no fragment when no user fragment', async ({ page, baseURL }) => {
+      await loadWithMediaViewer(page, `${baseURL}/ipfs/${txtDir}/readme.txt`)
+
+      const iframeSrc = await page.locator('iframe').getAttribute('src')
+      expect(iframeSrc).not.toContain('#')
+    })
+
+    test('SW cache keys do not include the user fragment', async ({ page, baseURL }) => {
+      // The SW boundary strips the fragment from `event.request.url`, so
+      // cache keys for `…#page=2` and `…#page=5` must collapse to the
+      // same entry as `…` with no fragment. Without the strip every
+      // distinct hash would create a duplicate cache entry for identical
+      // bytes.
+      await loadWithMediaViewer(page, `${baseURL}/ipfs/${pdfDir}/tiny.pdf#page=6`)
+
+      const cacheKeys = await page.evaluate(async () => {
+        const names = await caches.keys()
+        const all: string[] = []
+        for (const name of names) {
+          const cache = await caches.open(name)
+          const requests = await cache.keys()
+          for (const r of requests) {
+            all.push(r.url)
+          }
+        }
+        return all
+      })
+
+      for (const key of cacheKeys) {
+        expect(key, `cache key leaked a fragment: ${key}`).not.toContain('#')
+      }
+    })
   })
 
   // Raw-codec single-block CIDs (`bafkrei…`, what helia/unixfs emits by

--- a/test-e2e/website-loading.test.ts
+++ b/test-e2e/website-loading.test.ts
@@ -1,8 +1,22 @@
+import all from 'it-all'
+import { createKuboRPCClient } from 'kubo-rpc-client'
+import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { test, expect } from './fixtures/config-test-fixtures.ts'
 import { loadWithServiceWorker } from './fixtures/load-with-service-worker.ts'
 import { loadBypassingMediaViewer } from './fixtures/media-viewer.ts'
+import type { KuboRPCClient } from 'kubo-rpc-client'
 
 test.describe('website-loading', () => {
+  let kubo: KuboRPCClient
+
+  test.beforeEach(async ({ page }) => {
+    if (process.env.KUBO_GATEWAY == null || process.env.KUBO_GATEWAY === '') {
+      throw new Error('KUBO_GATEWAY not set')
+    }
+
+    kubo = createKuboRPCClient(process.env.KUBO_RPC)
+  })
+
   test('ensure unixfs directory trailing slash is added', async ({ page, baseURL }) => {
     const cid = 'bafybeifq2rzpqnqrsdupncmkmhs3ckxxjhuvdcbvydkgvch3ms24k5lo7q'
     const response = await loadWithServiceWorker(page, `${baseURL}/ipfs/${cid}`)
@@ -53,5 +67,26 @@ test.describe('website-loading', () => {
     expect(responseAfterReloading?.status()).toBe(200)
     const headersAfterReloading = await responseAfterReloading?.allHeaders()
     expect(headersAfterReloading?.['content-type']).toContain('text/html')
+  })
+
+  test('ensure URL fragments are available to the target page', async ({ page, baseURL, port }) => {
+    const [, { cid }] = await all(kubo.addAll([{
+      path: '/index.html',
+      content: uint8ArrayFromString(`<html>
+  <body data-testid="body">
+    <script type="text/javascript">
+        document.write(document.location)
+    </script>
+  </body>
+</html>`)
+    }], {
+      wrapWithDirectory: true,
+      cidVersion: 1
+    }))
+
+    const response = await loadWithServiceWorker(page, `${baseURL}/ipfs/${cid}#a-url-fragment`)
+    expect(response.status()).toBe(200)
+
+    await expect(page.getByTestId('body')).toHaveText(`http://${cid}.ipfs.localhost:${port}/#a-url-fragment`)
   })
 })


### PR DESCRIPTION
Fixes two bugs:

1. Uses `window.location.reload` when handing off to the service worker instead of assigning `window.location` - if a hash is present in the url the former works, the latter doesn't
2. Make the page index route also a wildcard so appropriate UI is shown while loading the content

Fixes #1088

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
