### PR TITLE
fix: respect cache-control response header

### DIFF
--- a/src/sw/handlers/content-request-handler.ts
+++ b/src/sw/handlers/content-request-handler.ts
@@ -7,6 +7,7 @@ import { errorToObject } from '../../lib/error-to-object.ts'
 import { getSubdomainParts } from '../../lib/get-subdomain-parts.ts'
 import { getSwLogger } from '../../lib/logger.ts'
 import { isBitswapProvider, isFallbackTrustlessGatewayProvider, isTrustlessGatewayProvider } from '../../lib/providers.ts'
+import { canUseStaleResponseOnError, needsRevalidateAfterUse, needsRevalidateBeforeUse } from '../lib/cache-control.ts'
 import { getInstallTime } from '../lib/install-time.ts'
 import { sniffRawContentType } from '../lib/sniff-raw-content-type.ts'
 import { getVerifiedFetch } from '../lib/verified-fetch.ts'
@@ -40,7 +41,6 @@ interface FetchHandlerArg {
   accept: string | null
 }
 
-const ONE_HOUR_IN_SECONDS = 3600
 const MAX_REDIRECTS = 5
 
 function getCacheKey (resource: ContentURI, headers: Headers, renderHtml: boolean, destination: RequestDestination): string {
@@ -56,16 +56,40 @@ async function getResponseFromCacheOrFetch (args: FetchHandlerArg): Promise<Resp
   log.trace('cache key: %s', args.cacheKey)
   const cache = await caches.open(args.isMutable ? CURRENT_CACHES.mutable : CURRENT_CACHES.immutable)
   const cachedResponse = await cache.match(args.cacheKey)
-  const validCacheHit = cachedResponse != null && !hasExpired(cachedResponse)
 
-  if (validCacheHit) {
-    log('cached response HIT for %s (expires: %s) %o', args.cacheKey, cachedResponse.headers.get('sw-cache-expires'), cachedResponse)
+  if (cachedResponse == null) {
+    log('cached response MISS for %s', args.cacheKey)
+    return fetchAndUpdateCache(args)
+  }
+
+  if (needsRevalidateBeforeUse(cachedResponse)) {
+    log('cached response HIT for %s but needs revalidation before use', args.cacheKey)
+
+    const response = await fetchAndUpdateCache(args)
+
+    if (canUseStaleResponseOnError(response, cachedResponse)) {
+      log('%d error revalidating response but can re-use cached response HIT for %s', response.status, args.cacheKey)
+      return cachedResponse
+    }
+
+    return response
+  }
+
+  if (needsRevalidateAfterUse(cachedResponse)) {
+    log('cached response HIT for %s but needs background revalidation', args.cacheKey)
+
+    args.event.waitUntil(
+      fetchAndUpdateCache(args)
+        .catch(err => {
+          log.error('background revalidate for %s failed - %e', args.cacheKey, err)
+        })
+    )
+
     return cachedResponse
   }
 
-  log('cached response MISS for %s', args.cacheKey)
-
-  return fetchAndUpdateCache(args)
+  log('cached response HIT for %s (expires: %s) %o', args.cacheKey, cachedResponse.headers.get('sw-cache-expires'), cachedResponse)
+  return cachedResponse
 }
 
 async function fetchAndUpdateCache (args: FetchHandlerArg): Promise<Response> {
@@ -84,22 +108,6 @@ async function fetchAndUpdateCache (args: FetchHandlerArg): Promise<Response> {
   }
 
   return response
-}
-
-/**
- * Checks whether our custom expires header shows that this response has expired
- */
-function hasExpired (response: Response): boolean {
-  const expiresHeader = response.headers.get('sw-cache-expires')
-
-  if (expiresHeader == null) {
-    return false
-  }
-
-  const expires = new Date(expiresHeader)
-  const now = new Date()
-
-  return expires < now
 }
 
 function shouldCacheResponse (response: Response, args: FetchHandlerArg): boolean {
@@ -127,6 +135,11 @@ function shouldCacheResponse (response: Response, args: FetchHandlerArg): boolea
     return false
   }
 
+  // no-store directive prevents any kind of caching
+  if (response.headers.get('cache-control')?.includes('no-store')) {
+    return false
+  }
+
   return true
 }
 
@@ -137,13 +150,10 @@ async function storeResponseInCache (response: Response, args: FetchHandlerArg):
     return
   }
 
-  if (args.isMutable) {
-    log.trace('setting expires header on response key %s before storing in cache', args.cacheKey)
-    // 👇 Set expires header to an hour from now for mutable (ipns://) resources
-    // Note that this technically breaks HTTP semantics, whereby the
-    // cache-control max-age takes precedence Setting this header is only used
-    // by the service worker using a mechanism similar to stale-while-revalidate
-    setExpiresHeader(response, ONE_HOUR_IN_SECONDS)
+  // ensure we can invalidate the cache later
+  if (response.headers.get('date') == null) {
+    log.trace('setting date header on response key %s before storing in cache', args.cacheKey)
+    response.headers.set('date', new Date().toUTCString())
   }
 
   log.trace('updating cache for %s in the background', args.cacheKey)
@@ -162,11 +172,11 @@ async function storeResponseInCache (response: Response, args: FetchHandlerArg):
     args.event.waitUntil(
       cache.put(args.cacheKey, respToCache)
         .catch((err) => {
-          log.error('error storing response in cache - %e', err)
+          log.error('error storing response for %s in cache - %e', args.cacheKey, err)
         })
     )
   } catch (err) {
-    log.error('error storing response in cache - %e', err)
+    log.error('error storing response for %s in cache - %e', args.cacheKey, err)
   }
 }
 
