### PR TITLE
fix: wait for UI before reloading in Safari

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -34,14 +34,14 @@ async function main (): Promise<void> {
   if (!isBrowserSupported()) {
     // browser is missing Web APIs we need, render the UI which will tell the
     // user their browser is unsupported
-    await renderUi()
+    renderUi()
     return
   }
 
   if (!('serviceWorker' in navigator)) {
     // no service worker support, render the UI which will tell the user
     // service workers are not supported
-    await renderUi()
+    renderUi()
     return
   }
 
@@ -60,7 +60,7 @@ async function main (): Promise<void> {
     globalThis.originIsolationWarning = {
       location: window.location.href
     }
-    await renderUi()
+    renderUi()
     return
   }
 
@@ -80,7 +80,7 @@ async function main (): Promise<void> {
       logs: []
     }
 
-    await renderUi()
+    renderUi()
     return
   }
 
@@ -106,15 +106,16 @@ async function main (): Promise<void> {
       logs: []
     }
 
-    await renderUi()
+    renderUi()
     return
   }
 
   try {
     if (request.type === 'path' || request.type === 'native') {
+      await showDownloadingPageAfterDelay(request)
+
       // redirect to subdomain
       window.location.href = request.subdomainURL.href
-      showUIAfterDelay(request)
       return
     }
 
@@ -137,8 +138,8 @@ async function main (): Promise<void> {
           const request = parseRequest(uri, new URL(globalThis.location.href))
 
           if (request.type === 'subdomain' || request.type === 'path' || request.type === 'native') {
+            await showDownloadingPageAfterDelay(request)
             window.location.href = request.subdomainURL.href
-            showUIAfterDelay(request)
             return
           }
           return
@@ -182,6 +183,8 @@ async function main (): Promise<void> {
         url.pathname = ''
       }
 
+      await showDownloadingPageAfterDelay(request)
+
       // Trigger a navigation so the just-installed service worker can
       // intercept the subdomain request. Pick the cheapest primitive
       // that still works in the presence of a URL fragment.
@@ -224,8 +227,6 @@ async function main (): Promise<void> {
         window.location.reload()
       }
 
-      showUIAfterDelay(request)
-
       return
     }
   } catch (err: any) {
@@ -247,23 +248,150 @@ async function main (): Promise<void> {
     }
   }
 
-  await renderUi()
+  renderUi()
+}
+
+/**
+ * Marks, on the current history entry, that we have already tried to recover
+ * from an app chunk that would not load.
+ *
+ * `history.state` is the right place for it. It survives `location.reload()`,
+ * it is scoped to this page rather than the whole origin, and reading it needs
+ * no storage permission, so the cap still holds in a browser configured to
+ * block storage. `tooManyRedirects` cannot be reused here for a different
+ * reason: it ignores everything unless `document.referrer` is the current URL,
+ * which a `location.reload()` never makes true.
+ */
+const CHUNK_RETRIED = 'ipfsSwChunkRetried'
+
+function alreadyRetriedChunk (): boolean {
+  return history.state?.[CHUNK_RETRIED] === true
+}
+
+function markChunkRetried (): void {
+  history.replaceState({ ...history.state, [CHUNK_RETRIED]: true }, '')
+}
+
+function forgetChunkRetry (): void {
+  if (!alreadyRetriedChunk()) {
+    return
+  }
+
+  const state = { ...history.state }
+  delete state[CHUNK_RETRIED]
+  history.replaceState(state, '')
+}
+
+/**
+ * Tell the user the app chunk will not load, using only the bootstrap DOM.
+ *
+ * Everything `renderUi` would normally reach for lives inside the chunk that
+ * just failed: every page, the error pages among them, and the
+ * `globalThis.serverError` channel that renders them. What is left is the
+ * markup `index.html` already parsed, so build the message out of that.
+ */
+function showAppChunkError (): void {
+  document.querySelector('.loading-indicator-js')?.classList.add('hidden')
+
+  const root = document.getElementById('root')
+
+  if (root == null) {
+    return
+  }
+
+  // `.sw-error` is defined in the inline stylesheet of index.html, because the
+  // stylesheet the app ships is inside the chunk that failed to load.
+  root.classList.add('sw-error')
+
+  const title = document.createElement('h1')
+  title.textContent = 'Could not load this page'
+
+  const cause = document.createElement('p')
+  cause.textContent = 'The application script failed to load. Usually a CDN or your browser is holding a stale copy of this page that points at a script which no longer exists.'
+
+  const remedy = document.createElement('p')
+  remedy.textContent = 'Waiting a few minutes and trying again normally clears it. A hard reload, which bypasses your browser cache, fetches a fresh copy right away.'
+
+  const retry = document.createElement('button')
+  retry.textContent = 'Try again'
+  retry.addEventListener('click', () => {
+    forgetChunkRetry()
+    // @ts-expect-error boolean `forceGet` argument is firefox-only
+    document.location.reload(true)
+  })
+
+  root.replaceChildren(title, cause, remedy, retry)
 }
 
 /**
  * Asynchronously loads and shows the UI - this is to make the number of bytes
  * downloaded before the service worker is installed smaller
  */
