### PR TITLE
fix: display correct namespace in directory listing

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "*.css"
   ],
   "overrides": {
-    "multiformats": "^13.4.1"
+    "multiformats": "^13.4.1",
+    "interface-datastore": "^10.0.0"
   }
 }

--- a/src/ui/pages/render-entity.tsx
+++ b/src/ui/pages/render-entity.tsx
@@ -126,8 +126,8 @@ interface UnixFSPathProps {
 
 function UnixFSPath ({ ipfsPath }: UnixFSPathProps): ReactElement {
   // /ipfs/cid/path
-  const parts = ipfsPath.split('/')
-    .slice(2)
+  const [namespace, ...rest] = ipfsPath.split('/').slice(1)
+  const parts = rest
     .filter(segment => segment !== '')
     .map((segment, index, arr) => {
       return (
@@ -137,7 +137,7 @@ function UnixFSPath ({ ipfsPath }: UnixFSPathProps): ReactElement {
 
   return (
     <>
-      /ipfs{parts}
+      /{namespace}{parts}
     </>
   )
 }

--- a/test-e2e/directory-listing.spec.ts
+++ b/test-e2e/directory-listing.spec.ts
@@ -44,7 +44,6 @@ test.describe('directory-listing', () => {
   })
 
   test('should load directory entry', async ({ page, baseURL }) => {
-    test.setTimeout(640_000_000)
     const response = await loadWithServiceWorker(page, `${baseURL}/ipns/${domain}`)
     expect(response.status()).toBe(200)
 
@@ -54,6 +53,20 @@ test.describe('directory-listing', () => {
     // iframe, so the body text lives inside the wrapper's iframe.
     await expect(mediaViewerFrame(page).getByText('hello world')).toBeVisible()
     expect(page.url().endsWith('/hello-world.txt')).toBeTruthy()
+  })
+
+  test('should show correct IPNS namespace in header', async ({ page, baseURL }) => {
+    const response = await loadWithServiceWorker(page, `${baseURL}/ipfs/${directory.cid}`)
+    expect(response.status()).toBe(200)
+
+    await expect(page.locator('#directory-index')).toContainText(`Index of /ipfs/${directory.cid}`)
+  })
+
+  test('should show correct IPFS namespace in header', async ({ page, baseURL }) => {
+    const response = await loadWithServiceWorker(page, `${baseURL}/ipns/${domain}`)
+    expect(response.status()).toBe(200)
+
+    await expect(page.locator('#directory-index')).toContainText(`Index of /ipns/${domain}`)
   })
 
   test('should download directory entry block', async ({ page, baseURL }) => {

--- a/test-e2e/directory-listing.spec.ts
+++ b/test-e2e/directory-listing.spec.ts
@@ -55,14 +55,14 @@ test.describe('directory-listing', () => {
     expect(page.url().endsWith('/hello-world.txt')).toBeTruthy()
   })
 
-  test('should show correct IPNS namespace in header', async ({ page, baseURL }) => {
-    const response = await loadWithServiceWorker(page, `${baseURL}/ipfs/${directory.cid}`)
+  test('should show IPFS namespace in header', async ({ page, baseURL }) => {
+    const response = await loadWithServiceWorker(page, `${baseURL}/ipfs/${directory.cid.toV1()}`)
     expect(response.status()).toBe(200)
 
-    await expect(page.locator('#directory-index')).toContainText(`Index of /ipfs/${directory.cid}`)
+    await expect(page.locator('#directory-index')).toContainText(`Index of /ipfs/${directory.cid.toV1()}`)
   })
 
-  test('should show correct IPFS namespace in header', async ({ page, baseURL }) => {
+  test('should show IPNS namespace in header', async ({ page, baseURL }) => {
     const response = await loadWithServiceWorker(page, `${baseURL}/ipns/${domain}`)
     expect(response.status()).toBe(200)
 


### PR DESCRIPTION
Display "Index of /ipns/..." for IPNS names and "Index of /ipfs/..." for CIDs.

Fixes #1120

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