@@ -436,16 +446,6 @@ async function fetchHandler ({ request, headers, renderHtml, event, logs, accept
     signal.clear()
     clearTimeout(timeout)
   }
-}
-
-/**
- * Set a custom expires header on a response object to a timestamp based on the
- * passed ttl interval. Defaults to one hour.
- */
-function setExpiresHeader (response: Response, ttlSeconds: number = ONE_HOUR_IN_SECONDS): void {
-  const expirationTime = new Date(Date.now() + ttlSeconds * 1000)
-
-  response.headers.set('sw-cache-expires', expirationTime.toUTCString())
 }
 
 function shouldRenderDirectory (url: URL, accept?: string | null): boolean {

--- a/src/sw/handlers/content-request-handler.ts
+++ b/src/sw/handlers/content-request-handler.ts
@@ -8,6 +8,7 @@ import { getSubdomainParts } from '../../lib/get-subdomain-parts.ts'
 import { getSwLogger } from '../../lib/logger.ts'
 import { isBitswapProvider, isFallbackTrustlessGatewayProvider, isTrustlessGatewayProvider } from '../../lib/providers.ts'
 import { canUseStaleResponseOnError, needsRevalidateAfterUse, needsRevalidateBeforeUse } from '../lib/cache-control.ts'
+import { parseHeaderDirectives } from '../lib/header-directives.ts'
 import { getInstallTime } from '../lib/install-time.ts'
 import { sniffRawContentType } from '../lib/sniff-raw-content-type.ts'
 import { getVerifiedFetch } from '../lib/verified-fetch.ts'
@@ -136,7 +137,7 @@ function shouldCacheResponse (response: Response, args: FetchHandlerArg): boolea
   }
 
   // no-store directive prevents any kind of caching
-  if (response.headers.get('cache-control')?.includes('no-store')) {
+  if (parseHeaderDirectives(response.headers.get('cache-control'))['no-store'] === true) {
     return false
   }
 

--- a/src/sw/handlers/content-request-handler.ts
+++ b/src/sw/handlers/content-request-handler.ts
@@ -88,7 +88,7 @@ async function getResponseFromCacheOrFetch (args: FetchHandlerArg): Promise<Resp
     return cachedResponse
   }
 
-  log('cached response HIT for %s (expires: %s) %o', args.cacheKey, cachedResponse.headers.get('sw-cache-expires'), cachedResponse)
+  log('cached response HIT for %s %o', args.cacheKey, cachedResponse)
   return cachedResponse
 }
 

