### PR TITLE
fix: use cheap parse request in ui

### DIFF
--- a/src/lib/parse-request-cheap.ts
+++ b/src/lib/parse-request-cheap.ts
@@ -299,8 +299,10 @@ function parsePeerId (str: string): string {
 export function parseRequest (url: URL | string, root: URL): ResolvableURI {
   if (url instanceof String || typeof url === 'string') {
     if (url.startsWith('/ipfs/')) {
+      url = url.split('/').map(part => encodeURIComponent(part)).join('/')
       url = new URL(`ipfs://${url.substring('/ipfs/'.length)}`)
     } else if (url.startsWith('/ipns/')) {
+      url = url.split('/').map(part => encodeURIComponent(part)).join('/')
       url = new URL(`ipns://${url.substring('/ipns/'.length)}`)
     } else {
       url = new URL(url)

--- a/src/lib/parse-request-cheap.ts
+++ b/src/lib/parse-request-cheap.ts
@@ -11,6 +11,7 @@ export type URIType = 'subdomain' | 'path' | 'native' | 'internal' | 'external'
 export interface IPFSURI {
   protocol: 'ipfs'
   type: 'subdomain' | 'path' | 'native'
+  cid: string
   subdomainURL: URL
   pathURL: URL
   nativeURL: URL
@@ -87,6 +88,7 @@ function toIPFSURI (type: 'subdomain' | 'path' | 'native', cidStr: string, host:
   const output: IPFSURI = {
     type,
     protocol: 'ipfs',
+    cid,
     subdomainURL: new URL(`${root.protocol}//${cid}.ipfs.${root.host}${pathname}${search}${hash}`),
     pathURL: new URL(`${root.protocol}//${root.host}/ipfs/${cidStr}${pathname}${search}${hash}`),
     nativeURL: new URL(`ipfs://${cidStr}${pathname}${search}${hash}`)

--- a/src/ui/components/cid-input.tsx
+++ b/src/ui/components/cid-input.tsx
@@ -1,6 +1,6 @@
 import { CID } from 'multiformats/cid'
 import React from 'react'
-import { parseRequest } from '../../lib/parse-request.ts'
+import { parseRequest } from '../../lib/parse-request-cheap.ts'
 import { Link } from './link.tsx'
 import type { ReactElement } from 'react'
 

--- a/src/ui/pages/fetch-error.tsx
+++ b/src/ui/pages/fetch-error.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { parseRequest } from '../../lib/parse-request.ts'
+import { parseRequest } from '../../lib/parse-request-cheap.ts'
 import { removeRootHashIfPresent } from '../../lib/remove-root-hash.ts'
 import { toGatewayRoot } from '../../lib/to-gateway-root.ts'
 import { Button } from '../components/button.tsx'

--- a/src/ui/pages/home.tsx
+++ b/src/ui/pages/home.tsx
@@ -88,8 +88,6 @@ function LoadContent (): ReactElement {
       })
       .join('&')
 
-    // window.location.href = getGatewayRoot() + request + (search === '' ? '' : `?${search}`)
-
     window.location.href = `${subdomainURL.protocol}//${subdomainURL.host}${subdomainURL.pathname}${search === '' ? '' : `?${search}`}${subdomainURL.hash}`
   }
 


### PR DESCRIPTION
Reduce bundle size by only using detailed parse request in the service worker, use the cheap version in the ui

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
