### PR TITLE
fix: cyclic reload from a poisoned cdn cache

### DIFF
--- a/.github/scripts/purge-cache.sh
+++ b/.github/scripts/purge-cache.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Purge the whole Cloudflare cache for a zone.
+#
+# purge_everything is the only purge available below Enterprise: purging by
+# prefix or by cache tag is not, and single-file purge by URL does not reach
+# entries stored under the custom cache keys that Snippet
+# 02_shared_sw_installer_cache sets. So this is a blunt instrument by
+# necessity.
+#
+# It is safe to run more than once, and safe to run when a deploy has not
+# landed. Built assets are content hashed, so the worst a purge can do is leave
+# the cache cold for a moment.
+
+set -euo pipefail
+
+: "${CF_ZONE_ID:?CF_ZONE_ID must be set}"
+: "${CF_TOKEN:?CF_TOKEN must be set}"
+
+echo "Purging Cloudflare cache for zone ${CF_ZONE_ID}"
+
+curl --fail --silent --show-error --request POST \
+  --url "https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/purge_cache" \
+  -H 'Content-Type: application/json' \
+  -H "Authorization: Bearer ${CF_TOKEN}" \
+  --data '{"purge_everything": true}'
+
+echo

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -49,12 +49,22 @@ jobs:
   # without waiting for the 24h TTL to expire.
   purge-cache-and-verify:
     needs: deploy
+    # Purge once the upload lands, whatever happens afterwards. In #1155 this
+    # job purged, then spent ten minutes waiting for a version the edge could
+    # never serve, hit the job timeout, and took the run down as "cancelled".
+    # A half filled cache is worse than a cold one, so the purge steps below
+    # must not be reachable only through the happy path.
+    if: always() && needs.deploy.result == 'success'
     runs-on: ubuntu-latest
     environment: production
-    timeout-minutes: 10
+    # Every step carries its own bound. The job timeout is only a backstop, and
+    # it is generous on purpose: if it fires mid-job it takes the purge with it.
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v7
       - name: Wait for deployment to be live on CF Pages origin
+        id: wait-origin
+        continue-on-error: true
         timeout-minutes: 9
         run: |
           # fetch the tag to ensure it's available
@@ -62,7 +72,7 @@ jobs:
           # check Pages origin directly (bypasses CDN cache)
           ./.github/scripts/wait-for-deploy.sh https://ipfs-service-worker-gateway.pages.dev ${{ inputs.tag }}
       - name: Fetch Cloudflare Pages deployment logs
-        if: success() || failure()
+        if: always()
         run: ./.github/scripts/fetch-cf-pages-logs.sh
         env:
           CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
@@ -70,18 +80,49 @@ jobs:
           CF_PAGES_TOKEN: ${{ secrets.CF_PAGES_TOKEN }}
           DEPLOY_COMMIT: ${{ inputs.tag }}
       - name: Purge Cloudflare cache for inbrowser.link
+        if: always()
+        timeout-minutes: 2
+        run: ./.github/scripts/purge-cache.sh
+        env:
+          CF_ZONE_ID: ${{ secrets.CF_ZONE_ID_PRODUCTION }}
+          CF_TOKEN: ${{ secrets.CF_CACHE_PURGE_TOKEN_PRODUCTION }}
+      # Pages does not flip every node at the same instant. The purge above
+      # empties the cache while some nodes may still answer from the previous
+      # deployment, and whatever they answer gets cached for 24h. Purge a second
+      # time once they have caught up, so nothing cached during that window
+      # outlives it. Assets are content hashed, so an extra purge only ever
+      # costs a cold cache.
+      - name: Purge again once Pages has finished propagating
+        if: always()
+        timeout-minutes: 3
         run: |
-          curl --fail --request POST \
-            --url "https://api.cloudflare.com/client/v4/zones/$CF_ZONE_ID/purge_cache" \
-            -H 'Content-Type: application/json' \
-            -H "Authorization: Bearer $CF_TOKEN" \
-            --data '{"purge_everything": true}'
+          sleep 60
+          ./.github/scripts/purge-cache.sh
         env:
           CF_ZONE_ID: ${{ secrets.CF_ZONE_ID_PRODUCTION }}
           CF_TOKEN: ${{ secrets.CF_CACHE_PURGE_TOKEN_PRODUCTION }}
       - name: Wait for new version to be served via inbrowser.link
+        id: verify
+        continue-on-error: true
+        timeout-minutes: 5
         run: |
           ./.github/scripts/wait-for-deploy.sh https://inbrowser.link ${{ inputs.tag }}
