### PR TITLE
chore: remove format param test ignores

### DIFF
--- a/test-conformance/fixtures/get-wontfix-tests.ts
+++ b/test-conformance/fixtures/get-wontfix-tests.ts
@@ -7,14 +7,6 @@ export function getWontFixTests (): string[] {
     'TestDNSLinkGatewayIPNS',
     'TestDNSLinkGatewayWithSubpath',
 
-    // these tests want to ignore the format arg and return a text/html
-    // content-type which is not in the spec?
-    // https://github.com/ipfs/gateway-conformance/issues/256
-    'TestDagPbConversion/GET_UnixFS_with_format=json_%28not_dag-json%29_is_no-op_%28no_conversion%29/Header_Content-Type',
-    'TestDagPbConversion/GET_UnixFS_with_format=cbor_%28not_dag-cbor%29_is_no-op_%28no_conversion%29/Header_Content-Type',
-    'TestDagPbConversion/GET_UnixFS_with_%27Accept:_application%2Fjson%27_%28not_dag-json%29_is_no-op_%28no_conversion%29/Header_Content-Type',
-    'TestDagPbConversion/GET_UnixFS_with_%27Accept:_application%2Fcbor%27_%28not_dag-cbor%29_is_no-op_%28no_conversion%29/Header_Content-Type',
-
     // kubo-specific tests
     'TestUnixFSDirectoryListing/path_gw:_backlink_on_root_CID_should_be_hidden_%28TODO:_cleanup_Kubo-specifics%29',
     'TestUnixFSDirectoryListing/path_gw:_dir_listing_HTML_response_%28TODO:_cleanup_Kubo-specifics%29',


### PR DESCRIPTION
The invalid tests were removed from the conformance suite so no need to ignore them any longer.

Refs https://github.com/ipfs/gateway-conformance/issues/256

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