--- a/src/sw/lib/cache-control.ts
+++ b/src/sw/lib/cache-control.ts
@@ -25,12 +25,6 @@ function findTtl (response: Response): number {
  * header, if it is present
  */
 function getResponseMaxAge (response: Response): number | undefined {
-  let age = parseInt(`${response.headers.get('age')}`, 10)
-
-  if (isNaN(age)) {
-    age = 0
-  }
-
   const header = response.headers.get('cache-control')
 
   // ignore if no cache control header is present
@@ -49,13 +43,9 @@ function getResponseMaxAge (response: Response): number | undefined {
     return 0
   }
 
-  const ttl = maxAge - age
-
-  if (ttl < 0) {
-    return 0
-  }
-
-  return ttl
+  // max-age is the freshness lifetime; the Age header is accounted for in
+  // findAge, so do not subtract it here as well
+  return maxAge
 }
 
 /**

--- a/src/sw/lib/cache-control.ts
+++ b/src/sw/lib/cache-control.ts
@@ -83,6 +83,32 @@ function getResponseExpiry (response: Response): number | undefined {
 }
 
 /**
+ * Signed responses such as IPNS records carry an `Expires` header set to the
+ * record's EOL. Past that point the record is cryptographically invalid, so this
+ * gateway must never serve it, even under `stale-while-revalidate` or
+ * `stale-if-error`. This is stricter than RFC 9111 freshness: a reverse proxy
+ * may serve a stale-but-still-valid copy, but we validate records, so an expired
+ * one fails. The EOL is an absolute wall-clock deadline, so it is compared
+ * against the current time rather than the response age.
+ */
+function isExpired (response: Response): boolean {
+  const expires = response.headers.get('expires')
+
+  if (expires == null) {
+    return false
+  }
+
+  const expiry = new Date(expires).getTime()
+
+  // an unparseable Expires header carries no usable deadline
+  if (isNaN(expiry)) {
+    return false
+  }
+
+  return Date.now() > expiry
+}
+
+/**
  * Returns true if the previously cached response cannot be used to respond to
  * a request
  */
@@ -114,6 +140,11 @@ function isFresh (response: Response, cacheControl: HeaderDirectives): boolean {
     return false
   }
 
+  // a record past its EOL is invalid regardless of max-age
+  if (isExpired(response)) {
+    return false
+  }
+
   // must-revalidate only forces revalidation once a response is stale, so it
   // does not affect freshness here; canUseStale enforces it for stale responses
   const age = findAge(response)
@@ -123,6 +154,11 @@ function isFresh (response: Response, cacheControl: HeaderDirectives): boolean {
 }
 
 function canUseStaleWhileRevalidate (response: Response, cacheControl: HeaderDirectives): boolean {
+  // never serve a record past its EOL, even while revalidating
+  if (isExpired(response)) {
+    return false
+  }
+
   const staleWhileRevalidate = parseInt(cacheControl['stale-while-revalidate']?.toString(), 10)
 
   // ignore invalid stale-while-revalidate values
@@ -177,6 +213,11 @@ export function needsRevalidateAfterUse (response: Response): boolean {
  */
 export function canUseStaleResponseOnError (errorResponse: Response, cachedResponse: Response): boolean {
   if (![500, 502, 503, 504].includes(errorResponse.status)) {
+    return false
+  }
+
+  // never fall back to a record past its EOL, even when the origin errors
+  if (isExpired(cachedResponse)) {
     return false
   }
 

--- a/src/sw/lib/cache-control.ts
+++ b/src/sw/lib/cache-control.ts
@@ -84,12 +84,15 @@ function getResponseExpiry (response: Response): number | undefined {
 
 /**
  * Signed responses such as IPNS records carry an `Expires` header set to the
- * record's EOL. Past that point the record is cryptographically invalid, so this
- * gateway must never serve it, even under `stale-while-revalidate` or
- * `stale-if-error`. This is stricter than RFC 9111 freshness: a reverse proxy
- * may serve a stale-but-still-valid copy, but we validate records, so an expired
- * one fails. The EOL is an absolute wall-clock deadline, so it is compared
- * against the current time rather than the response age.
+ * record's EOL. Past that point the record is cryptographically invalid, so
+ * this gateway must never serve it, even under `stale-while-revalidate` or
+ * `stale-if-error`.
+ *
+ * This is stricter than RFC 9111 freshness: a reverse proxy may serve a
+ * stale-but-still-valid copy, but we validate records, so an expired one fails.
+ *
+ * The EOL is an absolute wall-clock deadline, so it is compared against the
+ * current time rather than the response age.
  */
 function isExpired (response: Response): boolean {
   const expires = response.headers.get('expires')
@@ -140,7 +143,8 @@ function isFresh (response: Response, cacheControl: HeaderDirectives): boolean {
     return false
   }
 
-  // a record past its EOL is invalid regardless of max-age
+  // a record past its EOL is invalid regardless of max-age - nb. this is
+  // different to RFC 9111 freshness
   if (isExpired(response)) {
     return false
   }
@@ -154,7 +158,8 @@ function isFresh (response: Response, cacheControl: HeaderDirectives): boolean {
 }
 
 function canUseStaleWhileRevalidate (response: Response, cacheControl: HeaderDirectives): boolean {
-  // never serve a record past its EOL, even while revalidating
+  // never serve a record past its EOL, even while revalidating - nb. this is
+  // different to RFC 9111 freshness
   if (isExpired(response)) {
     return false
   }
@@ -216,7 +221,8 @@ export function canUseStaleResponseOnError (errorResponse: Response, cachedRespo
     return false
   }
 
-  // never fall back to a record past its EOL, even when the origin errors
+  // never fall back to a record past its EOL, even when the origin errors - nb.
+  // this is different to RFC 9111 freshness
   if (isExpired(cachedResponse)) {
     return false
   }
@@ -249,10 +255,10 @@ function findAge (response: Response): number {
     return 0
   }
 
-  const received = Math.round(new Date(dateHeader).getTime() / 1000)
+  const sent = Math.round(new Date(dateHeader).getTime() / 1000)
   const now = Math.round(Date.now() / 1000)
 
-  // the age header is how old the response was in seconds when we received it
+  // the age header is how old the response was in seconds when it was sent
   if (ageHeader != null) {
     const age = parseInt(ageHeader, 10)
 
@@ -261,9 +267,12 @@ function findAge (response: Response): number {
       return 0
     }
 
-    return (now - received) + age
+    // return the difference between now and the time the response was sent plus
+    // the age, or 0 if the result is negative
+    return Math.max(0, (now - sent) + age)
   }
 
-  // return the difference between now and the time we received the response
-  return now - received
+  // return the difference between now and the time the response was sent, or 0
+  // if the result is negative
+  return Math.max(0, now - sent)
 }

--- a/src/sw/lib/cache-control.ts
+++ b/src/sw/lib/cache-control.ts
@@ -114,10 +114,8 @@ function isFresh (response: Response, cacheControl: HeaderDirectives): boolean {
     return false
   }
 
-  if (cacheControl['must-revalidate'] === true) {
-    return false
-  }
-
+  // must-revalidate only forces revalidation once a response is stale, so it
+  // does not affect freshness here; canUseStale enforces it for stale responses
   const age = findAge(response)
   const ttl = findTtl(response)
 

--- a/src/sw/lib/cache-control.ts
+++ b/src/sw/lib/cache-control.ts
@@ -33,19 +33,27 @@ function getResponseMaxAge (response: Response): number | undefined {
   }
 
   const cacheControl = parseHeaderDirectives(header)
-  const maxAge = parseInt(cacheControl['max-age'].toString(), 10)
+  const maxAge = cacheControl['max-age']
+
+  // a cache-control header can be present without a max-age directive
+  // (e.g. `public`), in which case there is no max-age TTL to read here
+  if (maxAge == null) {
+    return
+  }
+
+  const seconds = parseInt(maxAge.toString(), 10)
 
   // Caches are encouraged to consider responses that have invalid freshness
   // information (e.g., a max-age directive with non-integer content) to be
   // stale.
   // https://httpwg.org/specs/rfc9111.html#calculating.freshness.lifetime
-  if (isNaN(maxAge) || maxAge.toString() !== cacheControl['max-age']) {
+  if (isNaN(seconds) || seconds.toString() !== maxAge.toString()) {
     return 0
   }
 
   // max-age is the freshness lifetime; the Age header is accounted for in
   // findAge, so do not subtract it here as well
-  return maxAge
+  return seconds
 }
 
 /**

--- a/src/sw/lib/cache-control.ts
+++ b/src/sw/lib/cache-control.ts
@@ -1,0 +1,230 @@
+import { parseHeaderDirectives } from './header-directives.ts'
+import type { HeaderDirectives } from './header-directives.ts'
+
+const ONE_HOUR_IN_SECONDS = 3_600
+
+/**
+ * Calculate how many seconds a response is valid for based on RFC 9111
+ *
+ * @see https://httpwg.org/specs/rfc9111.html#calculating.freshness.lifetime
+ */
+function findTtl (response: Response): number {
+  const dateHeader = response.headers.get('date')
+
+  // if we do not know when we received the response, we cannot calculate how
+  // long it has to live
+  if (dateHeader == null) {
+    return ONE_HOUR_IN_SECONDS
+  }
+
+  return getResponseMaxAge(response) ?? getResponseExpiry(response) ?? ONE_HOUR_IN_SECONDS
+}
+
+/**
+ * Try to read how long the response should be cached from the cache-control
+ * header, if it is present
+ */
+function getResponseMaxAge (response: Response): number | undefined {
+  let age = parseInt(`${response.headers.get('age')}`, 10)
+
+  if (isNaN(age)) {
+    age = 0
+  }
+
+  const header = response.headers.get('cache-control')
+
+  // ignore if no cache control header is present
+  if (header == null) {
+    return
+  }
+
+  const cacheControl = parseHeaderDirectives(header)
+  const maxAge = parseInt(cacheControl['max-age'].toString(), 10)
+
+  // Caches are encouraged to consider responses that have invalid freshness
+  // information (e.g., a max-age directive with non-integer content) to be
+  // stale.
+  // https://httpwg.org/specs/rfc9111.html#calculating.freshness.lifetime
+  if (isNaN(maxAge) || maxAge.toString() !== cacheControl['max-age']) {
+    return 0
+  }
+
+  const ttl = maxAge - age
+
+  if (ttl < 0) {
+    return 0
+  }
+
+  return ttl
+}
+
+/**
+ * Calculate the TTL for a response based on the Expiry header (if present)
+ * minus the current Date.
+ *
+ * Prefer the Date header from the response if present to reduce clock skew.
+ */
+function getResponseExpiry (response: Response): number | undefined {
+  const expires = response.headers.get('expires')
+  const date = new Date(response.headers.get('date') ?? Date.now())
+
+  if (expires == null) {
+    return
+  }
+
+  const ttl = parseInt(`${new Date(expires).getTime() - date.getTime()}`, 10)
+
+  // invalid or non-integer values are treated as 0
+  if (isNaN(ttl) || ttl < 0) {
+    return
+  }
+
+  return ttl
+}
+
+/**
+ * Returns true if the previously cached response cannot be used to respond to
+ * a request
+ */
+export function needsRevalidateBeforeUse (response: Response): boolean {
+  const cacheControl = parseHeaderDirectives(response.headers.get('cache-control'))
+
+  // no-cache means 'always revalidate', 'no-store' means do not cache
+  if (cacheControl['no-cache'] === true || cacheControl['no-store'] === true) {
+    return true
+  }
+
+  // the response is cached and within the TTL so no need to revalidate
+  if (isFresh(response, cacheControl)) {
+    return false
+  }
+
+  // not fresh & cannot use stale response - we must revalidate
+  return !canUseStale(response, cacheControl)
+}
+
+/**
+ * In HTTP caching terms, a fresh response is one that can usually be reused for
+ * subsequent requests, depending on request directives, otherwise it is stale
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Caching#fresh_and_stale_based_on_age
+ */
+function isFresh (response: Response, cacheControl: HeaderDirectives): boolean {
+  if (cacheControl['no-cache'] === true || cacheControl['no-store'] === true) {
+    return false
+  }
+
+  if (cacheControl['must-revalidate'] === true) {
+    return false
+  }
+
+  const age = findAge(response)
+  const ttl = findTtl(response)
+
+  return age < ttl
+}
+
+function canUseStaleWhileRevalidate (response: Response, cacheControl: HeaderDirectives): boolean {
+  const staleWhileRevalidate = parseInt(cacheControl['stale-while-revalidate']?.toString(), 10)
+
+  // ignore invalid stale-while-revalidate values
+  if (isNaN(staleWhileRevalidate) || staleWhileRevalidate < 0 || Math.round(staleWhileRevalidate).toString() !== cacheControl['stale-while-revalidate']) {
+    return false
+  }
+
+  const age = findAge(response)
+  const ttl = findTtl(response)
+
+  // `stale-while-revalidate` value extends the normal TTL for the response
+  return age < (ttl + staleWhileRevalidate)
+}
+
+/**
+ * Return true if the stale response can be used, otherwise return false
+ */
+function canUseStale (response: Response, cacheControl: HeaderDirectives): boolean {
+  // must-revalidate means revalidate when stale
+  if (cacheControl['must-revalidate'] === true) {
+    return false
+  }
+
+  // the immutable response directive indicates that the response will not be
+  // updated while it's fresh so we must revalidate once stale
+  if (cacheControl['immutable']) {
+    return false
+  }
+
+  // `stale-while-revalidate` directive extends the normal TTL for the response
+  return canUseStaleWhileRevalidate(response, cacheControl)
+}
+
+export function needsRevalidateAfterUse (response: Response): boolean {
+  const cacheControl = parseHeaderDirectives(response.headers.get('cache-control'))
+  const fresh = isFresh(response, cacheControl)
+
+  // not stale, no need to revalidate
+  if (fresh) {
+    return false
+  }
+
+  // `stale-while-revalidate` value extends the normal TTL for the response
+  return canUseStaleWhileRevalidate(response, cacheControl)
+}
+
+/**
+ * For certain error response codes, it can be possible to re-use a previously
+ * cached stale response
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cache-Control#stale-if-error
+ */
+export function canUseStaleResponseOnError (errorResponse: Response, cachedResponse: Response): boolean {
+  if (![500, 502, 503, 504].includes(errorResponse.status)) {
+    return false
+  }
+
+  const cacheControl = parseHeaderDirectives(cachedResponse.headers.get('cache-control'))
+  const staleIfError = parseInt(cacheControl['stale-if-error']?.toString(), 10)
+
+  // ignore invalid stale-if-error values
+  if (isNaN(staleIfError) || staleIfError < 0 || Math.round(staleIfError).toString() !== cacheControl['stale-if-error']) {
+    return false
+  }
+
+  const age = findAge(cachedResponse)
+  const ttl = findTtl(cachedResponse)
+
+  // `stale-if-error` value extends the normal TTL for the response
+  return age < (ttl + staleIfError)
+}
+
+/**
+ * Find the age in seconds of a previously cached response
+ */
+function findAge (response: Response): number {
+  const ageHeader = response.headers.get('age')
+  const dateHeader = response.headers.get('date')
+
+  // if no date header is present, we don't know when we received the response
+  // so cannot calculate the age
+  if (dateHeader == null) {
+    return 0
+  }
+
+  const received = Math.round(new Date(dateHeader).getTime() / 1000)
+  const now = Math.round(Date.now() / 1000)
+
+  // the age header is how old the response was in seconds when we received it
+  if (ageHeader != null) {
+    const age = parseInt(ageHeader, 10)
+
+    // cannot parse invalid age
+    if (isNaN(age) || age < 0) {
+      return 0
+    }
+
+    return (now - received) + age
+  }
+
+  // return the difference between now and the time we received the response
+  return now - received
+}

--- a/src/sw/lib/cache-control.ts
+++ b/src/sw/lib/cache-control.ts
@@ -72,9 +72,11 @@ function getResponseExpiry (response: Response): number | undefined {
     return
   }
 
-  const ttl = parseInt(`${new Date(expires).getTime() - date.getTime()}`, 10)
+  // Date.getTime() is in milliseconds, but every TTL in this module is in
+  // seconds, so convert before returning
+  const ttl = Math.round((new Date(expires).getTime() - date.getTime()) / 1000)
 
-  // invalid or non-integer values are treated as 0
+  // invalid or negative values mean the response has no usable expiry
   if (isNaN(ttl) || ttl < 0) {
     return
   }

--- a/src/sw/lib/header-directives.ts
+++ b/src/sw/lib/header-directives.ts
@@ -1,0 +1,19 @@
+export type HeaderDirectives = Record<string, string | boolean>
+
+export function parseHeaderDirectives (header?: string | null): HeaderDirectives {
+  const directives: HeaderDirectives = {}
+
+  header?.split(',').forEach(val => {
+    val = val.trim()
+
+    if (val.includes('=')) {
+      const [key, value] = val.split('=').map(v => v.trim())
+      directives[key] = value
+      return
+    }
+
+    directives[val] = true
+  })
+
+  return directives
+}

--- a/src/sw/lib/header-directives.ts
+++ b/src/sw/lib/header-directives.ts
@@ -6,13 +6,15 @@ export function parseHeaderDirectives (header?: string | null): HeaderDirectives
   header?.split(',').forEach(val => {
     val = val.trim()
 
+    // directive names are case-insensitive (RFC 9110), so normalise the key;
+    // values may be case-sensitive so leave them as-is
     if (val.includes('=')) {
       const [key, value] = val.split('=').map(v => v.trim())
-      directives[key] = value
+      directives[key.toLowerCase()] = value
       return
     }
 
-    directives[val] = true
+    directives[val.toLowerCase()] = true
   })
 
   return directives

--- a/test/sw/lib/cache-control.spec.ts
+++ b/test/sw/lib/cache-control.spec.ts
@@ -259,6 +259,38 @@ describe('cache-control', () => {
 
       expect(needsRevalidateBeforeUse(res)).to.be.false()
     })
+
+    it('should revalidate before use when Expires has passed even if max-age is fresh', () => {
+      const res = new Response('', {
+        headers: {
+          date: new Date().toUTCString(),
+          // max-age says fresh for 5 minutes...
+          'cache-control': 'public, max-age=300',
+          // ...but the record's EOL has already passed
+          expires: new Date(Date.now() - 10_000).toUTCString()
+        }
+      })
+
+      expect(needsRevalidateBeforeUse(res)).to.be.true()
+    })
+
+    it('should not serve stale-while-revalidate past Expires', () => {
+      const res = new Response('', {
+        headers: {
+          // received 20s ago
+          date: new Date(Date.now() - 20_000).toUTCString(),
+          // stale by max-age but well within the SWR window by age...
+          'cache-control': 'public, max-age=10, stale-while-revalidate=3600',
+          // ...yet the record's EOL has passed
+          expires: new Date(Date.now() - 10_000).toUTCString()
+        }
+      })
+
+      // cannot serve the expired record, must revalidate first
+      expect(needsRevalidateBeforeUse(res)).to.be.true()
+      // and must not be handed out while revalidating in the background
+      expect(needsRevalidateAfterUse(res)).to.be.false()
+    })
   })
 
   describe('can-use-stale-on-response-error', () => {
@@ -355,6 +387,23 @@ describe('cache-control', () => {
         headers: {
           date: new Date(Date.now() - 20_000).toUTCString(),
           'cache-control': 'public, max-age=10, stale-if-error=-10'
+        }
+      })
+
+      expect(canUseStaleResponseOnError(res, cached)).to.be.false()
+    })
+
+    it('should not re-use stale response on error past Expires', () => {
+      const res = new Response('', {
+        status: 500
+      })
+      const cached = new Response('', {
+        headers: {
+          date: new Date(Date.now() - 20_000).toUTCString(),
+          // within the stale-if-error window by age...
+          'cache-control': 'public, max-age=10, stale-if-error=3600',
+          // ...but the record's EOL has passed
+          expires: new Date(Date.now() - 10_000).toUTCString()
         }
       })
 

--- a/test/sw/lib/cache-control.spec.ts
+++ b/test/sw/lib/cache-control.spec.ts
@@ -198,6 +198,32 @@ describe('cache-control', () => {
     })
   })
 
+  describe('expires-header', () => {
+    it('should treat a response past its Expires as stale', () => {
+      const res = new Response('', {
+        headers: {
+          date: new Date(Date.now() - 20_000).toUTCString(),
+          // expired 10s ago
+          expires: new Date(Date.now() - 10_000).toUTCString()
+        }
+      })
+
+      expect(needsRevalidateBeforeUse(res)).to.be.true()
+    })
+
+    it('should treat a response within its Expires as fresh', () => {
+      const res = new Response('', {
+        headers: {
+          date: new Date().toUTCString(),
+          // expires in 10 minutes
+          expires: new Date(Date.now() + 600_000).toUTCString()
+        }
+      })
+
+      expect(needsRevalidateBeforeUse(res)).to.be.false()
+    })
+  })
+
   describe('can-use-stale-on-response-error', () => {
     it('should re-use stale response if within stale-if-error ttl', () => {
       const res = new Response('', {

--- a/test/sw/lib/cache-control.spec.ts
+++ b/test/sw/lib/cache-control.spec.ts
@@ -70,6 +70,19 @@ describe('cache-control', () => {
       expect(needsRevalidateBeforeUse(res)).to.be.true()
     })
 
+    it('should not revalidate response within max-age that carries a large Age header', () => {
+      const res = new Response('', {
+        headers: {
+          date: new Date(Date.now() - 5_000).toUTCString(),
+          age: '60',
+          // current age is Age + (now - date) = 60 + 5 = 65s, below max-age
+          'cache-control': 'public, max-age=100'
+        }
+      })
+
+      expect(needsRevalidateBeforeUse(res)).to.be.false()
+    })
+
     it('should not revalidate response outside ttl but inside stale-while-revalidate', () => {
       const res = new Response('', {
         headers: {

--- a/test/sw/lib/cache-control.spec.ts
+++ b/test/sw/lib/cache-control.spec.ts
@@ -47,6 +47,19 @@ describe('cache-control', () => {
       expect(needsRevalidateBeforeUse(res)).to.be.true()
     })
 
+    it('should not throw when cache-control has no max-age directive', () => {
+      const res = new Response('', {
+        headers: {
+          date: new Date().toUTCString(),
+          'cache-control': 'public'
+        }
+      })
+
+      // falls back to the default TTL rather than throwing on a missing max-age
+      expect(() => needsRevalidateBeforeUse(res)).to.not.throw()
+      expect(needsRevalidateBeforeUse(res)).to.be.false()
+    })
+
     it('should revalidate immutable response outside ttl', () => {
       const res = new Response('', {
         headers: {

--- a/test/sw/lib/cache-control.spec.ts
+++ b/test/sw/lib/cache-control.spec.ts
@@ -36,7 +36,18 @@ describe('cache-control', () => {
       expect(needsRevalidateBeforeUse(res)).to.be.true()
     })
 
-    it('should revalidate responses that must be revalidated', () => {
+    it('should revalidate stale response that must be revalidated', () => {
+      const res = new Response('', {
+        headers: {
+          date: new Date(Date.now() - 20_000).toUTCString(),
+          'cache-control': 'public, max-age=10, must-revalidate'
+        }
+      })
+
+      expect(needsRevalidateBeforeUse(res)).to.be.true()
+    })
+
+    it('should not revalidate fresh response that must be revalidated', () => {
       const res = new Response('', {
         headers: {
           date: new Date(Date.now()).toUTCString(),
@@ -44,7 +55,7 @@ describe('cache-control', () => {
         }
       })
 
-      expect(needsRevalidateBeforeUse(res)).to.be.true()
+      expect(needsRevalidateBeforeUse(res)).to.be.false()
     })
 
     it('should not throw when cache-control has no max-age directive', () => {

--- a/test/sw/lib/cache-control.spec.ts
+++ b/test/sw/lib/cache-control.spec.ts
@@ -1,0 +1,301 @@
+import { expect } from 'aegir/chai'
+import { canUseStaleResponseOnError, needsRevalidateAfterUse, needsRevalidateBeforeUse } from '../../../src/sw/lib/cache-control.ts'
+
+describe('cache-control', () => {
+  describe('needs-revalidate-before-use', () => {
+    it('should not revalidate immutable response within ttl', () => {
+      const res = new Response('', {
+        headers: {
+          date: new Date().toUTCString(),
+          'cache-control': 'public, max-age=29030400, immutable'
+        }
+      })
+
+      expect(needsRevalidateBeforeUse(res)).to.be.false()
+    })
+
+    it('should revalidate non-cacheable response', () => {
+      const res = new Response('', {
+        headers: {
+          date: new Date(Date.now()).toUTCString(),
+          'cache-control': 'public, no-cache'
+        }
+      })
+
+      expect(needsRevalidateBeforeUse(res)).to.be.true()
+    })
+
+    it('should revalidate non-storable response', () => {
+      const res = new Response('', {
+        headers: {
+          date: new Date(Date.now()).toUTCString(),
+          'cache-control': 'public, no-store'
+        }
+      })
+
+      expect(needsRevalidateBeforeUse(res)).to.be.true()
+    })
+
+    it('should revalidate responses that must be revalidated', () => {
+      const res = new Response('', {
+        headers: {
+          date: new Date(Date.now()).toUTCString(),
+          'cache-control': 'public, max-age=29030400, must-revalidate'
+        }
+      })
+
+      expect(needsRevalidateBeforeUse(res)).to.be.true()
+    })
+
+    it('should revalidate immutable response outside ttl', () => {
+      const res = new Response('', {
+        headers: {
+          date: new Date(Date.now() - 20_000).toUTCString(),
+          'cache-control': 'public, max-age=10, immutable'
+        }
+      })
+
+      expect(needsRevalidateBeforeUse(res)).to.be.true()
+    })
+
+    it('should revalidate response if age outside ttl', () => {
+      const res = new Response('', {
+        headers: {
+          date: new Date(Date.now() - 20_000).toUTCString(),
+          age: '50',
+          'cache-control': 'public, max-age=30'
+        }
+      })
+
+      expect(needsRevalidateBeforeUse(res)).to.be.true()
+    })
+
+    it('should not revalidate response outside ttl but inside stale-while-revalidate', () => {
+      const res = new Response('', {
+        headers: {
+          date: new Date(Date.now() - 20_000).toUTCString(),
+          'cache-control': 'public, max-age=10, stale-while-revalidate=30'
+        }
+      })
+
+      expect(needsRevalidateBeforeUse(res)).to.be.false()
+    })
+
+    it('should revalidate response outside ttl but inside non-integer stale-while-revalidate', () => {
+      const res = new Response('', {
+        headers: {
+          date: new Date(Date.now() - 20_000).toUTCString(),
+          'cache-control': 'public, max-age=10, stale-while-revalidate=30.1'
+        }
+      })
+
+      expect(needsRevalidateBeforeUse(res)).to.be.true()
+    })
+
+    it('should revalidate response outside ttl but stale-while-revalidate is invalid', () => {
+      const res = new Response('', {
+        headers: {
+          date: new Date(Date.now() - 20_000).toUTCString(),
+          'cache-control': 'public, max-age=10, stale-while-revalidate=abc'
+        }
+      })
+
+      expect(needsRevalidateBeforeUse(res)).to.be.true()
+    })
+
+    it('should revalidate response outside ttl but stale-while-revalidate is negative', () => {
+      const res = new Response('', {
+        headers: {
+          date: new Date(Date.now() - 20_000).toUTCString(),
+          'cache-control': 'public, max-age=10, stale-while-revalidate=-30'
+        }
+      })
+
+      expect(needsRevalidateBeforeUse(res)).to.be.true()
+    })
+  })
+
+  describe('needs-revalidate-after-use', () => {
+    it('should not need revalidation after use when response is fresh', () => {
+      const res = new Response('', {
+        headers: {
+          date: new Date(Date.now() - 20_000).toUTCString(),
+          'cache-control': 'public, max-age=500, immutable'
+        }
+      })
+
+      expect(needsRevalidateBeforeUse(res)).to.be.false()
+      expect(needsRevalidateAfterUse(res)).to.be.false()
+    })
+
+    it('should not need revalidation after use when response is stale', () => {
+      const res = new Response('', {
+        headers: {
+          date: new Date(Date.now() - 20_000).toUTCString(),
+          'cache-control': 'public, max-age=1, immutable'
+        }
+      })
+
+      expect(needsRevalidateBeforeUse(res)).to.be.true()
+      expect(needsRevalidateAfterUse(res)).to.be.false()
+    })
+
+    it('should revalidate used response outside ttl but inside stale-while-revalidate', () => {
+      const res = new Response('', {
+        headers: {
+          date: new Date(Date.now() - 20_000).toUTCString(),
+          'cache-control': 'public, max-age=10, stale-while-revalidate=30'
+        }
+      })
+
+      expect(needsRevalidateBeforeUse(res)).to.be.false()
+      expect(needsRevalidateAfterUse(res)).to.be.true()
+    })
+
+    it('should not revalidate stale response if age outside ttl', () => {
+      const res = new Response('', {
+        headers: {
+          date: new Date(Date.now() - 20_000).toUTCString(),
+          age: '50',
+          'cache-control': 'public, max-age=10, stale-while-revalidate=30'
+        }
+      })
+
+      expect(needsRevalidateAfterUse(res)).to.be.false()
+    })
+
+    it('should not revalidate used response if stale-while-revalidate not an integer', () => {
+      const res = new Response('', {
+        headers: {
+          date: new Date(Date.now() - 20_000).toUTCString(),
+          'cache-control': 'public, max-age=10, stale-while-revalidate=30.1'
+        }
+      })
+
+      expect(needsRevalidateAfterUse(res)).to.be.false()
+    })
+
+    it('should not revalidate used response if stale-while-revalidate not a number', () => {
+      const res = new Response('', {
+        headers: {
+          date: new Date(Date.now() - 20_000).toUTCString(),
+          'cache-control': 'public, max-age=10, stale-while-revalidate=abc'
+        }
+      })
+
+      expect(needsRevalidateAfterUse(res)).to.be.false()
+    })
+
+    it('should not revalidate used response if stale-while-revalidate not a positive number', () => {
+      const res = new Response('', {
+        headers: {
+          date: new Date(Date.now() - 20_000).toUTCString(),
+          'cache-control': 'public, max-age=10, stale-while-revalidate=-10'
+        }
+      })
+
+      expect(needsRevalidateAfterUse(res)).to.be.false()
+    })
+  })
+
+  describe('can-use-stale-on-response-error', () => {
+    it('should re-use stale response if within stale-if-error ttl', () => {
+      const res = new Response('', {
+        status: 500
+      })
+      const cached = new Response('', {
+        headers: {
+          date: new Date(Date.now() - 20_000).toUTCString(),
+          'cache-control': 'public, max-age=10, stale-if-error=30'
+        }
+      })
+
+      expect(canUseStaleResponseOnError(res, cached)).to.be.true()
+    })
+
+    it('should not re-use stale response if outside stale-if-error ttl', () => {
+      const res = new Response('', {
+        status: 500
+      })
+      const cached = new Response('', {
+        headers: {
+          date: new Date(Date.now() - 20_000).toUTCString(),
+          'cache-control': 'public, max-age=1, stale-if-error=1'
+        }
+      })
+
+      expect(canUseStaleResponseOnError(res, cached)).to.be.false()
+    })
+
+    it('should not re-use stale response if stale-if-error not specified', () => {
+      const res = new Response('', {
+        status: 500
+      })
+      const cached = new Response('', {
+        headers: {
+          date: new Date(Date.now() - 20_000).toUTCString(),
+          'cache-control': 'public, max-age=10'
+        }
+      })
+
+      expect(canUseStaleResponseOnError(res, cached)).to.be.false()
+    })
+
+    it('should not re-use stale response if age outside ttl', () => {
+      const res = new Response('', {
+        status: 500
+      })
+      const cached = new Response('', {
+        headers: {
+          date: new Date(Date.now() - 20_000).toUTCString(),
+          age: '50',
+          'cache-control': 'public, max-age=10, stale-if-error=30'
+        }
+      })
+
+      expect(canUseStaleResponseOnError(res, cached)).to.be.false()
+    })
+
+    it('should not re-use stale response if stale-if-error not an integer', () => {
+      const res = new Response('', {
+        status: 500
+      })
+      const cached = new Response('', {
+        headers: {
+          date: new Date(Date.now() - 20_000).toUTCString(),
+          'cache-control': 'public, max-age=10, stale-if-error=30.1'
+        }
+      })
+
+      expect(canUseStaleResponseOnError(res, cached)).to.be.false()
+    })
+
+    it('should not re-use stale response if stale-if-error not a number', () => {
+      const res = new Response('', {
+        status: 500
+      })
+      const cached = new Response('', {
+        headers: {
+          date: new Date(Date.now() - 20_000).toUTCString(),
+          'cache-control': 'public, max-age=10, stale-if-error=abc'
+        }
+      })
+
+      expect(canUseStaleResponseOnError(res, cached)).to.be.false()
+    })
+
+    it('should not re-use stale response if stale-if-error not a positive number', () => {
+      const res = new Response('', {
+        status: 500
+      })
+      const cached = new Response('', {
+        headers: {
+          date: new Date(Date.now() - 20_000).toUTCString(),
+          'cache-control': 'public, max-age=10, stale-if-error=-10'
+        }
+      })
+
+      expect(canUseStaleResponseOnError(res, cached)).to.be.false()
+    })
+  })
+})

--- a/test/sw/lib/header-directives.spec.ts
+++ b/test/sw/lib/header-directives.spec.ts
@@ -13,4 +13,12 @@ describe('header-directives', () => {
   it('should parse empty header', () => {
     expect(parseHeaderDirectives(null)).to.deep.equal({})
   })
+
+  it('should lowercase directive names', () => {
+    expect(parseHeaderDirectives('Public, Max-Age=600, IMMUTABLE')).to.deep.equal({
+      public: true,
+      'max-age': '600',
+      immutable: true
+    })
+  })
 })

--- a/test/sw/lib/header-directives.spec.ts
+++ b/test/sw/lib/header-directives.spec.ts
@@ -1,0 +1,16 @@
+import { expect } from 'aegir/chai'
+import { parseHeaderDirectives } from '../../../src/sw/lib/header-directives.ts'
+
+describe('header-directives', () => {
+  it('should parse header directives', () => {
+    expect(parseHeaderDirectives('public, max-age=29030400, immutable')).to.deep.equal({
+      public: true,
+      'max-age': '29030400',
+      immutable: true
+    })
+  })
+
+  it('should parse empty header', () => {
+    expect(parseHeaderDirectives(null)).to.deep.equal({})
+  })
+})


### PR DESCRIPTION
Removes the custom 1h `sw-cache-expires` header added to responses in https://github.com/ipfs/service-worker-gateway/pull/92 instead deriving the cached response staleness/freshness based on the received `Date` (defaulting to `now` if not set), any `Age` header, and the `Cache-Control` or `Expires` headers according to RFC 9111.

Resorts to the previous default of 1h if it's not possible to detect the server-supplied max-age.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
