### PR TITLE
fix: only show logs on error page if there are logs to show

### DIFF
--- a/src/ui/pages/fetch-error.tsx
+++ b/src/ui/pages/fetch-error.tsx
@@ -103,7 +103,7 @@ function DebugInfo ({ request, response, logs }: FetchErrorPageProps): ReactElem
 
   let logDisplay = <></>
 
-  if (logs != null) {
+  if (logs != null && logs.length > 0) {
     logDisplay = (
       <>
         <h4 className='ma3'>Logs</h4>


### PR DESCRIPTION
If logging is disabled the list of logs will be empty so only render logs if there are actually logs to render.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
