### PR TITLE
fix: wait for skipWaiting promise

### DIFF
--- a/src/sw/sw.ts
+++ b/src/sw/sw.ts
@@ -36,11 +36,15 @@ self.addEventListener('install', (event) => {
   const log = getSwLogger('install')
 
   // 👇 When a new version of the SW is installed, activate immediately
-  self.skipWaiting()
-    .catch(err => {
-      log.error('error skipping waiting - %e', err)
-    })
-  event.waitUntil(clearSwAssetCache())
+  event.waitUntil(
+    Promise.all([
+      self.skipWaiting()
+        .catch(err => {
+          log.error('error skipping waiting - %e', err)
+        }),
+      clearSwAssetCache()
+    ])
+  )
 })
 
 self.addEventListener('activate', (event) => {


### PR DESCRIPTION
To prevent the service worker context being killed while we wait for the `stopWaiting` promise to resolve, extend the lifetime of the event to include this promise.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
