### PR TITLE
fix: remove cache on failed asset get

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -30,7 +30,8 @@ export const CACHE_VERSION = 2
 export const CURRENT_CACHES = Object.freeze({
   mutable: `mutable-cache-v${CACHE_VERSION}`,
   immutable: `immutable-cache-v${CACHE_VERSION}`,
-  swAssets: `sw-assets-v${CACHE_VERSION}`
+  swAssets: `sw-assets-v${CACHE_VERSION}`,
+  delegatedRouting: 'delegated-routing-v1-cache'
 })
 
 /**

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -172,13 +172,14 @@ async function main (): Promise<void> {
         await registerServiceWorker()
       }
 
-      // Clear SW-UI hashes before navigating: otherwise the post-reload
-      // React app would match a `/ipfs-sw-…` route from the HashRouter
-      // and show a SW UI page instead of the requested CID content,
+      // Clear SW-UI hash nav or assets before navigating: otherwise the
+      // post-reload React app would match a `/ipfs-sw-…` route from the
+      // HashRouter and show a SW UI page instead of the requested CID content,
       // causing endless redirects between the two.
-      if (window.location.hash.startsWith('#/ipfs-sw')) {
+      if (window.location.hash.startsWith('#/ipfs-sw') || window.location.pathname.startsWith('/ipfs-sw')) {
         url.hash = ''
         window.location.hash = ''
+        url.pathname = ''
       }
 
       // Trigger a navigation so the just-installed service worker can
@@ -256,6 +257,36 @@ async function renderUi (): Promise<void> {
   // dynamically load the app chunk using the correct filename
   try {
     const script = document.createElement('script')
+    script.addEventListener('error', () => {
+      // failed to load script, there may be a new service worker available -
+      // delete all caches, unregister the service worker and reload
+      Promise.all([
+        caches.keys()
+          .then(async (cacheNames) => {
+            return Promise.all(
+              cacheNames.map(async function (cacheName) {
+                return caches.delete(cacheName)
+              })
+            )
+          })
+          .catch(err => {
+            // eslint-disable-next-line no-console
+            console.error('could not delete out of date cache - %e', err)
+          }),
+        navigator.serviceWorker.getRegistration()
+          .then(async registration => {
+            registration?.unregister()
+          })
+      ])
+        .then(() => {
+          // @ts-expect-error boolean `forceGet` argument is firefox-only
+          document.location.reload(true)
+        })
+        .catch((err) => {
+          // eslint-disable-next-line no-console
+          console.error('could not refresh context', err)
+        })
+    })
     script.type = 'module'
     script.src = '<%-- src/ui/index.tsx --%>'
     document.body.appendChild(script)

--- a/src/sw/handlers/asset-request-handler.ts
+++ b/src/sw/handlers/asset-request-handler.ts
@@ -2,6 +2,22 @@ import { CURRENT_CACHES } from '../../constants.ts'
 import { getSwLogger } from '../../lib/logger.ts'
 import type { Handler } from './index.ts'
 
+/**
+ * When we are loading a js asset it normally has a hash in the filename. On new
+ * deployments these hashes change and the root HTML page is served to try to
+ * install the service worker which won't work if it's being loaded from a
+ * script tag.
+ */
+function isCorrectContentType (request: Request, response: Response): boolean {
+  const requestUrl = new URL(request.url)
+
+  if (requestUrl.pathname.endsWith('.js') && response.headers.get('content-type')?.includes('javascript') === false) {
+    return false
+  }
+
+  return true
+}
+
 export const assetRequestHandler: Handler = {
   name: 'asset-request-handler',
 
@@ -28,6 +44,7 @@ export const assetRequestHandler: Handler = {
       const cachedResponse = await cache.match(event.request)
 
       if (cachedResponse != null) {
+        log('returning cached response for', event.request.url)
         return cachedResponse
       }
     } catch (err) {
@@ -36,10 +53,15 @@ export const assetRequestHandler: Handler = {
 
     const response = await fetch(event.request)
 
-    try {
-      await cache.put(event.request, response.clone())
-    } catch (err) {
-      log.error('error caching response - %e', err)
+    log('got asset response %d with content type %s for %s', response.status, response.headers.get('content-type'), event.request.url)
+
+    if (response.ok && isCorrectContentType(event.request, response)) {
+      event.waitUntil(
+        cache.put(event.request, response.clone())
+          .catch(err => {
+            log.error('error caching response - %e', err)
+          })
+      )
     }
 
     return response

--- a/src/sw/handlers/content-request-handler.ts
+++ b/src/sw/handlers/content-request-handler.ts
@@ -53,22 +53,21 @@ function getCacheKey (resource: ContentURI, headers: Headers, renderHtml: boolea
 async function getResponseFromCacheOrFetch (args: FetchHandlerArg): Promise<Response> {
   const log = getSwLogger('get-response-from-cache-or-fetch')
 
-  log.trace('cache key: %s', args.cacheKey)
   const cache = await caches.open(args.isMutable ? CURRENT_CACHES.mutable : CURRENT_CACHES.immutable)
   const cachedResponse = await cache.match(args.cacheKey)
 
   if (cachedResponse == null) {
-    log('cached response MISS for %s', args.cacheKey)
+    log('cached response MISS for %s (cache key %s)', args.event.request.url, args.cacheKey)
     return fetchAndUpdateCache(args)
   }
 
   if (needsRevalidateBeforeUse(cachedResponse)) {
-    log('cached response HIT for %s but needs revalidation before use', args.cacheKey)
+    log('cached response HIT for %s (cache key %s) but needs revalidation before use', args.event.request.url, args.cacheKey)
 
     const response = await fetchAndUpdateCache(args)
 
     if (canUseStaleResponseOnError(response, cachedResponse)) {
-      log('%d error revalidating response but can re-use cached response HIT for %s', response.status, args.cacheKey)
+      log('%d error revalidating response but can re-use cached response HIT for %s (cache key %s)', response.status, args.event.request.url, args.cacheKey)
       return cachedResponse
     }
 
@@ -76,19 +75,19 @@ async function getResponseFromCacheOrFetch (args: FetchHandlerArg): Promise<Resp
   }
 
   if (needsRevalidateAfterUse(cachedResponse)) {
-    log('cached response HIT for %s but needs background revalidation', args.cacheKey)
+    log('cached response HIT for %s (cache key %s) but needs background revalidation', args.event.request.url, args.cacheKey)
 
     args.event.waitUntil(
       fetchAndUpdateCache(args)
         .catch(err => {
-          log.error('background revalidate for %s failed - %e', args.cacheKey, err)
+          log.error('background revalidate for %s (cache key %s) failed - %e', args.event.request.url, args.cacheKey, err)
         })
     )
 
     return cachedResponse
   }
 
-  log('cached response HIT for %s %o', args.cacheKey, cachedResponse)
+  log('cached response HIT for %s (cache key %s)', args.event.request.url, args.cacheKey)
   return cachedResponse
 }
 

--- a/src/sw/pages/page.ts
+++ b/src/sw/pages/page.ts
@@ -44,7 +44,36 @@ globalThis.${key} = ${JSON.stringify(value, null, 2).replace(/</g, '\\u003c')}
   </head>
   <body>
     <div id="root" class="sans-serif charcoal f5"></div>
-    <script type="module" src="<%-- src/ui/index.tsx --%>"></script>
+    <script>
+      const script = document.createElement('script')
+      script.addEventListener('error', (evt) => {
+        // failed to load script, there may be a new service worker available -
+        // delete all caches, unregister the service worker and reload
+        Promise.all([
+          caches.keys()
+            .then(async (cacheNames) => {
+              return Promise.all(
+                cacheNames.map(async function (cacheName) {
+                  return caches.delete(cacheName)
+                })
+              )
+            })
+            .catch(err => {
+              console.error('could not delete out of date cache - %e', err)
+            }),
+          navigator.serviceWorker.getRegistration()
+            .then(async registration => {
+              registration?.unregister()
+            })
+        ])
+          .then(() => {
+            document.location.reload(true)
+          })
+      })
+      script.type = 'module'
+      script.src = '<%-- src/ui/index.tsx --%>'
+      document.body.appendChild(script)
+    </script>
   </body>
 </html>
 `


### PR DESCRIPTION
When the service worker is older than the currently deployed version, it will generate and have cached HTML pages that contain script tags with src attributes that point to old assets that have been removed from the server (e.g. after a code change `/ipfs-sw-index-HASH-A.js` becomes `/ipfs-sw-index-HASH-B.js`.

Detect when this happens, remove old caches, unregister the service worker, and reload the page so we get the updated versions.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