+      # Both waits above are advisory so that neither can skip a purge. Turn
+      # their outcome into the job's, otherwise a deploy that never went live
+      # reports green.
+      - name: Report whether the deploy went live
+        if: always()
+        run: |
+          failed=0
+          if [ "${{ steps.wait-origin.outcome }}" != "success" ]; then
+            echo "::error::CF Pages origin never served ${{ inputs.tag }}"
+            failed=1
+          fi
+          if [ "${{ steps.verify.outcome }}" != "success" ]; then
+            echo "::error::inbrowser.link never served ${{ inputs.tag }}, even after two purges"
+            failed=1
+          fi
+          exit "$failed"
   deploy-snippets:
     needs: deploy
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -49,18 +49,23 @@ jobs:
   # without waiting for the 24h TTL to expire.
   purge-cache-and-verify:
     needs: deploy
+    # See deploy-to-production.yml for why the purge must not sit behind the
+    # happy path.
+    if: always() && needs.deploy.result == 'success'
     runs-on: ubuntu-latest
     environment: staging
-    timeout-minutes: 10
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v7
       - name: Wait for deployment to be live on CF Pages origin
+        id: wait-origin
+        continue-on-error: true
         timeout-minutes: 9
         run: |
           # check Pages origin directly (bypasses CDN cache)
           ./.github/scripts/wait-for-deploy.sh https://staging.ipfs-service-worker-gateway.pages.dev ${{ inputs.tag }}
       - name: Fetch Cloudflare Pages deployment logs
-        if: success() || failure()
+        if: always()
         run: ./.github/scripts/fetch-cf-pages-logs.sh
         env:
           CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
@@ -68,18 +73,40 @@ jobs:
           CF_PAGES_TOKEN: ${{ secrets.CF_PAGES_TOKEN }}
           DEPLOY_COMMIT: ${{ inputs.tag }}
       - name: Purge Cloudflare cache for inbrowser.dev
+        if: always()
+        timeout-minutes: 2
+        run: ./.github/scripts/purge-cache.sh
+        env:
+          CF_ZONE_ID: ${{ secrets.CF_ZONE_ID_STAGING }}
+          CF_TOKEN: ${{ secrets.CF_CACHE_PURGE_TOKEN_STAGING }}
+      - name: Purge again once Pages has finished propagating
+        if: always()
+        timeout-minutes: 3
         run: |
-          curl --fail --request POST \
-            --url "https://api.cloudflare.com/client/v4/zones/$CF_ZONE_ID/purge_cache" \
-            -H 'Content-Type: application/json' \
-            -H "Authorization: Bearer $CF_TOKEN" \
-            --data '{"purge_everything": true}'
+          sleep 60
+          ./.github/scripts/purge-cache.sh
         env:
           CF_ZONE_ID: ${{ secrets.CF_ZONE_ID_STAGING }}
           CF_TOKEN: ${{ secrets.CF_CACHE_PURGE_TOKEN_STAGING }}
       - name: Wait for new version to be served via inbrowser.dev
+        id: verify
+        continue-on-error: true
+        timeout-minutes: 5
         run: |
           ./.github/scripts/wait-for-deploy.sh https://inbrowser.dev ${{ inputs.tag }}
+      - name: Report whether the deploy went live
+        if: always()
+        run: |
+          failed=0
+          if [ "${{ steps.wait-origin.outcome }}" != "success" ]; then
+            echo "::error::CF Pages origin never served ${{ inputs.tag }}"
+            failed=1
+          fi
+          if [ "${{ steps.verify.outcome }}" != "success" ]; then
+            echo "::error::inbrowser.dev never served ${{ inputs.tag }}, even after two purges"
+            failed=1
+          fi
+          exit "$failed"
   deploy-snippets:
     needs: deploy
     runs-on: ubuntu-latest

--- a/main.go
+++ b/main.go
@@ -66,6 +66,15 @@ func ipfsLikeHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// A missing versioned build asset must 404. Serving index.html under a .js
+	// URL makes the browser reject the module on its MIME type, which the
+	// installer reads as "a new version shipped" and answers with a reload,
+	// over and over. See #1155.
+	if strings.HasPrefix(r.URL.Path, "/ipfs-sw-") {
+		http.NotFound(w, r)
+		return
+	}
+
 	// Otherwise serve the index file
 	http.ServeFile(w, r, "dist/index.html")
 }

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,4 +1,23 @@
 # Cloudflare redirects file
-# - Proxy all requests to index file to install service worker
 # https://developers.cloudflare.com/pages/configuration/redirects/
