### PR TITLE
fix: update libp2p version to get smaller bundle size

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@helia/bitswap": "^4.0.7",
     "@helia/delegated-routing-v1-http-api-client": "^9.0.0",
     "@helia/http": "^4.0.6",
-    "@helia/libp2p": "^2.0.0",
+    "@helia/libp2p": "^2.1.0",
     "@helia/trustless-gateway-client": "^1.0.5",
     "@helia/verified-fetch": "^8.0.4",
     "@ipld/dag-cbor": "^10.0.1",

--- a/src/sw/lib/verified-fetch.ts
+++ b/src/sw/lib/verified-fetch.ts
@@ -3,7 +3,7 @@ import { yamux } from '@chainsafe/libp2p-yamux'
 import { withBitswap } from '@helia/bitswap'
 import { delegatedRoutingV1HttpApiClientContentRouting, delegatedRoutingV1HttpApiClientPeerRouting } from '@helia/delegated-routing-v1-http-api-client'
 import { withHTTP } from '@helia/http'
-import { withLibp2p } from '@helia/libp2p'
+import { withLibp2pLight } from '@helia/libp2p'
 import { createVerifiedFetchWithHelia } from '@helia/verified-fetch'
 import * as dagCbor from '@ipld/dag-cbor'
 import * as dagJson from '@ipld/dag-json'
@@ -96,7 +96,7 @@ export async function updateVerifiedFetch (): Promise<void> {
   libp2pOptions.logger = logger
   libp2pOptions.datastore = datastore
 
-  const helia = await withBitswap(withLibp2p(withHTTP(createHeliaLight({
+  const helia = await withBitswap(withLibp2pLight(withHTTP(createHeliaLight({
     datastore,
     blockstore,
     logger,


### PR DESCRIPTION
Use `withLibp2pLight` for a smaller bundle size.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
