### PR TITLE
chore: remove accept header test ignore

### DIFF
--- a/test-conformance/fixtures/get-wontfix-tests.ts
+++ b/test-conformance/fixtures/get-wontfix-tests.ts
@@ -63,10 +63,6 @@ export function getWontFixTests (): string[] {
     'TestProxyTunnelGatewaySubdomains',
     'TestProxyGatewaySubdomains',
 
-    // this is the wrong way round
-    // https://github.com/ipfs/specs/issues/521
-    'TestTrustlessCarOrderAndDuplicates/GET_CAR_with_Accept_and_%3Fformat%2C_specific_Accept_header_is_prioritized',
-
     // last few tests
     'TestTar/GET_TAR_with_relative_paths_inside_root_works',
     'TestGatewaySymlink/Test_the_directory_listing',


### PR DESCRIPTION
The priority of the content type overrides has changed after IPIP-523 so it is not necessary to ignore this test any more.

Refs: https://github.com/ipfs/specs/issues/521

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