-/* /index.html 200
+#
+# There is deliberately no `/* /index.html 200` catch-all here.
+#
+# It used to be the way every subdomain got the service worker installer on
+# any path, but Cloudflare Snippet 02_shared_sw_installer_cache already does
+# that: it ignores the requested path and fetches "/" from origin. So the
+# catch-all served nobody, and it lied about missing files.
+#
+# A request for a hashed asset that this deployment does not have, which is
+# what a browser holding the previous deployment's HTML asks for during a
+# cutover, came back as 200 text/html rather than 404. A 200 is cacheable, and
+# the edge pinned that HTML for 24h under a cache key shared by every
+# subdomain, so the whole site served an HTML page where a .js file belonged.
+# That is the cyclic reload reported in #1155.
+#
+# Without the catch-all, Pages answers a missing file with a real 404, which
+# the snippet's `cacheTtlByStatus: {'300-599': 0}` refuses to cache. The bad
+# response cannot outlive the request that produced it.
+#
+# `build.js` appends a `/*/<file> /<file>` rewrite per built asset below, so an
+# asset referenced from a nested path still resolves.

--- a/public/index.html
+++ b/public/index.html
@@ -118,6 +118,37 @@
       .hidden {
         display: none;
       }
+      /* Shown when the app chunk will not load. These rules have to live here:
+         every stylesheet the app ships is inside the chunk that just failed. */
+      .sw-error {
+        max-width: 38rem;
+        margin: 12vh auto 0;
+        padding: 0 1.25rem;
+        font-family: system-ui, -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
+        line-height: 1.55;
+        color: #0b3a53;
+      }
+      .sw-error h1 {
+        margin: 0 0 1rem;
+        font-size: 1.5rem;
+        font-weight: 600;
+      }
+      .sw-error p {
+        margin: 0 0 1rem;
+        color: #3f4b53;
+      }
+      .sw-error button {
+        font: inherit;
+        color: #fff;
+        background: #378085;
+        border: 0;
+        border-radius: 4px;
+        padding: 0.6rem 1.25rem;
+        cursor: pointer;
+      }
+      .sw-error button:hover {
+        background: #2c686c;
+      }
     </style>
   </head>
   <body>

--- a/src/cloudflare/snippets/02_shared_sw_installer_cache.ts
+++ b/src/cloudflare/snippets/02_shared_sw_installer_cache.ts
@@ -17,10 +17,15 @@
 //   everything else (the installer page)
 //     cache key normalized to one entry per subdomain.
 //
-// HTML and asset TTLs match on purpose: a stale HTML referencing
-// fresh JS (or vice versa) would mismatch and break the installer.
-// Badbits is enforced by purging the whole subdomain, so a long
-// TTL does not delay takedowns.
+// HTML and asset TTLs are both 24h, but note that equal TTLs are
+// not synchronized expiry: the two entries are written whenever
+// they are first requested, so they drift apart by however long
+// separates those requests. In #1155 the HTML entry was written
+// two and a half hours after the asset entry. What keeps a stale
+// HTML from naming an asset that is gone is that a missing asset
+// 404s (see below), not that the numbers match. Badbits is
+// enforced by purging the whole subdomain, so a long TTL does not
+// delay takedowns.
 //
 // Why we rewrite the upstream URL for the installer branch
 //
@@ -45,8 +50,89 @@
 // so this snippet owns the cache decision. We only cache 200-299.
 // 3xx, 4xx and 5xx are not cached so a transient origin response
 // cannot get pinned for the full 24 hour TTL.
+//
+// Why the asset branch also checks the content type
+//
+// A status of 200 is not enough to tell a real asset from a missing
+// one, because an origin can answer a file it does not have with
+// the installer HTML and a 200. Every origin we ship now returns a
+// real 404 instead: Pages because public/_redirects no longer has a
+// catch-all, main.go and the dev server because they special case
+// the /ipfs-sw- prefix. cacheTtlByStatus only ever sees the status,
+// so a 404 is enough to keep it out of the cache and this check
+// should never fire.
+//
+// It stays because "should never" has already been wrong once, in
+// #1155. A deploy cutover raced a request for a freshly hashed
+// chunk. Origin did not have it yet, answered 200 text/html, and
+// the edge pinned that HTML for 24 hours under the shared base
+// domain key, five seconds after the deploy's cache purge had
+// emptied it. Every subdomain then served HTML where a .js file
+// belonged. Browsers reject a module on its MIME type, the
+// installer read that as "a new version shipped" and reloaded, and
+// the reload storm rate limited us.
+//
+// Two things keep that from recurring. The origin no longer lies,
+// and if one ever does again, this branch refuses to pass the lie
+// on. The deployment being replaced during a cutover is itself an
+// origin that may still have the old catch-all, so the window is
+// real on the very deploy that removes it.
+//
+// The build never emits HTML under /ipfs-sw-, so a text/html body
+// on an asset path always means the file is missing. When we see
+// one we go back to origin with `cache: 'no-store'`, the one option
+// that skips the cache read rather than just the write. If the
+// deploy has since settled we serve the real asset, so a poisoned
+// entry costs an extra origin fetch rather than a day of downtime,
+// and it heals without waiting for a purge that may never run: the
+// purge is a step in a workflow, and that workflow gets cancelled.
+// If origin still does not have the file we answer 404, which is
+// honest and, unlike HTML, cannot be mistaken for a script.
+//
+// We cannot stop a poisoned entry being written in the first place.
+// cf.cacheTtlByStatus decides on status alone, before the snippet
+// ever sees the response. Owning the entry through the Cache API
+// instead would mean buffering the body to call cache.put, and the
+// built chunks and their source maps run to several MB against a
+// 2 MB snippet memory limit. So we let the entry exist and refuse
+// to serve it.
+//
+// Worst case, if a runtime ever ignored `cache: 'no-store'`, the
+// retry reads the poisoned entry again and we answer 404 until the
+// TTL lapses or a purge lands. That is a bad day, but it is a 404
+// rather than HTML masquerading as a script, so the installer shows
+// an error instead of reloading itself into a rate limit.
 
 const EDGE_CACHE_TTL_S = 86400 // 24h
+
+/**
+ * Whether a response body is really a versioned asset.
+ *
+ * Only the headers are inspected, never the body: assets here reach several MB
+ * and a snippet gets 2 MB of memory, so everything has to stream through.
+ *
+ * A missing file arrives as the installer page with a 200, and the build emits
+ * only JS, CSS, source maps and images under /ipfs-sw-, so text/html on an
+ * asset path means the file is gone. A response with no content type is not
+ * trusted either, since there is nothing to tell it apart from that fallback.
+ */
+function isAssetResponse (response: Response): boolean {
+  if (!response.ok) {
+    return false
+  }
+
+  const contentType = response.headers.get('content-type')
+
+  return contentType != null && !contentType.startsWith('text/html')
+}
+
+/** A missing asset, marked so nothing downstream keeps it. */
+function notFound (): Response {
+  return new Response(null, {
+    status: 404,
+    headers: { 'cache-control': 'no-store' }
+  })
+}
 
 export default {
   async fetch (request: Request): Promise<Response> {
@@ -64,7 +150,7 @@ export default {
       // not the followed 2xx.
       const assetReq = new Request(request, { redirect: 'manual' })
 
-      return fetch(assetReq, {
+      const response = await fetch(assetReq, {
         cf: {
           cacheEverything: true,
           cacheKey,
@@ -76,6 +162,36 @@ export default {
           }
         }
       })
+
+      if (isAssetResponse(response)) {
+        return response
+      }
+
+      // A real 3xx/4xx/5xx from origin, already kept out of cache by
+      // cacheTtlByStatus. Pass it through as-is.
+      if (!response.ok) {
+        return response
+      }
+
+      // A 2xx that is not an asset: the shared entry, or origin itself, is
+      // handing back the installer page for a file that does not exist. Ask
+      // origin again with the cache out of the way.
+      //
+      // `cache: 'no-store'` is the only thing that skips the cache read. It
+      // has to, because on the base domain the request URL is byte-for-byte
+      // the shared cacheKey, so a plain re-fetch would be answered by the
+      // poisoned entry we are trying to get around. `cf.cacheTtl: 0` does not
+      // help: it expires the entry it writes, it does not bypass the lookup.
+      const fresh = await fetch(new Request(request, {
+        redirect: 'manual',
+        cache: 'no-store'
+      }))
+
+      if (isAssetResponse(fresh)) {
+        return fresh
+      }
+
+      return notFound()
     }
 
     // The installer branch handles GET and HEAD only. Other

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -250,6 +250,78 @@ async function main (): Promise<void> {
 }
 
 /**
+ * Marks, on the current history entry, that we have already tried to recover
+ * from an app chunk that would not load.
+ *
+ * `history.state` is the right place for it. It survives `location.reload()`,
+ * it is scoped to this page rather than the whole origin, and reading it needs
+ * no storage permission, so the cap still holds in a browser configured to
+ * block storage. `tooManyRedirects` cannot be reused here for a different
+ * reason: it ignores everything unless `document.referrer` is the current URL,
+ * which a `location.reload()` never makes true.
+ */
+const CHUNK_RETRIED = 'ipfsSwChunkRetried'
+
+function alreadyRetriedChunk (): boolean {
+  return history.state?.[CHUNK_RETRIED] === true
+}
+
+function markChunkRetried (): void {
+  history.replaceState({ ...history.state, [CHUNK_RETRIED]: true }, '')
+}
+
+function forgetChunkRetry (): void {
+  if (!alreadyRetriedChunk()) {
+    return
+  }
+
+  const state = { ...history.state }
+  delete state[CHUNK_RETRIED]
+  history.replaceState(state, '')
+}
+
+/**
+ * Tell the user the app chunk will not load, using only the bootstrap DOM.
+ *
+ * Everything `renderUi` would normally reach for lives inside the chunk that
+ * just failed: every page, the error pages among them, and the
+ * `globalThis.serverError` channel that renders them. What is left is the
+ * markup `index.html` already parsed, so build the message out of that.
+ */
+function showAppChunkError (): void {
+  document.querySelector('.loading-indicator-js')?.classList.add('hidden')
+
+  const root = document.getElementById('root')
+
+  if (root == null) {
+    return
+  }
+
+  // `.sw-error` is defined in the inline stylesheet of index.html, because the
+  // stylesheet the app ships is inside the chunk that failed to load.
+  root.classList.add('sw-error')
+
+  const title = document.createElement('h1')
+  title.textContent = 'Could not load this page'
+
+  const cause = document.createElement('p')
+  cause.textContent = 'The application script failed to load. Usually a CDN or your browser is holding a stale copy of this page that points at a script which no longer exists.'
+
+  const remedy = document.createElement('p')
+  remedy.textContent = 'Waiting a few minutes and trying again normally clears it. A hard reload, which bypasses your browser cache, fetches a fresh copy right away.'
+
+  const retry = document.createElement('button')
+  retry.textContent = 'Try again'
+  retry.addEventListener('click', () => {
+    forgetChunkRetry()
+    // @ts-expect-error boolean `forceGet` argument is firefox-only
+    document.location.reload(true)
+  })
+
+  root.replaceChildren(title, cause, remedy, retry)
+}
+
+/**
  * Asynchronously loads and shows the UI - this is to make the number of bytes
  * downloaded before the service worker is installed smaller
  */
@@ -257,7 +329,28 @@ async function renderUi (): Promise<void> {
   // dynamically load the app chunk using the correct filename
   try {
     const script = document.createElement('script')
+
+    script.addEventListener('load', () => {
+      forgetChunkRetry()
+    })
+
     script.addEventListener('error', () => {
+      // Recover once, and only once. Dropping the caches and the service worker
+      // is what fixes a bootstrap left behind by a deploy, and the reload is
+      // what picks up the current one. If the chunk is still missing after
+      // that, the stale copy lives in a CDN entry that no reload can evict, so
+      // trying again only hammers the CDN until it rate limits us, with the
+      // user watching a blank page throughout. That is the cyclic reload
+      // reported in #1155.
+      if (alreadyRetriedChunk()) {
+        showAppChunkError()
+        return
+      }
+
+      // Mark before the purge below, which deletes every cache, and before the
+      // reload, which resets the page.
+      markChunkRetried()
+
       // failed to load script, there may be a new service worker available -
       // delete all caches, unregister the service worker and reload
       Promise.all([

--- a/test-e2e/fixtures/serve/service-worker.ts
+++ b/test-e2e/fixtures/serve/service-worker.ts
@@ -18,8 +18,13 @@ const MIME_TYPES: Record<string, string> = {
 }
 
 /**
- * create a web server that serves an asset if it exists or index.html if not,
- * this simulates the behaviour of Cloudflare with `./dist/_redirects`
+ * create a web server that serves an asset if it exists, or index.html if not
+ *
+ * This mirrors production, where Cloudflare Snippet 02_shared_sw_installer_cache
+ * answers any non-asset path with the installer page, and `main.go` does the
+ * same for the standalone binary. A missing versioned asset is the exception:
+ * it 404s here, in `main.go` and on Pages, so that a stale reference to a
+ * chunk that no longer exists cannot be mistaken for a script.
  */
 export async function createHttpServer (port = HTTP_PORT): Promise<Server> {
   const server = createServer((req, res) => {
@@ -32,6 +37,16 @@ export async function createHttpServer (port = HTTP_PORT): Promise<Server> {
     let asset = join(__dirname, '../../../dist', file)
 
     if (!existsSync(asset)) {
+      // a missing versioned build asset 404s. Serving index.html under a .js
+      // URL makes the browser reject the module on its MIME type, which the
+      // installer reads as "a new version shipped" and answers with a reload.
+      if (file.startsWith('/ipfs-sw-')) {
+        res.statusCode = 404
+        res.setHeader('content-type', 'text/plain; charset=utf8')
+        res.end('Not Found')
+        return
+      }
+
       // serve index.html instead of 404ing
       asset = join(__dirname, '../../../dist/index.html')
     }

--- a/test/cloudflare/snippets/02_shared_sw_installer_cache.spec.ts
+++ b/test/cloudflare/snippets/02_shared_sw_installer_cache.spec.ts
@@ -5,45 +5,74 @@
 // upstream rewrite (path → "/", Accept: text/html, redirect: manual,
 // GET/HEAD only) that prevents path-specific origin responses from poisoning
 // the collapsed per-subdomain cache entry.
+//
+// The asset branch additionally refuses to serve a text/html body under a
+// /ipfs-sw-* URL. That body is the origin's installer page standing in for a
+// file it does not have, and pinning it under the shared base-domain key is
+// what took production down in #1155.
 
 import { expect } from 'aegir/chai'
 import Sinon from 'sinon'
 import handler from '../../../src/cloudflare/snippets/02_shared_sw_installer_cache.ts'
 import type { SinonSandbox } from 'sinon'
 
-// Captured cf options from the last fetch() call made by the snippet.
-let lastCfOptions = null
-// Captured Request from the last fetch() call (to assert URL/method/headers/redirect).
-let lastRequest: Request | null = null
+// Captured cf options from every fetch() call made by the snippet, in order.
+let cfOptions: any[] = []
+// Captured Requests from every fetch() call made by the snippet, in order.
+let requests: Request[] = []
 // Status code the stubbed origin response will return.
 let stubStatus = 200
 // Headers on the stubbed origin response.
-let stubHeaders = {}
+let stubHeaders: Record<string, string> = {}
+// When set, supplies the response for each fetch() call by index, letting a
+// test model "the shared cache entry is poisoned but origin is healthy".
+let stubByCall: Array<{ status?: number, headers?: Record<string, string> }> | null = null
 
-// Helper: call the snippet handler and return { cf, request, response }.
-async function callHandler (inputUrl: string, init: RequestInit = {}): Promise<{ cf: any, request: Request | null, response: Response }> {
-  lastCfOptions = null
-  lastRequest = null
+interface HandlerResult {
+  cf: any
+  request: Request | null
+  response: Response
+  calls: number
+}
+
+// Helper: call the snippet handler and return the first fetch's cf/request.
+async function callHandler (inputUrl: string, init: RequestInit = {}): Promise<HandlerResult> {
+  cfOptions = []
+  requests = []
   const response = await handler.fetch(new Request(inputUrl, init))
 
-  return { cf: lastCfOptions, request: lastRequest, response }
+  return {
+    cf: cfOptions[0] ?? null,
+    request: requests[0] ?? null,
+    response,
+    calls: requests.length
+  }
 }
+
+const HTML = { 'content-type': 'text/html; charset=utf-8' }
+const JS = { 'content-type': 'application/javascript' }
 
 describe('02_shared_sw_installer_cache', () => {
   let sandbox: SinonSandbox
 
   beforeEach(() => {
-    lastCfOptions = null
-    lastRequest = null
+    cfOptions = []
+    requests = []
     stubStatus = 200
     stubHeaders = {}
+    stubByCall = null
 
     sandbox = Sinon.createSandbox()
     sandbox.replace(globalThis, 'fetch', (requestOrUrl, init) => {
-      lastRequest = requestOrUrl instanceof Request ? requestOrUrl : new Request(requestOrUrl as RequestInfo, init)
-      lastCfOptions = init?.cf ?? null
-      const headers = new Headers(stubHeaders)
-      return Promise.resolve(new Response(null, { status: stubStatus, headers }))
+      const index = requests.length
+      requests.push(requestOrUrl instanceof Request ? requestOrUrl : new Request(requestOrUrl as RequestInfo, init))
+      cfOptions.push(init?.cf ?? null)
+
+      const stub = stubByCall?.[index]
+      const status = stub?.status ?? stubStatus
+      const headers = new Headers(stub?.headers ?? stubHeaders)
+
+      return Promise.resolve(new Response(null, { status, headers }))
     })
   })
 
@@ -53,52 +82,141 @@ describe('02_shared_sw_installer_cache', () => {
 
   describe('/ipfs-sw-* paths (versioned SW assets)', () => {
     it('uses normalized cache key with base domain on .dev', async () => {
+      stubHeaders = JS
       const { cf } = await callHandler('https://inbrowser.dev/ipfs-sw-main.js')
       expect(cf.cacheKey).to.equal('https://inbrowser.dev/ipfs-sw-main.js')
       expect(cf.cacheEverything).to.equal(true)
     })
 
-    it('uses normalized cache key with base domain on .link', async () => {
-      const { cf } = await callHandler('https://inbrowser.link/ipfs-sw-main.js')
-      expect(cf.cacheKey).to.equal('https://inbrowser.link/ipfs-sw-main.js')
-    })
-
     it('normalizes subdomain cache key to base domain', async () => {
+      stubHeaders = JS
       const { cf } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/ipfs-sw-main.js')
       expect(cf.cacheKey).to.equal('https://inbrowser.dev/ipfs-sw-main.js')
     })
 
     it('normalizes subdomain cache key to base domain on .link', async () => {
+      stubHeaders = JS
       const { cf } = await callHandler('https://bafyxxx.ipfs.inbrowser.link/ipfs-sw-main.js')
       expect(cf.cacheKey).to.equal('https://inbrowser.link/ipfs-sw-main.js')
     })
 
     it('uses 24h edge TTL for 200s only', async () => {
+      stubHeaders = JS
       const { cf } = await callHandler('https://inbrowser.dev/ipfs-sw-main.js')
       expect(cf.cacheTtlByStatus['200-299']).to.equal(86400)
     })
 
     it('does not cache non-200 responses at edge', async () => {
+      stubHeaders = JS
       const { cf } = await callHandler('https://inbrowser.dev/ipfs-sw-main.js')
       expect(cf.cacheTtlByStatus['300-599']).to.equal(0)
     })
 
-    it('does not override Cache-Control header', async () => {
-      stubHeaders = { 'Cache-Control': 'original-value' }
+    it('does not override Cache-Control on a real asset', async () => {
+      stubHeaders = { ...JS, 'cache-control': 'original-value' }
       const { response } = await callHandler('https://inbrowser.dev/ipfs-sw-main.js')
-      expect(response.headers.get('Cache-Control'), 'original-value')
+      expect(response.headers.get('cache-control')).to.equal('original-value')
     })
 
     it('matches /ipfs-sw- prefix exactly', async () => {
-      // /ipfs-sw-bundle-abc123.js should match
+      stubHeaders = JS
       const { cf } = await callHandler('https://inbrowser.dev/ipfs-sw-bundle-abc123.js')
-      expect(cf.cacheKey, 'https://inbrowser.dev/ipfs-sw-bundle-abc123.js')
+      expect(cf.cacheKey).to.equal('https://inbrowser.dev/ipfs-sw-bundle-abc123.js')
       expect(cf.cacheTtlByStatus['200-299']).to.equal(86400)
     })
 
     it('uses redirect: manual so an origin 3xx cannot poison the asset cache key', async () => {
+      stubHeaders = JS
       const { request } = await callHandler('https://inbrowser.dev/ipfs-sw-main.js')
       expect(request!.redirect).to.equal('manual')
+    })
+
+    it('serves a real asset straight from the shared entry, without a second fetch', async () => {
+      stubHeaders = JS
+      const { response, calls } = await callHandler('https://inbrowser.dev/ipfs-sw-main.js')
+      expect(response.status).to.equal(200)
+      expect(calls).to.equal(1)
+    })
+
+    // The regression from #1155, which #1156 fixes: status alone cannot tell a
+    // real asset from the origin's SPA fallback, a 200 carrying text/html.
+    it('never serves a 200 text/html body as an asset', async () => {
+      stubHeaders = HTML
+      const { response } = await callHandler('https://bafyxxx.ipfs.inbrowser.link/ipfs-sw-index-ABC123.js')
+      expect(response.status).to.equal(404)
+      expect(response.headers.get('content-type')).to.not.equal('text/html; charset=utf-8')
+    })
+
+    it('bypasses the poisoned entry and serves the asset once origin has it', async () => {
+      // first fetch: the poisoned shared entry. second: origin, now healthy.
+      stubByCall = [{ headers: HTML }, { headers: JS }]
+      const { response, calls } = await callHandler('https://bafyxxx.ipfs.inbrowser.link/ipfs-sw-main.js')
+      expect(response.status).to.equal(200)
+      expect(response.headers.get('content-type')).to.equal('application/javascript')
+      expect(calls).to.equal(2)
+    })
+
+    // cf.cacheTtl: 0 would only expire what it writes; it does not skip the
+    // cache read. On the base domain the request URL *is* the shared cacheKey,
+    // so without no-store the retry would be answered by the poisoned entry.
+    it('skips the cache read on the retry, rather than just the write', async () => {
+      stubByCall = [{ headers: HTML }, { headers: JS }]
+      await callHandler('https://inbrowser.dev/ipfs-sw-main.js')
+      expect(requests[1].cache).to.equal('no-store')
+      expect(cfOptions[1]).to.equal(null)
+    })
+
+    it('retries the same URL it was asked for', async () => {
+      stubByCall = [{ headers: HTML }, { headers: JS }]
+      await callHandler('https://bafyxxx.ipfs.inbrowser.link/ipfs-sw-main.js')
+      expect(requests[1].url).to.equal('https://bafyxxx.ipfs.inbrowser.link/ipfs-sw-main.js')
+      expect(requests[1].redirect).to.equal('manual')
+    })
+
+    it('404s when origin still does not have the file', async () => {
+      stubByCall = [{ headers: HTML }, { headers: HTML }]
+      const { response, calls } = await callHandler('https://inbrowser.dev/ipfs-sw-main.js')
+      expect(response.status).to.equal(404)
+      expect(calls).to.equal(2)
+    })
+
+    it('marks the 404 uncacheable so the next request can retry', async () => {
+      stubHeaders = HTML
+      const { response } = await callHandler('https://inbrowser.dev/ipfs-sw-main.js')
+      expect(response.headers.get('cache-control')).to.equal('no-store')
+    })
+
+    it('treats a 2xx with no content type as missing', async () => {
+      stubHeaders = {}
+      const { response } = await callHandler('https://inbrowser.dev/ipfs-sw-main.js')
+      expect(response.status).to.equal(404)
+    })
+
+    it('passes a 3xx through without a retry', async () => {
+      stubStatus = 302
+      const { response, calls } = await callHandler('https://inbrowser.dev/ipfs-sw-main.js')
+      expect(response.status).to.equal(302)
+      expect(calls).to.equal(1)
+    })
+
+    it('passes a 404 through without a retry', async () => {
+      stubStatus = 404
+      const { response, calls } = await callHandler('https://inbrowser.dev/ipfs-sw-main.js')
+      expect(response.status).to.equal(404)
+      expect(calls).to.equal(1)
+    })
+
+    it('passes a 500 through without a retry', async () => {
+      stubStatus = 500
+      const { response, calls } = await callHandler('https://inbrowser.dev/ipfs-sw-main.js')
+      expect(response.status).to.equal(500)
+      expect(calls).to.equal(1)
+    })
+
+    it('lets a source map through (not html, so a real asset)', async () => {
+      stubHeaders = { 'content-type': 'application/json' }
+      const { response } = await callHandler('https://inbrowser.dev/ipfs-sw-index-ABC.js.map')
+      expect(response.status).to.equal(200)
     })
   })
 
@@ -170,6 +288,14 @@ describe('02_shared_sw_installer_cache', () => {
       expect(response.headers.get('Cache-Control')).to.equal('no-store')
     })
 
+    // An installer path that happens to look like HTML is exactly right, so the
+    // asset branch's content-type check must not leak into this branch.
+    it('serves the installer html untouched', async () => {
+      stubHeaders = HTML
+      const { response } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/wiki/')
+      expect(response.status).to.equal(200)
+    })
+
     // The next block covers the cache-poisoning fix: the upstream fetch
     // must be rewritten so a path-specific origin response (e.g. a 308
     // redirect) cannot be pinned under the per-subdomain cache key.
@@ -226,6 +352,7 @@ describe('02_shared_sw_installer_cache', () => {
 
     it('HTML and versioned SW asset TTLs match (avoid HTML-JS skew)', async () => {
       const { cf: cfHtml } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/page')
+      stubHeaders = JS
       const { cf: cfAsset } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/ipfs-sw-main.js')
       expect(cfHtml.cacheTtlByStatus['200-299']).to.equal(cfAsset.cacheTtlByStatus['200-299'])
     })
@@ -233,6 +360,7 @@ describe('02_shared_sw_installer_cache', () => {
 
   describe('TLD-agnostic behavior', () => {
     it('works the same for .dev and .link on SW asset paths', async () => {
+      stubHeaders = JS
       const { cf: cfDev } = await callHandler('https://bafyxxx.ipfs.inbrowser.dev/ipfs-sw-main.js')
       const { cf: cfLink } = await callHandler('https://bafyxxx.ipfs.inbrowser.link/ipfs-sw-main.js')
       expect(cfDev.cacheTtlByStatus['200-299']).to.equal(cfLink.cacheTtlByStatus['200-299'])


### PR DESCRIPTION
## Problem

iiuc after the 3.4.10 deploy, every page on inbrowser.link was a blank screen (#1155).
it got fixed via Purge Everything in Cache at Cloudflare, but may come back.

A browser asked for a hashed chunk the origin did not have yet, and the `/* /index.html 200` catch-all answered with installer HTML and a 200 rather than a 404. A 200 is cacheable, so the edge pinned that HTML for 24h under a cache key shared by every subdomain. Browsers reject a module on its MIME type, the bootstrap read that as a new version shipping and reloaded, about 100 times in 12 seconds, until Cloudflare rate limited us. No error, just a spinner.

## Fix

The origin stops lying, the snippet stops passing a lie on, and the bootstrap stops reloading into one. Worst case is now a single wasted reload and a page that tells you to wait, rather than a loop that costs wasted requests.

<img width="1280" height="800" alt="01-desktop-light" src="https://github.com/user-attachments/assets/0d7dcb64-a065-45c2-aed8-da67c797efa5" />

## Changes

@achingbrain since the problem is nuanced, and fixes are at different abstraction layers, it may be easier to review in stages. Each commit stands alone, in this order:

- 97caad9 **fix: 404 missing versioned assets**
The root cause. Drops the catch-all so Pages, `main.go` and the dev server all answer a missing `/ipfs-sw-*` with a real 404, which the snippet's `cacheTtlByStatus: {'300-599': 0}` already refuses to cache. Nothing poisonable gets written. The catch-all served nobody: the snippet answers non-asset paths by fetching `/` anyway.

- 9052ba5 **fix: never serve html under an asset url**
Insurance for the cutover, when the deployment being replaced still carries the old catch-all. The snippet checks the content type; a `text/html` body under a `.js` URL means the file is gone, so it refetches origin with `cache: 'no-store'` and serves the real chunk, or answers 404. A poisoned entry costs one fetch, not a day.

- 84987ff **fix: retry a failed app chunk once**
Caps the loop. One purge and reload clears every cache the client owns; if the chunk is still missing, nothing a reload can reach will fix it, so the second failure renders the page above. The marker lives in `history.state`, so it survives the reload and still works when the browser blocks storage.

- e41507c **ci: purge cache even if deploy is cut short**
In the bad deploy the purge did run, and the cache refilled with the poison five seconds later while Pages was mid rollout. The job then timed out and the run went down as cancelled. Now the purge runs even when the job is cut short, and again a minute later once Pages has propagated.

We need to test this end-to-end on `.dev` as I was not able to test fully.

Note: a subdomain can still hold stale installer HTML for 24h. A double unconditional total global Cloudflare cache purge clears that, and the 404 keeps it from becoming HTML served as a script.

---

- Closes #1155