### PR TITLE
fix: use iife instead of esm bundle

### DIFF
--- a/build.js
+++ b/build.js
@@ -462,7 +462,7 @@ export const buildOptions = {
   metafile: true,
   splitting: false,
   target: ['es2020'],
-  format: 'esm',
+  format: 'iife',
   entryNames: 'ipfs-sw-[name]-[hash]',
   assetNames: 'ipfs-sw-[name]-[hash]',
   plugins: [

--- a/src/lib/register-service-worker.ts
+++ b/src/lib/register-service-worker.ts
@@ -2,7 +2,7 @@
  * This function is always and only used from the UI
  */
 export async function registerServiceWorker (): Promise<ServiceWorkerRegistration> {
-  const swRegistration = await navigator.serviceWorker.register(new URL('ipfs-sw-sw.js', import.meta.url), {
+  const swRegistration = await navigator.serviceWorker.register(new URL(`${window.location.protocol}//${window.location.host}/ipfs-sw-sw.js`), {
     scope: '/'
   })
 


### PR DESCRIPTION
In WebKit all imports end up in the global scope so use iife to ensure variables like `WebTransport` aren't overwritten.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
