### PR TITLE
fix: do not wait for UI forever

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "multiformats": "^14.0.4",
     "preact": "^10.28.2",
     "pretty-bytes": "^7.1.0",
+    "race-signal": "^2.0.0",
     "react-icons": "^5.5.0",
     "react-router-dom": "^7.9.5",
     "tachyons": "^4.12.0",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable max-depth */
 
+import { raceSignal } from 'race-signal'
 import weald from 'weald'
 import { config } from './config/index.ts'
 import { QUERY_PARAMS } from './lib/constants.ts'
@@ -441,13 +442,13 @@ function tooManyRedirects (storageKey: string, maxRedirects = 5, period = 5_000)
  * on a loading page.
  *
  * If the user is on a WebKit-based browser loading the UI js file while a
- * navigation is occurring will fail so wait for the UI to appear before
+ * navigation is occurring will fail so give the UI some time to appear before
  * redirecting, otherwise load the UI asynchronously.
  */
 async function showDownloadingPageAfterDelay (request: ResolvableURI, delay = 500): Promise<void> {
   if (isWebkit()) {
     showDownloadingPage(request)
-    await waitForUiToRender()
+    await waitForUiToRender(AbortSignal.timeout(2_000))
 
     return
   }
@@ -489,21 +490,24 @@ function isWebkit (): boolean {
 }
 
 /**
- * Wait for the UI to be present in the DOM
+ * Wait for the UI to be present in the DOM until the passed abort signal fires
  */
-async function waitForUiToRender (): Promise<void> {
+async function waitForUiToRender (signal?: AbortSignal): Promise<void> {
   let interval: ReturnType<typeof setInterval>
 
-  await new Promise<void>((resolve) => {
+  await raceSignal(new Promise<void>((resolve) => {
     interval = setInterval(() => {
       if (document.getElementsByTagName('header').length === 0) {
         return
       }
 
-      clearInterval(interval)
       resolve()
     }, 100)
-  })
+  }), signal)
+    .catch(() => {})
+    .finally(() => {
+      clearInterval(interval)
+    })
 }
 
 main()


### PR DESCRIPTION
Follow up to #1161 - only wait for a short amount of time before starting the download in Safari

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
Follow up to #1161 - only wait for a short amount of time before
starting the download in Safari