-async function renderUi (): Promise<void> {
+function renderUi (): void {
   // dynamically load the app chunk using the correct filename
   try {
     const script = document.createElement('script')
+    script.addEventListener('load', () => {
+      forgetChunkRetry()
+    })
+    script.addEventListener('error', () => {
+      // Safari errors when loading a script during page navigation so swallow
+      // the error if it fails
+      if (isWebkit()) {
+        return
+      }
+
+      // Recover once, and only once. Dropping the caches and the service worker
+      // is what fixes a bootstrap left behind by a deploy, and the reload is
+      // what picks up the current one. If the chunk is still missing after
+      // that, the stale copy lives in a CDN entry that no reload can evict, so
+      // trying again only hammers the CDN until it rate limits us, with the
+      // user watching a blank page throughout. That is the cyclic reload
+      // reported in #1155.
+      if (alreadyRetriedChunk()) {
+        showAppChunkError()
+        return
+      }
+
+      // Mark before the purge below, which deletes every cache, and before the
+      // reload, which resets the page.
+      markChunkRetried()
+
+      // failed to load script, there may be a new service worker available -
+      // delete all caches, unregister the service worker and reload
+      Promise.all([
+        caches.keys()
+          .then(async (cacheNames) => {
+            return Promise.all(
+              cacheNames.map(async function (cacheName) {
+                return caches.delete(cacheName)
+              })
+            )
+          })
+          .catch(err => {
+            // eslint-disable-next-line no-console
+            console.error('could not delete out of date cache - %e', err)
+          }),
+        navigator.serviceWorker.getRegistration()
+          .then(async registration => {
+            registration?.unregister()
+          })
+      ])
+        .then(() => {
+          // @ts-expect-error boolean `forceGet` argument is firefox-only
+          document.location.reload(true)
+        })
+        .catch((err) => {
+          // eslint-disable-next-line no-console
+          console.error('could not refresh context', err)
+        })
+    })
     script.type = 'module'
     script.src = '<%-- src/ui/index.tsx --%>'
     document.body.appendChild(script)
   } catch (err) {
     // eslint-disable-next-line no-console
-    console.error('failed to load ui', err)
+    console.error('failed to load app ui', err)
     throw err
   }
 }
@@ -310,27 +438,72 @@ function tooManyRedirects (storageKey: string, maxRedirects = 5, period = 5_000)
 /**
  * If the requested URL triggers a download, the currently displayed page will
  * not change so show the user something, otherwise it looks like they are stuck
+ * on a loading page.
+ *
+ * If the user is on a WebKit-based browser loading the UI js file while a
+ * navigation is occurring will fail so wait for the UI to appear before
+ * redirecting, otherwise load the UI asynchronously.
+ */
+async function showDownloadingPageAfterDelay (request: ResolvableURI, delay = 500): Promise<void> {
+  if (isWebkit()) {
+    showDownloadingPage(request)
+    await waitForUiToRender()
+
+    return
+  }
+
+  setTimeout(() => {
+    showDownloadingPage(request)
+  }, delay)
+}
+
+/**
+ * If the requested URL triggers a download, the currently displayed page will
+ * not change so show the user something, otherwise it looks like they are stuck
  * on a loading page
  */
-function showUIAfterDelay (request: ResolvableURI): void {
-  setTimeout(() => {
-    let cid: string | undefined
+function showDownloadingPage (request: ResolvableURI): void {
+  let cid: string | undefined
 
-    if (request.type === 'native' && request.protocol === 'ipfs') {
-      cid = request.nativeURL.hostname
-    } else if (request.type === 'path' && request.protocol === 'ipfs') {
-      cid = request.pathURL.pathname.split('/')[2]
-    } else if (request.type === 'subdomain' && request.protocol === 'ipfs') {
-      cid = request.subdomainURL.hostname.split('.ipfs.')[0]
-    }
+  if (request.type === 'native' && request.protocol === 'ipfs') {
+    cid = request.nativeURL.hostname
+  } else if (request.type === 'path' && request.protocol === 'ipfs') {
+    cid = request.pathURL.pathname.split('/')[2]
+  } else if (request.type === 'subdomain' && request.protocol === 'ipfs') {
+    cid = request.subdomainURL.hostname.split('.ipfs.')[0]
+  }
 
-    globalThis.downloadingPage = {
-      request,
-      cid
-    }
+  globalThis.downloadingPage = {
+    request,
+    cid
+  }
 
-    renderUi()
-  }, 500)
+  renderUi()
+}
+
+/**
+ * Detect WebKit browsers
+ */
+function isWebkit (): boolean {
+  return 'GestureEvent' in globalThis
+}
+
+/**
+ * Wait for the UI to be present in the DOM
+ */
+async function waitForUiToRender (): Promise<void> {
+  let interval: ReturnType<typeof setInterval>
+
+  await new Promise<void>((resolve) => {
+    interval = setInterval(() => {
+      if (document.getElementsByTagName('header').length === 0) {
+        return
+      }
+
+      clearInterval(interval)
+      resolve()
+    }, 100)
+  })
 }
 
 main()

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -225,6 +225,7 @@ async function main (): Promise<void> {
       }
 
       showUIAfterDelay(request)
+
       return
     }
   } catch (err: any) {
@@ -250,78 +251,6 @@ async function main (): Promise<void> {
 }
 
 /**
- * Marks, on the current history entry, that we have already tried to recover
- * from an app chunk that would not load.
- *
- * `history.state` is the right place for it. It survives `location.reload()`,
- * it is scoped to this page rather than the whole origin, and reading it needs
- * no storage permission, so the cap still holds in a browser configured to
- * block storage. `tooManyRedirects` cannot be reused here for a different
- * reason: it ignores everything unless `document.referrer` is the current URL,
- * which a `location.reload()` never makes true.
- */
-const CHUNK_RETRIED = 'ipfsSwChunkRetried'
-
-function alreadyRetriedChunk (): boolean {
-  return history.state?.[CHUNK_RETRIED] === true
-}
-
-function markChunkRetried (): void {
-  history.replaceState({ ...history.state, [CHUNK_RETRIED]: true }, '')
-}
-
-function forgetChunkRetry (): void {
-  if (!alreadyRetriedChunk()) {
-    return
-  }
-
-  const state = { ...history.state }
-  delete state[CHUNK_RETRIED]
-  history.replaceState(state, '')
-}
-
-/**
- * Tell the user the app chunk will not load, using only the bootstrap DOM.
- *
- * Everything `renderUi` would normally reach for lives inside the chunk that
- * just failed: every page, the error pages among them, and the
- * `globalThis.serverError` channel that renders them. What is left is the
- * markup `index.html` already parsed, so build the message out of that.
- */
-function showAppChunkError (): void {
-  document.querySelector('.loading-indicator-js')?.classList.add('hidden')
-
-  const root = document.getElementById('root')
-
-  if (root == null) {
-    return
-  }
-
-  // `.sw-error` is defined in the inline stylesheet of index.html, because the
-  // stylesheet the app ships is inside the chunk that failed to load.
-  root.classList.add('sw-error')
-
-  const title = document.createElement('h1')
-  title.textContent = 'Could not load this page'
-
-  const cause = document.createElement('p')
-  cause.textContent = 'The application script failed to load. Usually a CDN or your browser is holding a stale copy of this page that points at a script which no longer exists.'
-
-  const remedy = document.createElement('p')
-  remedy.textContent = 'Waiting a few minutes and trying again normally clears it. A hard reload, which bypasses your browser cache, fetches a fresh copy right away.'
-
-  const retry = document.createElement('button')
-  retry.textContent = 'Try again'
-  retry.addEventListener('click', () => {
-    forgetChunkRetry()
-    // @ts-expect-error boolean `forceGet` argument is firefox-only
-    document.location.reload(true)
-  })
-
-  root.replaceChildren(title, cause, remedy, retry)
-}
-
-/**
  * Asynchronously loads and shows the UI - this is to make the number of bytes
  * downloaded before the service worker is installed smaller
  */
@@ -329,63 +258,12 @@ async function renderUi (): Promise<void> {
   // dynamically load the app chunk using the correct filename
   try {
     const script = document.createElement('script')
-
-    script.addEventListener('load', () => {
-      forgetChunkRetry()
-    })
-
-    script.addEventListener('error', () => {
-      // Recover once, and only once. Dropping the caches and the service worker
-      // is what fixes a bootstrap left behind by a deploy, and the reload is
-      // what picks up the current one. If the chunk is still missing after
-      // that, the stale copy lives in a CDN entry that no reload can evict, so
-      // trying again only hammers the CDN until it rate limits us, with the
-      // user watching a blank page throughout. That is the cyclic reload
-      // reported in #1155.
-      if (alreadyRetriedChunk()) {
-        showAppChunkError()
-        return
-      }
-
-      // Mark before the purge below, which deletes every cache, and before the
-      // reload, which resets the page.
-      markChunkRetried()
-
-      // failed to load script, there may be a new service worker available -
-      // delete all caches, unregister the service worker and reload
-      Promise.all([
-        caches.keys()
-          .then(async (cacheNames) => {
-            return Promise.all(
-              cacheNames.map(async function (cacheName) {
-                return caches.delete(cacheName)
-              })
-            )
-          })
-          .catch(err => {
-            // eslint-disable-next-line no-console
-            console.error('could not delete out of date cache - %e', err)
-          }),
-        navigator.serviceWorker.getRegistration()
-          .then(async registration => {
-            registration?.unregister()
-          })
-      ])
-        .then(() => {
-          // @ts-expect-error boolean `forceGet` argument is firefox-only
-          document.location.reload(true)
-        })
-        .catch((err) => {
-          // eslint-disable-next-line no-console
-          console.error('could not refresh context', err)
-        })
-    })
     script.type = 'module'
     script.src = '<%-- src/ui/index.tsx --%>'
     document.body.appendChild(script)
   } catch (err) {
     // eslint-disable-next-line no-console
-    console.error('Failed to load app chunk config:', err)
+    console.error('failed to load ui', err)
     throw err
   }
 }

--- a/src/sw/pages/page.ts
+++ b/src/sw/pages/page.ts
@@ -45,30 +45,124 @@ globalThis.${key} = ${JSON.stringify(value, null, 2).replace(/</g, '\\u003c')}
   <body>
     <div id="root" class="sans-serif charcoal f5"></div>
     <script>
+      ${''
+      // Marks, on the current history entry, that we have already tried to
+      // recover from an app chunk that would not load.
+      //
+      // history.state is the right place for it. It survives location.reload(),
+      // it is scoped to this page rather than the whole origin, and reading it
+      // needs no storage permission, so the cap still holds in a browser
+      // configured to deny block storage
+      }
+      const CHUNK_RETRIED = 'ipfsSwChunkRetried'
+
+      function alreadyRetriedChunk () {
+        return history.state?.[CHUNK_RETRIED] === true
+      }
+
+      function markChunkRetried () {
+        history.replaceState({ ...history.state, [CHUNK_RETRIED]: true }, '')
+      }
+
+      function forgetChunkRetry () {
+        if (!alreadyRetriedChunk()) {
+          return
+        }
+
+        const state = { ...history.state }
+        delete state[CHUNK_RETRIED]
+        history.replaceState(state, '')
+      }
+
+      ${''
+      // Tell the user the app chunk will not load, using only the bootstrap DOM
+      }
+      function showAppChunkError () {
+        document.querySelector('.loading-indicator-js')?.classList.add('hidden')
+
+        const root = document.getElementById('root')
+
+        if (root == null) {
+          return
+        }
+
+        ${''
+        // .sw-error is defined in the inline stylesheet of index.html, because
+        // the stylesheet the app ships is inside the chunk that failed to load.
+        }
+        root.classList.add('sw-error')
+
+        const title = document.createElement('h1')
+        title.textContent = 'Could not load this page'
+
+        const cause = document.createElement('p')
+        cause.textContent = 'The application script failed to load. Usually a CDN or your browser is holding a stale copy of this page that points at a script which no longer exists.'
+
+        const remedy = document.createElement('p')
+        remedy.textContent = 'Waiting a few minutes and trying again normally clears it. A hard reload, which bypasses your browser cache, fetches a fresh copy right away.'
+
+        const retry = document.createElement('button')
+        retry.textContent = 'Try again'
+        retry.addEventListener('click', () => {
+          forgetChunkRetry()
+          document.location.reload(true)
+        })
+
+        root.replaceChildren(title, cause, remedy, retry)
+      }
+
       const script = document.createElement('script')
-      script.addEventListener('error', (evt) => {
-        // failed to load script, there may be a new service worker available -
-        // delete all caches, unregister the service worker and reload
-        Promise.all([
-          caches.keys()
-            .then(async (cacheNames) => {
-              return Promise.all(
-                cacheNames.map(async function (cacheName) {
-                  return caches.delete(cacheName)
-                })
-              )
-            })
-            .catch(err => {
-              console.error('could not delete out of date cache - %e', err)
-            }),
-          navigator.serviceWorker.getRegistration()
-            .then(async registration => {
-              registration?.unregister()
-            })
-        ])
-          .then(() => {
-            document.location.reload(true)
+      script.addEventListener('load', () => {
+        forgetChunkRetry()
+      })
+      script.addEventListener('error', () => {
+      ${''
+      // Recover once, and only once. Dropping the caches and the service worker
+      // is what fixes a bootstrap left behind by a deploy, and the reload is
+      // what picks up the current one. If the chunk is still missing after
+      // that, the stale copy lives in a CDN entry that no reload can evict, so
+      // trying again only hammers the CDN until it rate limits us, with the
+      // user watching a blank page throughout. That is the cyclic reload
+      // reported in #1155.
+      }
+      if (alreadyRetriedChunk()) {
+        showAppChunkError()
+        return
+      }
+
+      ${''
+      // Mark before the purge below, which deletes every cache, and before the
+      // reload, which resets the page.
+      }
+      markChunkRetried()
+
+      ${''
+      // failed to load script, there may be a new service worker available -
+      // delete all caches, unregister the service worker and reload
+      }
+      Promise.all([
+        caches.keys()
+          .then(async (cacheNames) => {
+            return Promise.all(
+              cacheNames.map(async function (cacheName) {
+                return caches.delete(cacheName)
+              })
+            )
           })
+          .catch(err => {
+            console.error('could not delete out of date cache - %e', err)
+          }),
+        navigator.serviceWorker.getRegistration()
+          .then(async registration => {
+            registration?.unregister()
+          })
+      ])
+        .then(() => {
+          document.location.reload(true)
+        })
+        .catch((err) => {
+          console.error('could not refresh context', err)
+        })
       })
       script.type = 'module'
       script.src = '<%-- src/ui/index.tsx --%>'

--- a/test-e2e/fixtures/load-kubo-fixtures.ts
+++ b/test-e2e/fixtures/load-kubo-fixtures.ts
@@ -20,6 +20,7 @@ import { $ } from 'execa'
 import { glob } from 'glob'
 import itAll from 'it-all'
 import drain from 'it-drain'
+import { GWC_IMAGE } from '../../test-conformance/fixtures/constants.ts'
 import type { KuboNode } from 'ipfsd-ctl'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -47,7 +48,7 @@ export async function downloadFixtures (force = false): Promise<void> {
   console.info('Downloading fixtures to', relative('.', GWC_FIXTURES_PATH))
 
   try {
-    await $`docker run -v ${process.cwd()}:/workspace -w /workspace ghcr.io/ipfs/gateway-conformance:v0.7.1 extract-fixtures --directory ${relative('.', GWC_FIXTURES_PATH)} --merged false`
+    await $`docker run -v ${process.cwd()}:/workspace -w /workspace ${GWC_IMAGE} extract-fixtures --directory ${relative('.', GWC_FIXTURES_PATH)} --merged false`
   } catch (err: any) {
     if (err.message.includes('docker')) {
       throw err


### PR DESCRIPTION
In Safari loading a script during navigation triggers the onerror event listener which unregisters the service worker and reloads the page.

Instead wait for the "Your download is happening" page to appear before reloading in Safari only.

Fixes #1159

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
