### PR TITLE
fix: use module version for cache version

### DIFF
--- a/build.js
+++ b/build.js
@@ -6,6 +6,12 @@ import path from 'node:path'
 import { isIP } from '@chainsafe/is-ip'
 import esbuild from 'esbuild'
 
+const pkg = JSON.parse(readFileSync(path.resolve('package.json'), 'utf-8'))
+const revision = gitRevision()
+const version = `${pkg.version}/${revision}-${Date.now()}`
+
+console.info('Detected versions', pkg.name, pkg.version, revision)
+
 /**
  * @param {string} str
  * @returns {string}
@@ -90,9 +96,8 @@ function gitRevision () {
  * Inject all ipfs-sw-*.html pages (not index.html) in the dist folder with CSS, git revision, and logo.
  *
  * @param {esbuild.Metafile} metafile - esbuild's metafile to extract output file names
- * @param {string} revision - Pre-computed Git revision string
  */
-const injectHtmlPages = async (metafile, revision) => {
+const injectHtmlPages = async (metafile) => {
   const htmlFilePaths = await fs.readdir(path.resolve('dist'), { withFileTypes: true })
     .then(files => files.filter(file => file.isFile() && (file.name.endsWith('.html') || file.name.endsWith('.js'))))
     .then(files => files.map(file => path.resolve('dist', file.name)))
@@ -159,8 +164,8 @@ const injectHtmlPages = async (metafile, revision) => {
     }
 
     if (fileContent.includes('<%= MODULE_VERSION %>')) {
-      fileContent = fileContent.replace(/<%= MODULE_VERSION %>/g, `${pkg.version}/${revision}-${Date.now()}`)
-      console.log(`Added git revision (${revision}) to ${path.relative(process.cwd(), filePath)}.`)
+      fileContent = fileContent.replace(/<%= MODULE_VERSION %>/g, version)
+      console.log(`Injected module version (${version}) to ${path.relative(process.cwd(), filePath)}.`)
     }
 
     // preconnect to routers as we will probably need to use them to find provs
@@ -354,13 +359,10 @@ const modifyBuiltFiles = {
     build.onEnd(async (result) => {
       const metafile = result.metafile
 
-      // Cache the Git revision once
-      const revision = gitRevision()
-
       // Run copyPublicFiles first to make sure public assets are in place
       await copyPublicFiles()
 
-      await injectHtmlPages(metafile, revision)
+      await injectHtmlPages(metafile)
 
       // Modify the redirects file last
       await modifyRedirects()
@@ -384,10 +386,6 @@ const excludeFilesPlugin = (extensions) => ({
     })
   }
 })
-
-const pkg = JSON.parse(readFileSync(path.resolve('package.json'), 'utf-8'))
-const rev = gitRevision()
-console.info('Detected versions', pkg.name, pkg.version, rev)
 
 // build cloudflare
 const cloudflareResult = await esbuild.build({
@@ -444,7 +442,7 @@ export const buildOptions = {
     'process.env.NODE_ENV': `"${process.env.NODE_ENV ?? 'production'}"`,
     'process.env.APP_NAME': `'${pkg.name}'`,
     'process.env.APP_VERSION': `'${pkg.version}'`,
-    'process.env.GIT_REVISION': `'${rev}'`
+    'process.env.GIT_REVISION': `'${revision}'`
   },
   entryPoints: [
     'src/index.tsx',

--- a/build.js
+++ b/build.js
@@ -158,6 +158,11 @@ const injectHtmlPages = async (metafile, revision) => {
       throw new Error(`${path.relative(process.cwd(), filePath)} does not contain <%= GIT_VERSION %>.`)
     }
 
+    if (fileContent.includes('<%= MODULE_VERSION %>')) {
+      fileContent = fileContent.replace(/<%= MODULE_VERSION %>/g, `${pkg.version}/${revision}-${Date.now()}`)
+      console.log(`Added git revision (${revision}) to ${path.relative(process.cwd(), filePath)}.`)
+    }
+
     // preconnect to routers as we will probably need to use them to find provs
     const preconnect = new Set([
       ...config.routers.map(toUrl)

--- a/build.js
+++ b/build.js
@@ -8,7 +8,7 @@ import esbuild from 'esbuild'
 
 const pkg = JSON.parse(readFileSync(path.resolve('package.json'), 'utf-8'))
 const revision = gitRevision()
-const version = `${pkg.version}/${revision}-${Date.now()}`
+const version = `${pkg.version}/${revision}${process.env.NODE_ENV === 'development' ? `'${Date.now()}` : ''}`
 
 console.info('Detected versions', pkg.name, pkg.version, revision)
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,7 +7,7 @@
  *
  * @see https://github.com/ipfs/service-worker-gateway/pull/853#issuecomment-3309246532
  */
-export const CACHE_VERSION = 2
+export const CACHE_VERSION = '<%= MODULE_VERSION %>'
 
 /**
  * This is one best practice that can be followed in general to keep track of

--- a/test-e2e/fixtures/has-cache-entry.ts
+++ b/test-e2e/fixtures/has-cache-entry.ts
@@ -2,7 +2,14 @@ import type { Page } from 'playwright'
 
 export async function hasCacheEntry (page: Page, cacheName: string, key: string): Promise<boolean> {
   return page.evaluate(async ({ cacheName, key }) => {
-    const cache = await caches.open(cacheName)
+    const cacheKeys = await caches.keys()
+    const cacheKey = cacheKeys.find(k => k.startsWith(cacheName))
+
+    if (cacheKey == null) {
+      return false
+    }
+
+    const cache = await caches.open(cacheKey)
 
     for (const req of await cache.keys()) {
       if (req.url.includes(key)) {

--- a/test-e2e/smoke-test.test.ts
+++ b/test-e2e/smoke-test.test.ts
@@ -5,7 +5,6 @@ import { CID } from 'multiformats/cid'
 import * as json from 'multiformats/codecs/json'
 import { identity } from 'multiformats/hashes/identity'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
-import { CURRENT_CACHES } from '../src/constants.ts'
 import { CODE_RAW } from '../src/ui/pages/multicodec-table.ts'
 import { test, expect } from './fixtures/config-test-fixtures.ts'
 import { hasCacheEntry } from './fixtures/has-cache-entry.ts'
@@ -22,8 +21,8 @@ test.describe('smoke test', () => {
     expect(response?.headers()['cache-control']).toBe('public, max-age=29030400, immutable')
 
     // should be in the immutable cache
-    expect(await hasCacheEntry(page, CURRENT_CACHES.mutable, cid)).toBeFalsy()
-    expect(await hasCacheEntry(page, CURRENT_CACHES.immutable, cid)).toBeTruthy()
+    expect(await hasCacheEntry(page, 'mutable-cache', cid)).toBeFalsy()
+    expect(await hasCacheEntry(page, 'immutable-cache', cid)).toBeTruthy()
   })
 
   test('request to /ipfs/dir-cid redirects to /ipfs/dir-cid/', async ({ page, baseURL, protocol, host }) => {
@@ -71,16 +70,16 @@ test.describe('smoke test', () => {
     const name = 'k51qzi5uqu5dk3v4rmjber23h16xnr23bsggmqqil9z2gduiis5se8dht36dam'
 
     // should not be cached
-    expect(await hasCacheEntry(page, CURRENT_CACHES.mutable, name)).toBeFalsy()
-    expect(await hasCacheEntry(page, CURRENT_CACHES.immutable, name)).toBeFalsy()
+    expect(await hasCacheEntry(page, 'mutable-cache', name)).toBeFalsy()
+    expect(await hasCacheEntry(page, 'immutable-cache', name)).toBeFalsy()
 
     const response = await loadBypassingMediaViewer(page, `${baseURL}/ipns/${name}`)
     expect(response.status()).toBe(200)
     expect(await response.text()).toContain('hello')
 
     // should be in the mutable cache only
-    expect(await hasCacheEntry(page, CURRENT_CACHES.mutable, name)).toBeTruthy()
-    expect(await hasCacheEntry(page, CURRENT_CACHES.immutable, name)).toBeFalsy()
+    expect(await hasCacheEntry(page, 'mutable-cache', name)).toBeTruthy()
+    expect(await hasCacheEntry(page, 'immutable-cache', name)).toBeFalsy()
   })
 
   test('normalizes base16 CIDs to base32', async ({ page, baseURL, protocol, host }) => {


### PR DESCRIPTION
Reset the cache when new versions are released, otherwise UI scripts can fail to load properly when in UI pages that are cached from older service worker versions.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
Reset the cache when new versions are released, otherwise UI files that
load UI scripts can fail to load properly.