### PR TITLE
fix: show clear notice on unsupported browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,25 @@ The main goals of this project are:
 
 Compliance with [IPFS HTTP Gateway specifications](https://specs.ipfs.tech/http-gateways/) is tested using the [gateway-conformance](https://github.com/ipfs/gateway-conformance) test suite (the same suite used by [Kubo](https://github.com/ipfs/kubo) and [Rainbow](https://github.com/ipfs/rainbow)).
 
+## Browser support
+
+The gateway needs a recent browser. Minimum versions:
+
+| Browser | Minimum |
+| --- | --- |
+| Chrome / Edge | 130 |
+| Firefox | 122 |
+| Safari / iOS | 18.4 |
+
+The current [Firefox ESR](https://www.mozilla.org/firefox/enterprise/) and [Tor Browser](https://www.torproject.org/) are above this floor and work.
+
+Two capabilities set the floor:
+
+- Spec-compliant parsing of non-special-scheme URLs, so `new URL('ipfs://<cid>')` exposes the CID as the host (the gateway routes content through `ipfs://` and `ipns://` URLs). Chrome shipped this last, in [Chrome 130](https://developer.chrome.com/release-notes/130); Firefox in 122; Safari during the 18.x cycle.
+- `Promise.withResolvers()` (Chrome 119, Firefox 121, Safari 17.4), used by the bundled Helia/libp2p stack.
+
+The `browserslist` field in `package.json` records this floor. The esbuild syntax target (`es2020`) is configured separately in `build.js`.
+
 ## Usage
 
 ### Running locally

--- a/README.md
+++ b/README.md
@@ -74,22 +74,7 @@ Compliance with [IPFS HTTP Gateway specifications](https://specs.ipfs.tech/http-
 
 ## Browser support
 
-The gateway needs a recent browser. Minimum versions:
-
-| Browser | Minimum |
-| --- | --- |
-| Chrome / Edge | 130 |
-| Firefox | 122 |
-| Safari / iOS | 18.4 |
-
-The current [Firefox ESR](https://www.mozilla.org/firefox/enterprise/) and [Tor Browser](https://www.torproject.org/) are above this floor and work.
-
-Two capabilities set the floor:
-
-- Spec-compliant parsing of non-special-scheme URLs, so `new URL('ipfs://<cid>')` exposes the CID as the host (the gateway routes content through `ipfs://` and `ipns://` URLs). Chrome shipped this last, in [Chrome 130](https://developer.chrome.com/release-notes/130); Firefox in 122; Safari during the 18.x cycle.
-- `Promise.withResolvers()` (Chrome 119, Firefox 121, Safari 17.4), used by the bundled Helia/libp2p stack.
-
-The `browserslist` field in `package.json` records this floor. The esbuild syntax target (`es2020`) is configured separately in `build.js`.
+The gateway uses modern [Web APIs](https://developer.mozilla.org/en-US/docs/Web/API), so it needs a web browser kept up to date with security patches. If you see a notice asking you to update, please do.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,11 @@ Compliance with [IPFS HTTP Gateway specifications](https://specs.ipfs.tech/http-
 
 ## Browser support
 
-The gateway uses modern [Web APIs](https://developer.mozilla.org/en-US/docs/Web/API), so it needs a web browser kept up to date with security patches. If you see a notice asking you to update, please do.
+The gateway supports recent versions of all major web browsers.
+
+It is built using modern [Web APIs](https://developer.mozilla.org/en-US/docs/Web/API) so needs a web browser kept up to date with the latest features and security patches.
+
+If you see a notice asking you to update your browser, please do so.
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,11 @@
   },
   "browser": "./dist/src/index.js",
   "browserslist": [
-    "last 1 Chrome version"
+    "Chrome >= 130",
+    "Edge >= 130",
+    "Firefox >= 122",
+    "Safari >= 18.4",
+    "iOS >= 18.4"
   ],
   "eslintConfig": {
     "extends": "ipfs",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,7 @@
 import weald from 'weald'
 import { config } from './config/index.ts'
 import { QUERY_PARAMS } from './lib/constants.ts'
+import { isBrowserSupported } from './lib/is-browser-supported.ts'
 import { parseRequest } from './lib/parse-request-cheap.ts'
 import { isSafeOrigin } from './lib/path-or-subdomain.ts'
 import { registerServiceWorker } from './lib/register-service-worker.ts'
@@ -30,6 +31,13 @@ declare global {
  * reload the current page so the request can be handled by the service worker.
  */
 async function main (): Promise<void> {
+  if (!isBrowserSupported()) {
+    // browser is missing Web APIs we need, render the UI which will tell the
+    // user their browser is unsupported
+    await renderUi()
+    return
+  }
+
   if (!('serviceWorker' in navigator)) {
     // no service worker support, render the UI which will tell the user
     // service workers are not supported

--- a/src/lib/is-browser-supported.ts
+++ b/src/lib/is-browser-supported.ts
@@ -1,0 +1,18 @@
+/**
+ * The gateway needs these Web APIs; when one is missing the UI shows an
+ * "update your browser" page instead of failing later with an opaque error.
+ *
+ * - `Promise.withResolvers` (Chrome 119, Firefox 121, Safari 17.4)
+ * - non-special-scheme URL parsing, so `new URL('ipfs://cid').hostname` is the CID (Chrome 130, Firefox 122, Safari 18.x)
+ */
+export function isBrowserSupported (): boolean {
+  if (!('withResolvers' in Promise)) {
+    return false
+  }
+
+  try {
+    return new URL('ipfs://host').hostname === 'host'
+  } catch {
+    return false
+  }
+}

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -4,6 +4,7 @@ import './index.css'
 import { FaInfoCircle, FaGithub, FaExclamationTriangle, FaExclamationCircle, FaHome, FaListAlt, FaFileDownload } from 'react-icons/fa'
 import { HashRouter, Route, Routes, NavLink } from 'react-router-dom'
 import { HASH_FRAGMENTS } from '../lib/constants.ts'
+import { isBrowserSupported } from '../lib/is-browser-supported.ts'
 import { ErrorBoundary } from './components/error-boundary.tsx'
 import ipfsLogo from './ipfs-logo.svg'
 import AboutPage from './pages/about.tsx'
@@ -15,6 +16,7 @@ import OriginIsolationWarningPage from './pages/origin-isolation-warning.tsx'
 import { RenderEntityPage } from './pages/render-entity.tsx'
 import { RenderMediaPage } from './pages/render-media.tsx'
 import { ServerErrorPage } from './pages/server-error.tsx'
+import UnsupportedBrowserErrorPage from './pages/unsupported-browser.tsx'
 import { injectCSS } from './utils/css-injector.ts'
 
 // SW did not trigger for this request
@@ -181,6 +183,31 @@ function App (): React.ReactElement {
   )
 }
 
+/**
+ * Wraps an error page in the minimal header chrome used when the full app
+ * cannot run (no service worker, unsupported browser).
+ */
+function errorScreen (page: React.ReactElement): React.ReactElement {
+  return (
+    <React.StrictMode>
+      <header className='e2e-header flex items-center pa2 bg-navy bb bw3 b--aqua tc justify-between'>
+        <div>
+          <a href='https://ipfs.tech' title='IPFS Project' target='_blank' rel='noopener noreferrer' aria-label='Visit the website of the IPFS Project'>
+            <img alt='IPFS logo' src={toAbsolutePath(ipfsLogo)} style={{ height: 50 }} className='v-top' />
+          </a>
+        </div>
+        <div className='pb1 ma0 mr2 inline-flex items-center aqua'>
+          <h1 className='e2e-header-title f3 fw2 ttu sans-serif'>Service Worker Gateway</h1>
+          <a href='https://github.com/ipfs/service-worker-gateway' title='IPFS Service Worker Gateway on GitHub' target='_blank' rel='noopener noreferrer' aria-label='Visit the GitHub repository for the IPFS Service Worker Gateway'>
+            <FaGithub className='ml2 f3' />
+          </a>
+        </div>
+      </header>
+      {page}
+    </React.StrictMode>
+  )
+}
+
 async function renderUi (): Promise<void> {
   try {
     await injectCSS('<%-- src/ui/index.css --%>')
@@ -203,25 +230,14 @@ async function renderUi (): Promise<void> {
 
   const root = ReactDOMClient.createRoot(container)
 
+  if (!isBrowserSupported()) {
+    root.render(errorScreen(<UnsupportedBrowserErrorPage />))
+
+    return
+  }
+
   if (!('serviceWorker' in navigator)) {
-    root.render(
-      <React.StrictMode>
-        <header className='e2e-header flex items-center pa2 bg-navy bb bw3 b--aqua tc justify-between'>
-          <div>
-            <a href='https://ipfs.tech' title='IPFS Project' target='_blank' rel='noopener noreferrer' aria-label='Visit the website of the IPFS Project'>
-              <img alt='IPFS logo' src={toAbsolutePath(ipfsLogo)} style={{ height: 50 }} className='v-top' />
-            </a>
-          </div>
-          <div className='pb1 ma0 mr2 inline-flex items-center aqua'>
-            <h1 className='e2e-header-title f3 fw2 ttu sans-serif'>Service Worker Gateway</h1>
-            <a href='https://github.com/ipfs/service-worker-gateway' title='IPFS Service Worker Gateway on GitHub' target='_blank' rel='noopener noreferrer' aria-label='Visit the GitHub repository for the IPFS Service Worker Gateway'>
-              <FaGithub className='ml2 f3' />
-            </a>
-          </div>
-        </header>
-        <NoServiceWorkerErrorPage />
-      </React.StrictMode>
-    )
+    root.render(errorScreen(<NoServiceWorkerErrorPage />))
 
     return
   }

--- a/src/ui/pages/no-service-worker.tsx
+++ b/src/ui/pages/no-service-worker.tsx
@@ -11,16 +11,13 @@ export default function NoServiceWorkerErrorPage (): ReactElement {
           <line x1='12' y1='9' x2='12' y2='13' />
           <line x1='12' y1='17' x2='12.01' y2='17' />
         </svg>
-        <h1 className='ma0 f3'>Warning: Service Workers Are Not Supported</h1>
+        <h1 className='ma0 f3'>Service Worker Required</h1>
       </div>
       <p>
-        This page requires support for <Link href='https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API'>service workers</Link>.
+        This gateway uses a <Link href='https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API'>Service Worker</Link> to verify and load IPFS content in your browser, but your browser does not have one available.
       </p>
       <p>
-        Please ensure that your browser has support and that it is enabled (ie. navigator.serviceWorker is present).
-      </p>
-      <p>
-        If you are using Firefox, please note that <Link href='https://bugzilla.mozilla.org/show_bug.cgi?id=1320796'>service workers are disabled in private browsing mode</Link> - please try again in a regular browsing window.
+        This is most common in Tor Browser, which is <Link href='https://gitlab.torproject.org/tpo/applications/tor-browser/-/work_items/43873'>work-in-progress</Link>. To reach IPFS content there, use a <Link href='https://ipfs.github.io/public-gateway-checker/'>community-run Onion gateway</Link> instead.
       </p>
     </main>
   )

--- a/src/ui/pages/unsupported-browser.tsx
+++ b/src/ui/pages/unsupported-browser.tsx
@@ -10,7 +10,7 @@ export default function UnsupportedBrowserErrorPage (): ReactElement {
           <line x1='12' y1='9' x2='12' y2='13' />
           <line x1='12' y1='17' x2='12.01' y2='17' />
         </svg>
-        <h1 className='ma0 f3'>Warning: Your Browser Is Not Supported</h1>
+        <h1 className='ma0 f3'>Your Browser Is Not Supported</h1>
       </div>
       <p>
         Your browser is too old and does not support some of the Web APIs this page requires.

--- a/src/ui/pages/unsupported-browser.tsx
+++ b/src/ui/pages/unsupported-browser.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import type { ReactElement } from 'react'
+
+export default function UnsupportedBrowserErrorPage (): ReactElement {
+  return (
+    <main className='e2e-unsupported-browser-error pa4-l bg-red mw7 mv4-l center pa4 br2 white'>
+      <div className='flex items-center mb4'>
+        <svg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='currentColor' strokeWidth='2' strokeLinecap='round' strokeLinejoin='round' className='mr2'>
+          <path d='m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z' />
+          <line x1='12' y1='9' x2='12' y2='13' />
+          <line x1='12' y1='17' x2='12.01' y2='17' />
+        </svg>
+        <h1 className='ma0 f3'>Warning: Your Browser Is Not Supported</h1>
+      </div>
+      <p>
+        Your browser is too old and does not support some of the Web APIs this page requires.
+      </p>
+      <p>
+        Please update to the latest version of your browser and try again.
+      </p>
+    </main>
+  )
+}


### PR DESCRIPTION
## Problem

On browsers that are too old, loading content fails with an opaque error and no explanation. The reported case (#1110) is Chrome 116 returning `500 Internal Server Error` (`TypeError: Promise.withResolvers is not a function`) from inside the service worker. 


The gateway requires at least two capabilities older browsers lack: `Promise.withResolvers`, and spec-compliant non-special-scheme URL parsing so `new URL('ipfs://<cid>').hostname` is the CID. The latter shipped only in Chrome 130, so Chrome 119-129 also fail (with a misleading `400 "Check CID availability"`).

## Fix

- Add `isBrowserSupported()` that feature-detects both APIs.
- Check it before registering the service worker, mirroring the existing `navigator.serviceWorker` check, so a broken worker is never installed and the user gets a clear "update your browser" page.
- Set `browserslist` to the real floor (Chrome/Edge 130, Firefox 122, Safari 18.4) and document it in the README.

Unsupported browsers now get an actionable message instead of an opaque failure; the per-API version rationale lives in `src/lib/is-browser-supported.ts`.

- Closes #1110